### PR TITLE
Add permission checks for admin user impersonation in RegisterUserCon…

### DIFF
--- a/app/Http/Controllers/Admin/RegisterUserController.php
+++ b/app/Http/Controllers/Admin/RegisterUserController.php
@@ -430,6 +430,17 @@ class RegisterUserController extends Controller
     {
         $admin = auth('admin')->user();
 
+        // Check if admin has permission to impersonate users
+        $role = $admin->role;
+        if (!$role) {
+            return redirect()->back()->with('error', 'Admin role not found.');
+        }
+
+        $permissions = json_decode($role->permissions ?? '[]', true);
+        if (!in_array('Registered Users', $permissions)) {
+            return redirect()->back()->with('error', 'You do not have permission to impersonate users.');
+        }
+
         $plainTextToken = $user->createToken(
             "impersonated-by-{$admin->id}",
             ['impersonate']


### PR DESCRIPTION
…troller

- Implemented validation to ensure that admins have a role and the necessary permissions to impersonate users. If the admin lacks a role or the "Registered Users" permission, an error message is returned, enhancing security and access control in the user impersonation process.