### PR TITLE
Update TikTok icon fallback in footer-v1.blade.php

### DIFF
--- a/resources/views/user-front/realestate/partials/footer/footer-v1.blade.php
+++ b/resources/views/user-front/realestate/partials/footer/footer-v1.blade.php
@@ -66,7 +66,7 @@
                                                 $platform = strtolower($social['platform']);
                                                 // Handle special cases for platform icons
                                                 $iconClass = match($platform) {
-                                                    'tiktok' => 'fab fa-tiktok',
+                                                    'tiktok' => 'fab fa-music', // Fallback for TikTok since FA 5.8.0 doesn't have TikTok icon
                                                     'facebook' => 'fab fa-facebook-f',
                                                     'twitter' => 'fab fa-twitter',
                                                     'instagram' => 'fab fa-instagram',


### PR DESCRIPTION
- Changed the icon class for TikTok to a fallback 'fab fa-music' due to the absence of the TikTok icon in Font Awesome 5.8.0.
- Maintained the dynamic handling of social media platform icons for improved maintainability.