### PR TITLE
Add hidden input for city_id in property request form when city selec…

### DIFF
--- a/resources/views/user-front/realestate/property/property_requests/create.blade.php
+++ b/resources/views/user-front/realestate/property/property_requests/create.blade.php
@@ -105,6 +105,11 @@
         <div class="form-group">
             <label class="{{ $req('city_id') ? 'required' : '' }}">{{ $lbl('city_id','المدينة') }}</label>
 
+            {{-- Hidden input to ensure city_id is sent when disabled --}}
+            @if(isset($disableCitySelection) && $disableCitySelection && isset($defaultCityId))
+                <input type="hidden" name="city_id" value="{{ $defaultCityId }}">
+            @endif
+
             <select
                 class="form-select"
                 id="citySelect"


### PR DESCRIPTION
…tion is disabled

- Implemented a hidden input field to ensure the city_id is submitted even when the city selection dropdown is disabled for specific users.
- This change maintains data integrity and improves the user experience by ensuring the correct city ID is sent with the form submission.