### PR TITLE
Remove contract_number field from RmContract model and refactor Contr…

### DIFF
--- a/app/Models/Api/Rms/RmContract.php
+++ b/app/Models/Api/Rms/RmContract.php
@@ -13,7 +13,6 @@ class RmContract extends Model
 
     protected $fillable = [
         'user_id', 'rental_id',
-        'contract_number',
         'start_date', 
         'end_date', 
         'status',

--- a/app/Services/Rms/ContractService.php
+++ b/app/Services/Rms/ContractService.php
@@ -21,7 +21,6 @@ class ContractService
             $contract = RmContract::create([
                 'user_id' => $userId,
                 'rental_id' => $rental->id,
-                'contract_number' => $data['contract_number'] ?? $this->generateContractNumber($userId),
                 'start_date' => $data['start_date'],
                 'end_date' => $data['end_date'],
                 'status' => $data['status'],
@@ -189,12 +188,6 @@ class ContractService
                 }
                 break;
         }
-    }
-
-    protected function generateContractNumber($userId)
-    {
-        $count = RmContract::where('user_id', $userId)->count();
-        return 'CNT-' . str_pad($count + 1, 6, '0', STR_PAD_LEFT);
     }
 
     protected function validateNoOverlap($rentalId, $start, $end, $userId, $excludeId = null)

--- a/app/Services/Rms/DashboardService.php
+++ b/app/Services/Rms/DashboardService.php
@@ -20,10 +20,9 @@ class DashboardService
         return [
             'counts' => [
                 'ongoing_rentals' => RmRental::where('user_id', $userId)->where('status', 'active')->count(),
-                'expiring_contracts_next_' . $range . 'd' => RmContract::where('user_id', $userId)
+                'expiring_contracts_next_30d' => RmContract::where('user_id', $userId)
                     ->where('status', 'active')
-                    ->whereDate('end_date', '<=', $now->copy()->addDays($range))
-                    ->whereDate('end_date', '>=', $now) // Only contracts that haven't expired yet
+                    ->whereDate('end_date', '<=', $now->copy()->addDays(30))
                     ->count(),
                 'payments_due_next_' . $range . 'd' => RmPaymentInstallment::where('user_id', $userId)
                     ->where('status', 'pending')
@@ -37,6 +36,7 @@ class DashboardService
             ],
             'rental_amounts' => $this->getRentalAmounts($userId),
             'ongoing_rentals' => $this->getOngoingRentals($userId),
+            'expiring_contracts_next_30d' => $this->getExpiringContracts($userId),
             'reminders' => RmReminder::where('user_id', $userId)
                 ->where('status', 'pending')
                 ->whereBetween('due_on', [$now, $end])
@@ -79,6 +79,37 @@ class DashboardService
                     ],
                     'next_payment_due_on' => optional($nextPayment)->due_date,
                     'next_payment_amount' => optional($nextPayment)->amount,
+                ];
+            });
+    }
+
+    protected function getExpiringContracts($userId)
+    {
+        $now = Carbon::now('Asia/Riyadh');
+        
+        return RmContract::with(['rental.property.contents'])
+            ->where('user_id', $userId)
+            ->where('status', 'active')
+            ->whereDate('end_date', '<=', $now->copy()->addDays(30))
+            ->orderBy('end_date')
+            ->get()
+            ->map(function ($contract) {
+                return [
+                    'id' => $contract->id,
+                    'start_date' => $contract->start_date,
+                    'end_date' => $contract->end_date,
+                    'status' => $contract->status,
+                    'days_until_expiry' => Carbon::now('Asia/Riyadh')->diffInDays($contract->end_date, false),
+                    'rental' => [
+                        'id' => $contract->rental_id,
+                        'tenant_name' => optional($contract->rental)->tenant_full_name,
+                        'tenant_phone' => optional($contract->rental)->tenant_phone,
+                        'property' => [
+                            'id' => optional($contract->rental)->property_id,
+                            'name' => optional($contract->rental->property->firstContent)->title,
+                            'unit_label' => optional($contract->rental)->unit_label,
+                        ],
+                    ],
                 ];
             });
     }


### PR DESCRIPTION
…actService and DashboardService

- Eliminated the 'contract_number' field from the RmContract model and updated the ContractService to no longer generate contract numbers during contract creation.
- Refactored the DashboardService to calculate the number of expiring contracts within the next 30 days, ensuring only active contracts are considered and improving clarity in contract management.