### PR TITLE
Update reset password URL and email link parameters for consistency

### DIFF
--- a/app/Http/Controllers/Api/ResetPasswordController.php
+++ b/app/Http/Controllers/Api/ResetPasswordController.php
@@ -108,7 +108,7 @@ class ResetPasswordController extends Controller
         
         // Get frontend URL for reset link
         $frontendUrl = rtrim(env('FRONTEND_URL', url('/')), '/');
-        $resetUrl = $frontendUrl . '/reset-password';
+        $resetUrl = $frontendUrl . '/reset';
 
         // Send code
         if ($request->method === 'email') {

--- a/app/Services/EmailService.php
+++ b/app/Services/EmailService.php
@@ -62,7 +62,7 @@ class EmailService
                 
                 // Add reset link if provided
                 if ($resetUrl) {
-                    $resetLink = $resetUrl . '?code=' . $code . '&email=' . urlencode($email);
+                    $resetLink = $resetUrl . '?code=' . $code . '&identifier=' . $email;
                     $content = str_replace('{reset_link}', $resetLink, $content);
                 }
             } else {
@@ -71,7 +71,7 @@ class EmailService
                 $content = "مرحباً {$name}،\n\nرمز إعادة تعيين كلمة المرور: {$code}\n\n";
                 
                 if ($resetUrl) {
-                    $resetLink = $resetUrl . '?code=' . $code . '&email=' . urlencode($email);
+                    $resetLink = $resetUrl . '?code=' . $code . '&identifier=' . $email;
                     $content .= "يمكنك أيضاً الضغط على الرابط التالي:\n{$resetLink}\n\n";
                 }
                 


### PR DESCRIPTION
- Changed the reset password URL from '/reset-password' to '/reset' for a more concise endpoint.
- Updated email service to use 'identifier' instead of 'email' in the reset link query parameters for improved clarity and consistency.