### PR TITLE
Update password reset message template in ResetPasswordController

### DIFF
--- a/app/Http/Controllers/Api/ResetPasswordController.php
+++ b/app/Http/Controllers/Api/ResetPasswordController.php
@@ -168,7 +168,7 @@ class ResetPasswordController extends Controller
                     $user->name ?? $user->username ?? 'User',
                     $userLanguage,
                     $resetUrl,
-                    null, // templateName
+                    'password_reset', // templateName
                     $user->id
                 );
                 


### PR DESCRIPTION
- Changed the template name used for WhatsApp password reset messages from null to 'password_reset', enhancing message consistency and personalization for users.