### PR TITLE
Refactor contract number handling and add office fee calculation

### DIFF
--- a/app/Http/Controllers/Api/V1/Rms/ContractController.php
+++ b/app/Http/Controllers/Api/V1/Rms/ContractController.php
@@ -33,7 +33,6 @@ class ContractController extends Controller
     public function store(Request $request, $rentalId)
     {
         $validated = $request->validate([
-            'contract_number' => 'required|string|max:64',
             'start_date' => 'required|date',
             'end_date' => 'required|date|after:start_date',
             'status' => 'required|in:pending,active',

--- a/app/Http/Controllers/Api/V1/Rms/RentalController.php
+++ b/app/Http/Controllers/Api/V1/Rms/RentalController.php
@@ -46,6 +46,7 @@ class RentalController extends Controller
             'water_fee' => 'nullable|numeric|min:0',
             'office_commission_type' => 'nullable|in:percentage,amount',
             'office_commission_value' => 'nullable|numeric|min:0',
+            'contract_number' => 'nullable|string|max:255',
             'notes' => 'nullable|string',
         ]);
 
@@ -67,7 +68,7 @@ class RentalController extends Controller
             'tenant_social_status', 'tenant_national_id', 'property_id', 'project_id', 'unit_label', 'property_number',
             'move_in_date', 'rental_period_months', 'paying_plan',
             'base_rent_amount', 'currency', 'deposit_amount', 'platform_fee', 'water_fee', 
-            'office_commission_type', 'office_commission_value', 'notes'
+            'office_commission_type', 'office_commission_value', 'contract_number', 'notes'
         ]);
 
         $regenerate = $request->boolean('regenerate_schedule', false);

--- a/app/Models/Api/Rms/RmContract.php
+++ b/app/Models/Api/Rms/RmContract.php
@@ -12,7 +12,7 @@ class RmContract extends Model
     protected $table = 'rm_contracts';
 
     protected $fillable = [
-        'user_id', 'rental_id', 'contract_number',
+        'user_id', 'rental_id',
         'start_date', 'end_date', 'status',
         'termination_reason', 'file_path', 'created_by', 'updated_by',
         'property_id',

--- a/app/Models/Api/Rms/RmRental.php
+++ b/app/Models/Api/Rms/RmRental.php
@@ -36,6 +36,8 @@ class RmRental extends Model
         'water_fee',
         'office_commission_type',
         'office_commission_value',
+        'office_fee',
+        'contract_number',
         'move_in_date', 
         'paying_plan', 
         'rental_period_months',
@@ -50,6 +52,7 @@ class RmRental extends Model
         'platform_fee' => 'decimal:2',
         'water_fee' => 'decimal:2',
         'office_commission_value' => 'decimal:2',
+        'office_fee' => 'decimal:2',
     ];
 
     protected $appends = [
@@ -137,6 +140,26 @@ class RmRental extends Model
             ->first();
 
         return $installment?->amount;
+    }
+
+    public function getOfficeFeeAttribute()
+    {
+        // If any required field is null, return 0
+        if (is_null($this->office_commission_type) || 
+            is_null($this->office_commission_value) || 
+            is_null($this->rental_period_months) || 
+            is_null($this->base_rent_amount)) {
+            return 0;
+        }
+
+        // Calculate based on commission type
+        if ($this->office_commission_type === 'percentage') {
+            return ($this->rental_period_months * $this->base_rent_amount) * ($this->office_commission_value / 100);
+        } elseif ($this->office_commission_type === 'amount') {
+            return $this->office_commission_value;
+        }
+
+        return 0;
     }
 
 }

--- a/app/Services/Rms/ContractService.php
+++ b/app/Services/Rms/ContractService.php
@@ -21,7 +21,6 @@ class ContractService
             $contract = RmContract::create([
                 'user_id' => $userId,
                 'rental_id' => $rental->id,
-                'contract_number' => $data['contract_number'],
                 'start_date' => $data['start_date'],
                 'end_date' => $data['end_date'],
                 'status' => $data['status'],

--- a/app/Services/Rms/RentalService.php
+++ b/app/Services/Rms/RentalService.php
@@ -173,6 +173,8 @@ class RentalService
                 'water_fee' => (float) ($rental->water_fee ?? 0),
                 'office_commission_type' => $rental->office_commission_type,
                 'office_commission_value' => (float) ($rental->office_commission_value ?? 0),
+                'office_fee' => (float) $rental->office_fee,
+                'contract_number' => $rental->contract_number,
                 'currency' => $rental->currency,
                 'move_in_date' => $rental->move_in_date,
                 'paying_plan' => $rental->paying_plan,

--- a/database/migrations/2025_09_10_174415_add_office_fee_to_rm_rentals_table.php
+++ b/database/migrations/2025_09_10_174415_add_office_fee_to_rm_rentals_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rm_rentals', function (Blueprint $table) {
+            $table->decimal('office_fee', 12, 2)->default(0)->after('office_commission_value');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rm_rentals', function (Blueprint $table) {
+            $table->dropColumn('office_fee');
+        });
+    }
+};

--- a/database/migrations/2025_09_10_174446_populate_office_fee_for_existing_rentals.php
+++ b/database/migrations/2025_09_10_174446_populate_office_fee_for_existing_rentals.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // First, ensure the office_fee column exists
+        if (!Schema::hasColumn('rm_rentals', 'office_fee')) {
+            Schema::table('rm_rentals', function (Blueprint $table) {
+                $table->decimal('office_fee', 12, 2)->default(0)->after('office_commission_value');
+            });
+        }
+
+        // Calculate and populate office_fee for existing rentals
+        DB::statement("
+            UPDATE rm_rentals 
+            SET office_fee = CASE 
+                WHEN office_commission_type IS NULL 
+                    OR office_commission_value IS NULL 
+                    OR rental_period_months IS NULL 
+                    OR base_rent_amount IS NULL 
+                THEN 0
+                WHEN office_commission_type = 'percentage' 
+                THEN (rental_period_months * base_rent_amount) * (office_commission_value / 100)
+                WHEN office_commission_type = 'amount' 
+                THEN office_commission_value
+                ELSE 0
+            END
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Clear the office_fee field
+        DB::statement("UPDATE rm_rentals SET office_fee = 0");
+    }
+};

--- a/database/migrations/2025_09_10_183525_add_contract_number_to_rm_rentals_table.php
+++ b/database/migrations/2025_09_10_183525_add_contract_number_to_rm_rentals_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rm_rentals', function (Blueprint $table) {
+            $table->string('contract_number', 255)->nullable()->after('office_fee');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rm_rentals', function (Blueprint $table) {
+            $table->dropColumn('contract_number');
+        });
+    }
+};

--- a/database/migrations/2025_09_10_183601_remove_contract_number_from_rm_contracts_table.php
+++ b/database/migrations/2025_09_10_183601_remove_contract_number_from_rm_contracts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rm_contracts', function (Blueprint $table) {
+            $table->dropColumn('contract_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rm_contracts', function (Blueprint $table) {
+            $table->string('contract_number', 255)->nullable();
+        });
+    }
+};

--- a/database/migrations/2025_09_10_183631_migrate_contract_number_from_contracts_to_rentals.php
+++ b/database/migrations/2025_09_10_183631_migrate_contract_number_from_contracts_to_rentals.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // First, ensure the target column exists in rm_rentals
+        if (!Schema::hasColumn('rm_rentals', 'contract_number')) {
+            Schema::table('rm_rentals', function (Blueprint $table) {
+                $table->string('contract_number', 255)->nullable()->after('office_fee');
+            });
+        }
+
+        // Migrate data from contracts to rentals (latest contract per rental)
+        DB::statement("
+            UPDATE rm_rentals r
+            INNER JOIN (
+                SELECT
+                    rental_id,
+                    contract_number,
+                    ROW_NUMBER() OVER (PARTITION BY rental_id ORDER BY created_at DESC) as rn
+                FROM rm_contracts
+                WHERE contract_number IS NOT NULL
+            ) c ON r.id = c.rental_id AND c.rn = 1
+            SET
+                r.contract_number = c.contract_number
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Clear the contract_number field in rentals
+        DB::statement("UPDATE rm_rentals SET contract_number = NULL");
+    }
+};

--- a/database/migrations/2025_09_10_183958_drop_contract_number_unique_constraint_from_rm_contracts.php
+++ b/database/migrations/2025_09_10_183958_drop_contract_number_unique_constraint_from_rm_contracts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rm_contracts', function (Blueprint $table) {
+            $table->dropUnique(['user_id', 'contract_number']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rm_contracts', function (Blueprint $table) {
+            $table->unique(['user_id', 'contract_number']);
+        });
+    }
+};

--- a/tests/Feature/ContractControllerTest.php
+++ b/tests/Feature/ContractControllerTest.php
@@ -48,7 +48,6 @@ class ContractControllerTest extends TestCase
         $expectedContracts = collect([
             new RmContract([
                 'id' => 1,
-                'contract_number' => 'CNT-2024-00001',
                 'start_date' => '2024-01-01',
                 'end_date' => '2024-12-31',
                 'status' => 'active'
@@ -72,7 +71,6 @@ class ContractControllerTest extends TestCase
         // Arrange
         $rentalId = 1;
         $contractData = [
-            'contract_number' => 'CNT-2024-00001',
             'start_date' => '2024-01-01',
             'end_date' => '2024-12-31',
             'status' => 'active',
@@ -116,7 +114,6 @@ class ContractControllerTest extends TestCase
         // Assert
         $response->assertStatus(422)
                 ->assertJsonValidationErrors([
-                    'contract_number',
                     'start_date',
                     'end_date',
                     'status'
@@ -149,7 +146,6 @@ class ContractControllerTest extends TestCase
         // Arrange
         $rentalId = 1;
         $contractData = [
-            'contract_number' => 'CNT-2024-00001',
             'start_date' => '2024-01-01',
             'end_date' => '2024-12-31',
             'status' => 'invalid_status'
@@ -170,7 +166,6 @@ class ContractControllerTest extends TestCase
         // Arrange
         $rentalId = 1;
         $contractData = [
-            'contract_number' => 'CNT-2024-00001',
             'start_date' => '2024-01-01',
             'end_date' => '2024-12-31',
             'status' => 'active',
@@ -191,7 +186,6 @@ class ContractControllerTest extends TestCase
         // Arrange
         $rentalId = 1;
         $contractData = [
-            'contract_number' => 'CNT-2024-00001',
             'start_date' => '2024-01-01',
             'end_date' => '2024-12-31',
             'status' => 'active',
@@ -212,7 +206,6 @@ class ContractControllerTest extends TestCase
         // Arrange
         $rentalId = 1;
         $contractData = [
-            'contract_number' => 'CNT-2024-00001',
             'start_date' => '2024-01-01',
             'end_date' => '2024-12-31',
             'status' => 'active',

--- a/tests/Feature/RentalControllerTest.php
+++ b/tests/Feature/RentalControllerTest.php
@@ -126,6 +126,7 @@ class RentalControllerTest extends TestCase
             'water_fee' => 30.00,
             'office_commission_type' => 'percentage',
             'office_commission_value' => 5.0,
+            'contract_number' => 'CNT-2024-001',
             'notes' => 'Test rental'
         ];
 
@@ -468,6 +469,8 @@ class RentalControllerTest extends TestCase
                 'water_fee' => 30.0,
                 'office_commission_type' => 'percentage',
                 'office_commission_value' => 5.0,
+                'office_fee' => 600.0, // 12 months * 1000 * 5% = 600
+                'contract_number' => 'CNT-2024-001',
                 'currency' => 'USD'
             ],
             'property' => [
@@ -857,5 +860,116 @@ class RentalControllerTest extends TestCase
                     'status' => true,
                     'data' => $updatedRental->toArray()
                 ]);
+    }
+
+    /** @test */
+    public function it_calculates_office_fee_correctly_for_percentage_commission()
+    {
+        // Arrange
+        $rental = new RmRental([
+            'office_commission_type' => 'percentage',
+            'office_commission_value' => 5.0,
+            'rental_period_months' => 12,
+            'base_rent_amount' => 1000.00
+        ]);
+
+        // Act & Assert
+        // Expected: (12 * 1000) * (5 / 100) = 12000 * 0.05 = 600
+        $this->assertEquals(600.0, $rental->office_fee);
+    }
+
+    /** @test */
+    public function it_calculates_office_fee_correctly_for_amount_commission()
+    {
+        // Arrange
+        $rental = new RmRental([
+            'office_commission_type' => 'amount',
+            'office_commission_value' => 500.00,
+            'rental_period_months' => 12,
+            'base_rent_amount' => 1000.00
+        ]);
+
+        // Act & Assert
+        // Expected: 500.00 (direct amount)
+        $this->assertEquals(500.0, $rental->office_fee);
+    }
+
+    /** @test */
+    public function it_returns_zero_office_fee_when_required_fields_are_null()
+    {
+        // Arrange
+        $rental = new RmRental([
+            'office_commission_type' => null,
+            'office_commission_value' => 5.0,
+            'rental_period_months' => 12,
+            'base_rent_amount' => 1000.00
+        ]);
+
+        // Act & Assert
+        $this->assertEquals(0.0, $rental->office_fee);
+    }
+
+    /** @test */
+    public function it_validates_contract_number_field()
+    {
+        // Arrange
+        $rentalData = [
+            'tenant_full_name' => 'John Doe',
+            'tenant_phone' => '+1234567890',
+            'contract_number' => str_repeat('a', 256) // Exceeds max:255
+        ];
+
+        // Act
+        $response = $this->postJson('/api/v1/rms/rentals', $rentalData);
+
+        // Assert
+        $response->assertStatus(422)
+                ->assertJsonValidationErrors(['contract_number']);
+    }
+
+    /** @test */
+    public function it_accepts_valid_contract_number()
+    {
+        // Arrange
+        $rentalData = [
+            'tenant_full_name' => 'John Doe',
+            'tenant_phone' => '+1234567890',
+            'contract_number' => 'CNT-2024-001'
+        ];
+
+        $this->rentalService
+            ->shouldReceive('createRental')
+            ->once()
+            ->with($this->user->id, $rentalData)
+            ->andReturn(['id' => 1, 'status' => 'active']);
+
+        // Act
+        $response = $this->postJson('/api/v1/rms/rentals', $rentalData);
+
+        // Assert
+        $response->assertStatus(201);
+    }
+
+    /** @test */
+    public function it_accepts_null_contract_number()
+    {
+        // Arrange
+        $rentalData = [
+            'tenant_full_name' => 'John Doe',
+            'tenant_phone' => '+1234567890',
+            'contract_number' => null
+        ];
+
+        $this->rentalService
+            ->shouldReceive('createRental')
+            ->once()
+            ->with($this->user->id, $rentalData)
+            ->andReturn(['id' => 1, 'status' => 'active']);
+
+        // Act
+        $response = $this->postJson('/api/v1/rms/rentals', $rentalData);
+
+        // Assert
+        $response->assertStatus(201);
     }
 }


### PR DESCRIPTION
- Removed the 'contract_number' field from the RmContract model and migrated it to the RmRental model, allowing for better association with rentals.
- Updated validation rules in the RentalController to make 'contract_number' nullable and adjusted related services accordingly.
- Introduced 'office_fee' calculation logic in the RmRental model based on commission type and value, ensuring accurate fee computation.
- Added migrations to facilitate the transition of 'contract_number' and the addition of 'office_fee' in the database schema.
- Enhanced tests to validate the new contract number handling and office fee calculations.