### PR TITLE
Refactor tenant website properties routes for improved organization

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -798,9 +798,9 @@ Route::prefix('v1/tenant-website')->middleware(['api','tenant.resolve'])->group(
     Route::put('{tenantId}/settings', [SettingsController::class, 'update'])->middleware('auth:sanctum');
     Route::post('{tenantId}/publish', [PublishController::class, 'store'])->middleware('auth:sanctum');
     Route::post('{tenantId}/forms/contact', [FormController::class, 'store']);
-});
 
-// Tenant Website Properties (public)
-Route::get('{tenantId}/properties', [\App\Http\Controllers\Api\V1\TenantWebsite\PropertyController::class, 'index']);
-Route::get('{tenantId}/properties/{slug}', [\App\Http\Controllers\Api\V1\TenantWebsite\PropertyController::class, 'show']);
+    // Tenant Website Properties (public)
+    Route::get('{tenantId}/properties', [\App\Http\Controllers\Api\V1\TenantWebsite\PropertyController::class, 'index']);
+    Route::get('{tenantId}/properties/{slug}', [\App\Http\Controllers\Api\V1\TenantWebsite\PropertyController::class, 'show']);
+});
 


### PR DESCRIPTION
- Moved tenant website properties routes back into the group definition for better clarity.
- Ensured that the routes for retrieving properties and specific property details remain accessible under the tenant context.