### PR TITLE
Add subscription expiration notification features and settings

### DIFF
--- a/app/Http/Controllers/Admin/CommunicationController.php
+++ b/app/Http/Controllers/Admin/CommunicationController.php
@@ -298,6 +298,57 @@ class CommunicationController extends Controller
         return redirect()->back();
     }
 
+    public function updateSubscriptionExpired(Request $request)
+    {
+        $rules = [
+            'subscription_expired_enabled' => 'nullable|boolean',
+            'subscription_expired_text' => 'required|string|max:1000',
+            'subscription_expired_template' => 'nullable|string|max:100',
+            'subscription_expired_send_time' => 'nullable|date_format:H:i',
+        ];
+
+        $validator = Validator::make($request->all(), $rules);
+        if ($validator->fails()) {
+            return redirect()->back()
+                ->withErrors($validator)
+                ->withInput();
+        }
+
+        $abs = BasicSetting::first();
+        if (!$abs) {
+            $abs = new BasicSetting();
+        }
+
+        $abs->subscription_expired_enabled = $request->has('subscription_expired_enabled') ? 1 : 0;
+        $abs->subscription_expired_text = $request->subscription_expired_text;
+        $abs->subscription_expired_template = $request->subscription_expired_template;
+        $abs->subscription_expired_send_time = $request->subscription_expired_send_time ?? '09:00';
+        $abs->save();
+
+        Session::flash('success', 'On expiration notification settings updated successfully!');
+        return redirect()->back();
+    }
+
+    public function testSubscriptionExpired(Request $request)
+    {
+        $request->validate([
+            'test_phone' => 'required|string|max:20',
+        ]);
+
+        try {
+            $whatsappService = new WhatsAppService();
+            $testMessage = "انتهى اشتراكك وتم نقلك إلى الباقة المجانية. يمكنك الترقية في أي وقت.";
+            
+            $whatsappService->sendSubscriptionExpiredMessage($request->test_phone, $testMessage, 'Test User', 'Test Package', '2024-12-31');
+            
+            Session::flash('success', "Test on expiration message sent successfully to {$request->test_phone}");
+        } catch (\Exception $e) {
+            Session::flash('error', 'Test failed: ' . $e->getMessage());
+        }
+
+        return redirect()->back();
+    }
+
 
     /**
      * Fetch WhatsApp templates from Facebook Meta API

--- a/app/Http/Controllers/CronJobController.php
+++ b/app/Http/Controllers/CronJobController.php
@@ -79,26 +79,9 @@ class CronJobController extends Controller
                             $user->message = 'تم تحويلك إلى الباقة المجانية بعد انتهاء فترة التجربة. يمكنك ترقية باقاتك في أي وقت من لوحة التحكم.';
                             $user->save();
                             
-                            // Send WhatsApp notification about package expiration
-                            try {
-                                $whatsappService = new \App\Services\WhatsAppService();
-                                $expirationMessage = "تنبيه: باقة الاشتراك الخاصة بك قد انتهت وتم تحويلك إلى الباقة المجانية. يمكنك ترقية باقاتك في أي وقت من لوحة التحكم.";
-                                
-                                if (!empty($user->phone)) {
-                                    $whatsappService->sendSubscriptionExpirationMessage(
-                                        $user->phone,
-                                        $expirationMessage,
-                                        $user->first_name,
-                                        'الباقة المميزة',
-                                        Carbon::now()->format('Y-m-d')
-                                    );
-                                }
-                            } catch (\Exception $e) {
-                                Log::error('WhatsApp expiration notification failed', [
-                                    'user_id' => $user->id,
-                                    'phone' => $user->phone ?? 'N/A',
-                                    'error' => $e->getMessage()
-                                ]);
+                            // Send WhatsApp notification about package expiration (with retry logic)
+                            if ($bs->subscription_expired_enabled && !empty($user->phone) && !empty($bs->subscription_expired_text)) {
+                                $this->sendExpirationNotificationWithRetry($user, $bs, $exMember);
                             }
                             
                             \App\Jobs\FreePackageSwitchMail::dispatch($user, $bs, $be);
@@ -411,6 +394,60 @@ class CronJobController extends Controller
                 // dd($donationDetails);
                 // send a mail to the customer with the invoice
                 $donate->sendMail($donationDetails, $donationDetails->user_id);
+            }
+        }
+    }
+
+    /**
+     * Send expiration notification with retry logic
+     */
+    private function sendExpirationNotificationWithRetry($user, $bs, $membership)
+    {
+        $maxRetries = 3;
+        $retryDelay = 3; // minutes
+        
+        for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
+            try {
+                $whatsappService = new \App\Services\WhatsAppService();
+                $packageName = $membership->package ? $membership->package->title : 'الباقة المميزة';
+                $expiryDate = Carbon::parse($membership->expire_date)->format('Y-m-d');
+                
+                $whatsappService->sendSubscriptionExpiredMessage(
+                    $user->phone,
+                    $bs->subscription_expired_text,
+                    $user->first_name,
+                    $packageName,
+                    $expiryDate
+                );
+                
+                Log::info('Expiration notification sent successfully', [
+                    'user_id' => $user->id,
+                    'phone' => $user->phone,
+                    'attempt' => $attempt
+                ]);
+                
+                return; // Success, exit retry loop
+                
+            } catch (\Exception $e) {
+                Log::error('Expiration notification attempt failed', [
+                    'user_id' => $user->id,
+                    'phone' => $user->phone,
+                    'attempt' => $attempt,
+                    'max_retries' => $maxRetries,
+                    'error' => $e->getMessage()
+                ]);
+                
+                // If this is the last attempt, log final failure
+                if ($attempt === $maxRetries) {
+                    Log::error('All expiration notification attempts failed', [
+                        'user_id' => $user->id,
+                        'phone' => $user->phone,
+                        'total_attempts' => $maxRetries
+                    ]);
+                } else {
+                    // Wait before next retry (only if not the last attempt)
+                    sleep($retryDelay * 60); // Convert minutes to seconds
+                }
             }
         }
     }

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -383,6 +383,24 @@ class WhatsAppService
     }
 
     /**
+     * Send subscription expired message (on expiration day)
+     */
+    public function sendSubscriptionExpiredMessage($phoneNumber, $message, $userName = null, $packageName = null, $expiryDate = null)
+    {
+        $message = str_replace('{name}', $userName ?? 'User', $message);
+        $message = str_replace('{package_name}', $packageName ?? 'Package', $message);
+        $message = str_replace('{expiry_date}', $expiryDate ?? 'N/A', $message);
+        
+        if ($this->settings->whatsapp_service === 'meta_cloud') {
+            return $this->sendMetaCloudMessage($phoneNumber, $message, 'subscription_expired');
+        } elseif ($this->settings->whatsapp_service === 'evolution_api') {
+            return $this->sendViaEvolutionApi($phoneNumber, $message, $userName);
+        }
+        
+        throw new \Exception('No WhatsApp service configured');
+    }
+
+    /**
      * Send Meta Cloud message with template support
      */
     protected function sendMetaCloudMessage($phoneNumber, $message, $messageType = 'default')
@@ -395,6 +413,8 @@ class WhatsAppService
             $templateName = $this->settings->welcome_message_template;
         } elseif ($messageType === 'subscription_expiration' && !empty($this->settings->subscription_expiration_template)) {
             $templateName = $this->settings->subscription_expiration_template;
+        } elseif ($messageType === 'subscription_expired' && !empty($this->settings->subscription_expired_template)) {
+            $templateName = $this->settings->subscription_expired_template;
         } elseif ($messageType === 'password_reset' && !empty($this->settings->meta_template_name)) {
             $templateName = $this->settings->meta_template_name;
         }

--- a/database/migrations/2025_09_18_200717_add_subscription_expired_notification_fields_to_basic_settings_table.php
+++ b/database/migrations/2025_09_18_200717_add_subscription_expired_notification_fields_to_basic_settings_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('basic_settings', function (Blueprint $table) {
+            // On Expiration Notification fields
+            $table->boolean('subscription_expired_enabled')->default(false);
+            $table->text('subscription_expired_text')->nullable();
+            $table->string('subscription_expired_template')->nullable();
+            $table->time('subscription_expired_send_time')->default('09:00');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('basic_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'subscription_expired_enabled',
+                'subscription_expired_text',
+                'subscription_expired_template',
+                'subscription_expired_send_time'
+            ]);
+        });
+    }
+};

--- a/resources/views/admin/communication/whatsapp.blade.php
+++ b/resources/views/admin/communication/whatsapp.blade.php
@@ -39,7 +39,11 @@
           </button>
           <button class="tab-button {{request('tab') == 'subscription_expiration' ? 'active' : ''}}" 
                   data-tab="subscription_expiration">
-            رسالة انتهاء الباقة
+            اشعار قبل انتهاء الباقة
+          </button>
+          <button class="tab-button {{request('tab') == 'subscription_expired' ? 'active' : ''}}" 
+                  data-tab="subscription_expired">
+            إشعار انتهاء الباقة
           </button>
         </div>
       </div>
@@ -390,7 +394,7 @@
                       <div class="form-group">
                         <label for="subscription_expiration_text"><strong>نص رسالة انتهاء الباقة **</strong></label>
                         <textarea class="form-control" id="subscription_expiration_text" name="subscription_expiration_text" rows="4" 
-                                  placeholder="تنبيه: باقة الاشتراك الخاصة بك ستنتهي قريباً...">{{$abs->subscription_expiration_text ?? ''}}</textarea>
+                                  placeholder="تنبيه: باقة الاشتراك الخاصة بك ستنتهي قريباً...">{{$abs->subscription_expiration_text ?? 'تنبيه: باقة الاشتراك الخاصة بك ستنتهي قريباً.'}}</textarea>
                         <p class="text-muted">يمكن استخدام المتغيرات: {name}, {package_name}, {expiry_date}</p>
                         @error('subscription_expiration_text')
                           <p class="text-danger">{{ $message }}</p>
@@ -454,6 +458,99 @@
                         </button>
                         <button type="button" class="btn btn-warning ml-2" onclick="testSubscriptionExpiration()">
                           <i class="fas fa-paper-plane"></i> اختبار الرسالة
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </form>
+              </div>
+
+              <!-- On Expiration Notification Tab -->
+              <div id="subscription_expired-tab" class="tab-content {{request('tab') == 'subscription_expired' ? 'active' : ''}}">
+                <form action="{{route('admin.communication.subscription-expired.update')}}" method="POST">
+                  @csrf
+                  <div class="row">
+                    <div class="col-lg-12">
+                      <div class="form-group">
+                        <label for="subscription_expired_enabled">
+                          <strong>تفعيل إشعار انتهاء الباقة</strong>
+                        </label>
+                        <div class="toggle-switch-container">
+                          <div class="toggle-switch">
+                            <input type="checkbox" id="subscription_expired_enabled" name="subscription_expired_enabled" 
+                                   value="1" {{($abs->subscription_expired_enabled ?? false) ? 'checked' : ''}}>
+                            <label for="subscription_expired_enabled" class="toggle-label">
+                              <span class="toggle-slider"></span>
+                              <span class="toggle-text">
+                                <span class="toggle-on">ON</span>
+                                <span class="toggle-off">OFF</span>
+                              </span>
+                            </label>
+                          </div>
+                          <span class="toggle-description">إرسال إشعار عند انتهاء الباقة فعلياً</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-lg-12">
+                      <div class="form-group">
+                        <label for="subscription_expired_text"><strong>نص إشعار انتهاء الباقة **</strong></label>
+                        <textarea class="form-control" id="subscription_expired_text" name="subscription_expired_text" rows="4" 
+                                  placeholder="انتهى اشتراكك وتم نقلك إلى الباقة المجانية. يمكنك الترقية في أي وقت.">{{$abs->subscription_expired_text ?? 'انتهى اشتراكك وتم نقلك إلى الباقة المجانية. يمكنك الترقية في أي وقت.'}}</textarea>
+                        <p class="text-muted">يمكن استخدام المتغيرات: {name}, {package_name}, {expiry_date}</p>
+                        @error('subscription_expired_text')
+                          <p class="text-danger">{{ $message }}</p>
+                        @enderror
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-lg-6">
+                        <div class="form-group">
+                          <label for="subscription_expired_template"><strong>اسم القالب (Meta API)</strong></label>
+                          <select class="form-control" id="subscription_expired_template" name="subscription_expired_template">
+                            <option value="">اختر قالب أو اتركه فارغاً</option>
+                            @php
+                                try {
+                                    $expiredTemplates = \App\Models\WhatsAppTemplate::active()->ofType('subscription_expired')->get();
+                                } catch (Exception $e) {
+                                    $expiredTemplates = collect();
+                                }
+                            @endphp
+                            @foreach($expiredTemplates as $template)
+                              <option value="{{$template->name}}" {{($abs->subscription_expired_template ?? '') == $template->name ? 'selected' : ''}}>
+                                {{$template->name}} ({{$template->language_label}})
+                              </option>
+                            @endforeach
+                          </select>
+                          <p class="text-muted">اختر قالب من القوالب المحفوظة أو اتركه فارغاً للرسالة العادية</p>
+                          <small class="text-info">
+                            <i class="fas fa-info-circle"></i> 
+                            <a href="{{route('admin.whatsapp-templates.create')}}?type=subscription_expired" target="_blank">إنشاء قالب جديد</a>
+                          </small>
+                        </div>
+                    </div>
+                    <div class="col-lg-6">
+                      <div class="form-group">
+                        <label for="subscription_expired_send_time"><strong>وقت إرسال الإشعار</strong></label>
+                        <input type="time" class="form-control" id="subscription_expired_send_time" name="subscription_expired_send_time" 
+                               value="{{$abs->subscription_expired_send_time ?? '09:00'}}">
+                        <p class="text-muted">الوقت اليومي لإرسال إشعارات انتهاء الباقة</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-lg-12">
+                      <div class="form-group">
+                        <button type="submit" class="btn btn-primary">
+                          <i class="fas fa-save"></i> حفظ إعدادات إشعار انتهاء الباقة
+                        </button>
+                        <button type="button" class="btn btn-warning ml-2" onclick="testSubscriptionExpired()">
+                          <i class="fas fa-paper-plane"></i> اختبار الإشعار
                         </button>
                       </div>
                     </div>
@@ -631,6 +728,20 @@ function testSubscriptionExpiration() {
             location.reload();
         }).fail(function() {
             alert('حدث خطأ أثناء اختبار رسالة انتهاء الباقة');
+        });
+    }
+}
+
+function testSubscriptionExpired() {
+    var phone = prompt('أدخل رقم الهاتف للاختبار:', '+966501234567');
+    if (phone) {
+        $.post('{{route("admin.communication.subscription-expired.test")}}', {
+            _token: '{{csrf_token()}}',
+            test_phone: phone
+        }, function(response) {
+            location.reload();
+        }).fail(function() {
+            alert('حدث خطأ أثناء اختبار إشعار انتهاء الباقة');
         });
     }
 }

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -321,6 +321,10 @@ Route::middleware(['web', 'auth:admin', 'checkstatus', 'Demo'])
         // Subscription Expiration Routes
         Route::post('/communication/subscription-expiration/update', 'Admin\CommunicationController@updateSubscriptionExpiration')->name('communication.subscription-expiration.update');
         Route::post('/communication/subscription-expiration/test', 'Admin\CommunicationController@testSubscriptionExpiration')->name('communication.subscription-expiration.test');
+        
+        // On Expiration Notification Routes
+        Route::post('/communication/subscription-expired/update', 'Admin\CommunicationController@updateSubscriptionExpired')->name('communication.subscription-expired.update');
+        Route::post('/communication/subscription-expired/test', 'Admin\CommunicationController@testSubscriptionExpired')->name('communication.subscription-expired.test');
 
         // Email Communication Routes
         Route::get('/communication/email', 'Admin\EmailCommunicationController@index')->name('communication.email');


### PR DESCRIPTION
- Implemented a new method in CronJobController to send WhatsApp notifications for subscription expiration with retry logic.
- Added new fields in BasicSettings for enabling/disabling notifications, customizing message text, and setting send time.
- Created a new migration to add subscription expiration notification fields to the database.
- Updated CommunicationController to handle subscription expiration settings and testing functionality.
- Enhanced WhatsAppService to support sending subscription expired messages.
- Modified the admin communication view to include settings for subscription expiration notifications.