### PR TITLE
Add CheckMaintenanceMode middleware and integrate into web routes

### DIFF
--- a/app/Http/Controllers/Front/FrontendController.php
+++ b/app/Http/Controllers/Front/FrontendController.php
@@ -668,12 +668,7 @@ class FrontendController extends Controller
                 ['language_id', $userdefaultLang->id],
             ])->select(['video_section_image', 'video_section_title', 'video_section_subtitle', 'video_section_button_url', 'video_section_button_text', 'video_section_url', 'video_section_text'])->first();
 
-        // resources\views\user-front\maintenance_mode.blade.php
-        // maintenance_mode
-
-        if (isset($api_general_settingsData->maintenance_mode) && $api_general_settingsData->maintenance_mode == 1) {
-            return view('user-front.maintenance_mode', $data);
-        }
+        // Maintenance mode is now handled by CheckMaintenanceMode middleware
 
 
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -88,6 +88,7 @@ class Kernel extends HttpKernel
         'audit.ctx' => \App\Http\Middleware\PopulateAuditContext::class,
         'owner-or-can' => \App\Http\Middleware\OwnerOrCan::class,
         'require.active.package' => \App\Http\Middleware\RequireActiveMembership::class,
+        'check.maintenance' => \App\Http\Middleware\CheckMaintenanceMode::class,
 
     ];
 

--- a/app/Http/Middleware/CheckMaintenanceMode.php
+++ b/app/Http/Middleware/CheckMaintenanceMode.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\Models\Api\GeneralSetting;
+
+class CheckMaintenanceMode
+{
+    /**
+     * The URIs that should be reachable while maintenance mode is enabled.
+     * Add any routes you want to exclude from maintenance mode here.
+     *
+     * @var array
+     */
+    protected $except = [
+        // Property requests - as requested
+        'property-requests/*',
+        
+        // API routes
+        'api/*',
+        
+        // Authentication routes
+        'auth/google/*',
+        'register',
+        'login',
+        'auth/forgot-password',
+        'auth/verify-reset-code',
+        
+        // Payment callback routes (critical for business)
+        '*paytm/*',
+        '*razorpay/*',
+        '*mercadopago/*',
+        '*flutterwave/*',
+        '*phonepe/*',
+        '*paytabs/*',
+        '*iyzico/*',
+        '*mollie/*',
+        '*arb/*',
+        '*membership/*',
+        '*room_booking/*',
+        '*course-enrolment/*',
+        '*cause-donation/*',
+        '*item-checkout/*',
+        
+        // Static assets
+        'assets/*',
+        'css/*',
+        'js/*',
+        'images/*',
+        'storage/*',
+        'favicon.ico',
+        'robots.txt',
+        'sitemap.xml',
+        
+        // Add more routes here as needed
+        // Example: 'contact/*', 'about', 'services/*', etc.
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        // Check if the current route should be excluded from maintenance mode
+        foreach ($this->except as $pattern) {
+            if ($request->is($pattern)) {
+                return $next($request);
+            }
+        }
+
+        // Get the current user (tenant)
+        $user = getUser();
+        if (!$user) {
+            return $next($request);
+        }
+
+        // Check if maintenance mode is enabled for this user
+        $api_general_settingsData = GeneralSetting::where('user_id', $user->id)->first();
+        
+        if (isset($api_general_settingsData->maintenance_mode) && $api_general_settingsData->maintenance_mode == 1) {
+            // Prepare data for maintenance view (similar to FrontendController)
+            $data = [
+                'api_general_settingsData' => $api_general_settingsData,
+                // Add other necessary data here if needed
+            ];
+            
+            return response()->view('user-front.maintenance_mode', $data);
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1424,7 +1424,7 @@ Route::domain($domain)->group(function () {
     //     'env(WEBSITE_HOST)' => env('WEBSITE_HOST')
     //   ]);
 
-Route::group(['domain' => $domain, 'prefix' => $prefix], function () {
+Route::group(['domain' => $domain, 'prefix' => $prefix, 'middleware' => 'check.maintenance'], function () {
     Route::get('/', 'Front\FrontendController@userDetailView')->name('front.user.detail.view');
 
     // Route::group(['middleware' => 'auth:customer'], function () {


### PR DESCRIPTION
- Introduced a new middleware, CheckMaintenanceMode, to manage access during maintenance mode.
- Updated the web routes to apply the CheckMaintenanceMode middleware, ensuring critical routes remain accessible even when maintenance mode is enabled.
- The middleware allows specific URIs to bypass maintenance restrictions, enhancing user experience and operational continuity.