### PR TITLE
Add contract_number field to RmContract model and implement contract …

### DIFF
--- a/app/Models/Api/Rms/RmContract.php
+++ b/app/Models/Api/Rms/RmContract.php
@@ -13,6 +13,7 @@ class RmContract extends Model
 
     protected $fillable = [
         'user_id', 'rental_id',
+        'contract_number',
         'start_date', 
         'end_date', 
         'status',

--- a/app/Services/Rms/ContractService.php
+++ b/app/Services/Rms/ContractService.php
@@ -21,6 +21,7 @@ class ContractService
             $contract = RmContract::create([
                 'user_id' => $userId,
                 'rental_id' => $rental->id,
+                'contract_number' => $data['contract_number'] ?? $this->generateContractNumber($userId),
                 'start_date' => $data['start_date'],
                 'end_date' => $data['end_date'],
                 'status' => $data['status'],
@@ -188,6 +189,12 @@ class ContractService
                 }
                 break;
         }
+    }
+
+    protected function generateContractNumber($userId)
+    {
+        $count = RmContract::where('user_id', $userId)->count();
+        return 'CNT-' . str_pad($count + 1, 6, '0', STR_PAD_LEFT);
     }
 
     protected function validateNoOverlap($rentalId, $start, $end, $userId, $excludeId = null)

--- a/app/Services/Rms/DashboardService.php
+++ b/app/Services/Rms/DashboardService.php
@@ -20,9 +20,10 @@ class DashboardService
         return [
             'counts' => [
                 'ongoing_rentals' => RmRental::where('user_id', $userId)->where('status', 'active')->count(),
-                'expiring_contracts_next_30d' => RmContract::where('user_id', $userId)
+                'expiring_contracts_next_' . $range . 'd' => RmContract::where('user_id', $userId)
                     ->where('status', 'active')
-                    ->whereDate('end_date', '<=', $now->copy()->addDays(30))
+                    ->whereDate('end_date', '<=', $now->copy()->addDays($range))
+                    ->whereDate('end_date', '>=', $now) // Only contracts that haven't expired yet
                     ->count(),
                 'payments_due_next_' . $range . 'd' => RmPaymentInstallment::where('user_id', $userId)
                     ->where('status', 'pending')


### PR DESCRIPTION
…number generation in ContractService

- Introduced a new 'contract_number' field in the RmContract model to store unique contract identifiers.
- Updated the ContractService to generate a contract number based on the user ID when creating a new contract.
- Enhanced the DashboardService to dynamically calculate the number of expiring contracts within a specified range, ensuring only active contracts are considered.