### PR TITLE
Add user info route alias for frontend compatibility

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -137,6 +137,7 @@ Route::middleware('web')->group(function () {
 // Auth routes
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/user', [AuthController::class, 'getUserProfile']);
+    Route::get('/user/getUserInfo', [AuthController::class, 'getUserProfile']); // Alias for frontend compatibility
     Route::post('/user-read-message', [AuthController::class, 'read_message']);
 });
 


### PR DESCRIPTION
- Introduced a new route '/user/getUserInfo' as an alias for the existing '/user' route in AuthController, ensuring compatibility with frontend requirements.