### PR TITLE
Revert 'expire:user' command schedule back to daily in Kernel.php

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,7 +32,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('expire:user')->everyMinute(); // TESTING: Changed from daily() to everyMinute()
+        $schedule->command('expire:user')->daily();
         $schedule->command('app:expire-trials')->daily();
         $schedule->command('reminders:process')->dailyAt('04:00')->timezone('Asia/Riyadh');
         $schedule->command('health:check --auto')->dailyAt('03:55')->timezone('Asia/Riyadh');


### PR DESCRIPTION
- Changed the scheduling of the 'expire:user' command from every minute back to daily to restore original functionality.