### PR TITLE
Update rental status from 'pending' to 'active' in RentalService

### DIFF
--- a/app/Services/Rms/RentalService.php
+++ b/app/Services/Rms/RentalService.php
@@ -67,7 +67,7 @@ class RentalService
                     'rental_id' => $rental->id,
                     'start_date' => $data['move_in_date'],
                     'end_date' => Carbon::parse($data['move_in_date'])->addMonths($totalMonths)->subDay(),
-                    'status' => 'pending',
+                    'status' => 'active',
                     // Snapshot identifiers for audit/history
                     'property_id' => $rental->property_id,
                     'project_id' => $rental->project_id,
@@ -80,7 +80,7 @@ class RentalService
                     'status' => 'active',
                     'contract' => [
                         'id' => $contract->id,
-                        'status' => 'pending',
+                        'status' => $contract->status,
                     ]
                 ];
             }


### PR DESCRIPTION
Modified the RentalService to change the status of rentals and contracts from 'pending' to 'active' upon creation, enhancing the clarity of rental state management.