### PR TITLE
Update membership retrieval logic in AuthController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ test-webhook.php
 Credit_Management_API_Postman_Collection.json
 Marketing_Channels_API_Postman_Collection.json
 CREDIT_SYSTEM_FRONTEND_TESTING.postman_collection.json
+Taearif api local.postman_collection.json

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -580,7 +580,7 @@ class AuthController extends Controller
 
             // Get owner's latest membership from the membership table
             $membership = Membership::where('user_id', $owner->id)
-                ->orderBy('expire_date', 'desc')
+                ->orderBy('id', 'desc')
                 ->first();
 
             $domain = ApiDomainSetting::where('user_id', $owner->id)->where('status', 'active')->first([


### PR DESCRIPTION
- Changed the order of membership retrieval from 'expire_date' to 'id' to ensure the latest membership is fetched based on the record ID instead of the expiration date.