### PR TITLE
Add default city selection for specific user in property request form

### DIFF
--- a/app/Http/Controllers/User/RealestateManagement/ManageProperty/PropertyRequestController.php
+++ b/app/Http/Controllers/User/RealestateManagement/ManageProperty/PropertyRequestController.php
@@ -60,6 +60,12 @@ class PropertyRequestController extends Controller
             ->get();
         $formSettings = $frSettings->forTenant($tenantId);
 
+        // Set default city for specific user
+        $defaultCityId = null;
+        if ($user && $user->id == 1000) {
+            $defaultCityId = 3;
+        }
+
         // dd($cities);
         return view('user-front.realestate.property.property_requests.create', [
             'cities'              => $cities,
@@ -68,6 +74,7 @@ class PropertyRequestController extends Controller
             'userCurrentLang'     => $userCurrentLang,
             'website'             => $website,
             'formSettings'        => $formSettings,
+            'defaultCityId'       => $defaultCityId,
         ]);
     }
 

--- a/resources/views/user-front/realestate/property/property_requests/create.blade.php
+++ b/resources/views/user-front/realestate/property/property_requests/create.blade.php
@@ -117,7 +117,10 @@
                 <option value="">{{ $lbl('city_id_placeholder','اختر المدينة') }}</option>
 
                 @foreach($citiesList as $row)
-                    <option value="{{ $row->id }}" {{ (string)old('city_id') === (string)$row->id ? 'selected' : '' }}>
+                    <option value="{{ $row->id }}" {{ 
+                        (string)old('city_id') === (string)$row->id ? 'selected' : 
+                        (isset($defaultCityId) && $defaultCityId == $row->id && !old('city_id')) ? 'selected' : '' 
+                    }}>
                         {{ $isAr ? ($row->name_ar ?? $row->name_en) : ($row->name_en ?? $row->name_ar) }}
                     </option>
                 @endforeach
@@ -528,6 +531,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const OLD_CITY_ID = @json(old('city_id'));
     const OLD_DISTRICT_ID = @json(old('districts_id'));
+    const DEFAULT_CITY_ID = @json($defaultCityId ?? null);
     const IS_AR = @json(app()->getLocale() === 'ar');
 
     function resetDistricts(disabled = true) {
@@ -566,7 +570,9 @@ document.addEventListener('DOMContentLoaded', function() {
             resetDistricts();
             if (this.value) loadDistricts(this.value, null);
         });
-        if (OLD_CITY_ID) loadDistricts(OLD_CITY_ID, OLD_DISTRICT_ID);
+        // Load districts for old city or default city
+        const cityToLoad = OLD_CITY_ID || DEFAULT_CITY_ID;
+        if (cityToLoad) loadDistricts(cityToLoad, OLD_DISTRICT_ID);
     }
 });
 </script>


### PR DESCRIPTION
- Introduced logic to set a default city ID for a specific user (ID 1000) in the PropertyRequestController.
- Updated the property request creation view to pre-select the default city if no city is previously selected.
- Adjusted JavaScript to load districts based on either the old city or the newly set default city, enhancing user experience during property requests.