### PR TITLE
Enhance WhatsAppService with request timeout for API connection state…

### DIFF
--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -363,7 +363,7 @@ class WhatsAppService
             $response = Http::withHeaders([
                 'apikey' => $apiKey,
                 'Content-Type' => 'application/json',
-            ])->get("{$apiUrl}/instance/connectionState/{$instanceName}");
+            ])->timeout(10)->get("{$apiUrl}/instance/connectionState/{$instanceName}");
             
             if ($response->successful()) {
                 $responseData = $response->json();


### PR DESCRIPTION
… retrieval

- Added a timeout of 10 seconds to the API request for fetching the connection state of the WhatsApp instance, improving reliability in case of slow responses.