### PR TITLE
Add next payment information to RentalService response

### DIFF
--- a/app/Services/Rms/RentalService.php
+++ b/app/Services/Rms/RentalService.php
@@ -302,6 +302,9 @@ class RentalService
                 'total_rental_amount' => (float) $rental->total_rental_amount,
                 'currency' => $rental->currency,
                 'move_in_date' => $rental->move_in_date,
+                // Next payment information
+                'next_payment_due_date' => $rental->next_payment_due_date,
+                'next_payment_amount' => $rental->next_payment_amount,
                 'paying_plan' => $rental->paying_plan,
                 'rental_period' => (int) $rental->rental_period,
                 'status' => $rental->status,


### PR DESCRIPTION
- Included 'next_payment_due_date' and 'next_payment_amount' fields in the RentalService response to provide users with additional payment details related to their rental agreements.