### PR TITLE
Add destroy method to ApiPropertyRequestController for deleting prope…

### DIFF
--- a/app/Http/Controllers/Api/property/ApiPropertyRequestController.php
+++ b/app/Http/Controllers/Api/property/ApiPropertyRequestController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\JsonResponse;
 use App\Models\Api\UserPropertyRequest;
+use Illuminate\Validation\Rule;
 
 class ApiPropertyRequestController extends Controller
 {
@@ -81,5 +82,15 @@ class ApiPropertyRequestController extends Controller
                 ],
             ],
         ]);
+    }
+    public function destroy($id)
+    {
+        $user = Auth::user();
+        $propertyRequest = UserPropertyRequest::where('id', $id)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+        
+        $propertyRequest->delete();
+        return response()->json(['message' => 'Property request deleted successfully']);
     }
 }


### PR DESCRIPTION
…rty requests

- Implemented a new destroy method that allows authenticated users to delete their property requests by ID.
- This addition enhances user control over their property requests and improves the overall functionality of the API.