### PR TITLE
Implement Meta Cloud template validation for password reset messages

### DIFF
--- a/app/Http/Controllers/Admin/CommunicationController.php
+++ b/app/Http/Controllers/Admin/CommunicationController.php
@@ -431,8 +431,26 @@ class CommunicationController extends Controller
         
         $abs->save();
 
+        // Check for Meta Cloud template warning
+        $warningMessage = '';
+        if ($request->selected_api === 'meta' && $abs->whatsapp_service === 'meta_cloud') {
+            try {
+                $whatsappService = new \App\Services\WhatsAppService();
+                if (!$whatsappService->checkMetaTemplateExists('password_reset')) {
+                    $warningMessage = 'Warning: Meta Cloud API template "password_reset" not found. The system will use the default message format.';
+                }
+            } catch (\Exception $e) {
+                $warningMessage = 'Warning: Could not check Meta Cloud API templates. Please verify your API configuration.';
+            }
+        }
+
         $apiName = $request->selected_api === 'meta' ? 'Meta Cloud API' : 'Evolution API';
         Session::flash('success', "Password reset message settings updated successfully for {$apiName}!");
+        
+        if ($warningMessage) {
+            Session::flash('warning', $warningMessage);
+        }
+        
         return redirect()->back();
     }
 

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -43,6 +43,7 @@ class WhatsAppService
 
         // Get template - first try with specific template name, then with user language, then fallback
         $template = null;
+        $useMetaTemplate = false;
         
         // First, try to get the configured template from settings
         if ($this->settings->password_reset_template) {
@@ -77,6 +78,13 @@ class WhatsAppService
                 ->orderBy('created_at', 'desc')
                 ->first();
         }
+        
+        // If still no template found and using Meta Cloud, check for password_reset template
+        if (!$template && $this->settings->whatsapp_service === 'meta_cloud') {
+            if ($this->checkMetaTemplateExists('password_reset')) {
+                $useMetaTemplate = true;
+            }
+        }
 
         // Prepare message content
         if ($template) {
@@ -105,7 +113,7 @@ class WhatsAppService
 
         switch ($service) {
             case 'meta_cloud':
-                return $this->sendViaMetaCloud($phoneNumber, $code, $userName, $resetUrl, $message);
+                return $this->sendViaMetaCloud($phoneNumber, $code, $userName, $resetUrl, $message, $useMetaTemplate);
             case 'evolution_api':
                 return $this->sendViaEvolutionApi($phoneNumber, $code, $userName, $resetUrl, $message);
             default:
@@ -116,7 +124,7 @@ class WhatsAppService
     /**
      * Send message via Meta Cloud API
      */
-    protected function sendViaMetaCloud($phoneNumber, $code, $userName = null, $resetUrl = null, $message = null)
+    protected function sendViaMetaCloud($phoneNumber, $code, $userName = null, $resetUrl = null, $message = null, $useMetaTemplate = false)
     {
         try {
             $accessToken = $this->settings->meta_access_token;
@@ -130,6 +138,11 @@ class WhatsAppService
 
             // Format phone number (remove + and ensure it starts with country code)
             $formattedPhone = $this->formatPhoneNumber($phoneNumber);
+
+            // Auto-select password_reset template if no specific template is configured
+            if (!$templateName && !$message && $useMetaTemplate) {
+                $templateName = 'password_reset';
+            }
 
             // If no template name is provided or custom message is provided, send as regular message
             if (!$templateName || $message) {
@@ -721,6 +734,27 @@ class WhatsAppService
                 'error' => $e->getMessage()
             ]);
             throw $e;
+        }
+    }
+
+    /**
+     * Check if a specific Meta template exists
+     */
+    public function checkMetaTemplateExists($templateName)
+    {
+        try {
+            $templates = $this->fetchMetaTemplates();
+            
+            foreach ($templates as $template) {
+                if ($template['name'] === $templateName && $template['status'] === 'APPROVED') {
+                    return true;
+                }
+            }
+            
+            return false;
+        } catch (\Exception $e) {
+            // If we can't fetch templates, assume template doesn't exist
+            return false;
         }
     }
 

--- a/resources/views/admin/communication/whatsapp.blade.php
+++ b/resources/views/admin/communication/whatsapp.blade.php
@@ -614,6 +614,15 @@
                 <form action="{{route('admin.communication.password-reset.update')}}" method="POST" id="password-reset-form">
                   @csrf
                   <input type="hidden" name="selected_api" id="password_reset_selected_api" value="">
+                  
+                  @if(session('warning'))
+                    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                      <i class="fas fa-exclamation-triangle"></i> {{ session('warning') }}
+                      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                      </button>
+                    </div>
+                  @endif
                   <div class="row">
                     <div class="col-lg-12">
                       <div class="form-group">


### PR DESCRIPTION
- Added functionality in CommunicationController to check for the existence of the "password_reset" template in the Meta Cloud API and display a warning if not found.
- Enhanced WhatsAppService to support automatic selection of the "password_reset" template when using Meta Cloud if no specific template is configured.
- Updated the admin communication view to display warning messages related to template availability, improving user awareness and experience.