### PR TITLE
Add migration to include welcome and subscription expiration message …

### DIFF
--- a/database/migrations/2025_09_16_170015_add_welcome_and_subscription_message_fields_to_basic_settings_table.php
+++ b/database/migrations/2025_09_16_170015_add_welcome_and_subscription_message_fields_to_basic_settings_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('basic_settings', function (Blueprint $table) {
+            // Welcome Message fields
+            $table->boolean('welcome_message_enabled')->default(false);
+            $table->text('welcome_message_text')->nullable();
+            $table->integer('welcome_message_delay')->default(5);
+            $table->string('welcome_message_template')->nullable();
+            
+            // Subscription Expiration Message fields
+            $table->boolean('subscription_expiration_enabled')->default(false);
+            $table->text('subscription_expiration_text')->nullable();
+            $table->integer('subscription_expiration_days_before')->default(3);
+            $table->string('subscription_expiration_template')->nullable();
+            $table->time('subscription_expiration_send_time')->default('09:00');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('basic_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'welcome_message_enabled',
+                'welcome_message_text',
+                'welcome_message_delay',
+                'welcome_message_template',
+                'subscription_expiration_enabled',
+                'subscription_expiration_text',
+                'subscription_expiration_days_before',
+                'subscription_expiration_template',
+                'subscription_expiration_send_time'
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
…fields in basic_settings table

- Created a new migration to add fields for welcome messages and subscription expiration notifications in the basic_settings table.
- Included options for enabling/disabling messages, customizable text, delay settings, and templates for both welcome and subscription expiration messages.
- Ensured proper rollback functionality by defining the down method to remove the added columns if necessary.