### PR TITLE
Fix formatting in city selection logic for property request form

### DIFF
--- a/resources/views/user-front/realestate/property/property_requests/create.blade.php
+++ b/resources/views/user-front/realestate/property/property_requests/create.blade.php
@@ -119,7 +119,7 @@
                 @foreach($citiesList as $row)
                     <option value="{{ $row->id }}" {{ 
                         (string)old('city_id') === (string)$row->id ? 'selected' : 
-                        (isset($defaultCityId) && $defaultCityId == $row->id && !old('city_id')) ? 'selected' : '' 
+                        ((isset($defaultCityId) && $defaultCityId == $row->id && !old('city_id')) ? 'selected' : '')
                     }}>
                         {{ $isAr ? ($row->name_ar ?? $row->name_en) : ($row->name_en ?? $row->name_ar) }}
                     </option>


### PR DESCRIPTION
- Adjusted the conditional logic for selecting the default city in the property request creation view to ensure proper rendering of the selected option.
- This change improves code readability and maintains the intended functionality for user experience.