### PR TITLE
Add TestWhatsAppMessage command and update Kernel for WhatsApp messaging

### DIFF
--- a/app/Console/Commands/TestWhatsAppMessage.php
+++ b/app/Console/Commands/TestWhatsAppMessage.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Api\markting\MarketingChannel;
+use App\Models\Api\markting\UserCredit;
+use App\Http\Controllers\Api\markting\CreditController;
+use App\Services\WhatsAppService;
+
+class TestWhatsAppMessage extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'whatsapp:test {user_id} {phone} {message?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Test WhatsApp messaging for a specific user and phone number';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $userId = $this->argument('user_id');
+        $phone = $this->argument('phone');
+        $message = $this->argument('message') ?? 'Test message from Taearif CRM system';
+
+        $this->info("Testing WhatsApp message for User ID: {$userId}");
+        $this->info("Phone: {$phone}");
+        $this->info("Message: {$message}");
+
+        try {
+            // Check if user has WhatsApp channel
+            $channel = MarketingChannel::where('user_id', $userId)
+                ->where('type', 'whatsapp')
+                ->where('is_connected', true)
+                ->where('is_verified', true)
+                ->first();
+
+            if (!$channel) {
+                $this->error("No active WhatsApp channel found for user {$userId}");
+                $this->info("Available channels for user {$userId}:");
+                $channels = MarketingChannel::where('user_id', $userId)->get();
+                foreach ($channels as $ch) {
+                    $this->line("- ID: {$ch->id}, Type: {$ch->type}, Connected: " . ($ch->is_connected ? 'Yes' : 'No') . ", Verified: " . ($ch->is_verified ? 'Yes' : 'No'));
+                }
+                return 1;
+            }
+
+            $this->info("Found WhatsApp channel: {$channel->name} (ID: {$channel->id})");
+
+            // Check user credits
+            $userCredit = UserCredit::where('user_id', $userId)->first();
+            if (!$userCredit) {
+                $this->error("No credit record found for user {$userId}");
+                return 1;
+            }
+
+            $availableCredits = $userCredit->total_credits - $userCredit->used_credits;
+            $this->info("User credits: {$availableCredits} (Total: {$userCredit->total_credits}, Used: {$userCredit->used_credits})");
+
+            // Format phone number (add +966 if needed)
+            $formattedPhone = $this->formatPhoneNumber($phone);
+            $this->info("Formatted phone: {$formattedPhone}");
+
+            // Calculate credits needed
+            $creditsNeeded = UserCredit::getCostForMessageType('whatsapp');
+            $this->info("Credits needed: {$creditsNeeded}");
+
+            if ($availableCredits < $creditsNeeded) {
+                $this->error("Insufficient credits. Available: {$availableCredits}, Required: {$creditsNeeded}");
+                return 1;
+            }
+
+            // Use WhatsAppService to send message
+            $whatsappService = new WhatsAppService();
+
+            // Get Meta API credentials
+            $accessToken = $channel->access_token;
+            $phoneNumberId = $channel->phone_id;
+
+            if (!$accessToken || !$phoneNumberId) {
+                $this->error("WhatsApp channel missing API credentials");
+                $this->info("Access Token: " . ($accessToken ? 'Set' : 'Missing'));
+                $this->info("Phone ID: " . ($phoneNumberId ? 'Set' : 'Missing'));
+                return 1;
+            }
+
+            $this->info("Sending message via Meta API...");
+
+            // Send message via Meta API
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $url = "https://graph.facebook.com/{$apiVersion}/{$phoneNumberId}/messages";
+
+            $payload = [
+                'messaging_product' => 'whatsapp',
+                'to' => $formattedPhone,
+                'type' => 'text',
+                'text' => [
+                    'body' => $message
+                ]
+            ];
+
+            $response = \Illuminate\Support\Facades\Http::withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken,
+                'Content-Type' => 'application/json',
+            ])->post($url, $payload);
+
+            if ($response->successful()) {
+                $responseData = $response->json();
+                $messageId = $responseData['messages'][0]['id'] ?? null;
+
+                $this->info("✅ Message sent successfully!");
+                $this->info("Message ID: {$messageId}");
+
+                // Update channel message count
+                $channel->increment('sent_messages_count');
+
+                // Deduct credits
+                $creditResult = CreditController::useCredits(
+                    $userId,
+                    $creditsNeeded,
+                    "Test WhatsApp message sent to {$formattedPhone}",
+                    [
+                        'channel_id' => $channel->id,
+                        'channel_type' => 'whatsapp',
+                        'recipient' => $formattedPhone,
+                        'message_type' => 'text',
+                    ]
+                );
+
+                if ($creditResult['success']) {
+                    $this->info("Credits deducted: {$creditsNeeded}");
+                    $this->info("Remaining credits: {$creditResult['remaining_credits']}");
+                } else {
+                    $this->warn("Failed to deduct credits: {$creditResult['error']}");
+                }
+
+                return 0;
+            } else {
+                $errorData = $response->json();
+                $this->error("❌ Failed to send message");
+                $this->error("Status: " . $response->status());
+                $this->error("Error: " . ($errorData['error']['message'] ?? 'Unknown error'));
+                $this->error("Response: " . json_encode($errorData, JSON_PRETTY_PRINT));
+                return 1;
+            }
+
+        } catch (\Exception $e) {
+            $this->error("❌ Exception occurred: " . $e->getMessage());
+            $this->error("Trace: " . $e->getTraceAsString());
+            return 1;
+        }
+    }
+
+    /**
+     * Format phone number - keep as provided without adding country code
+     */
+    private function formatPhoneNumber($phoneNumber)
+    {
+        // Remove all non-numeric characters and return as is
+        $phone = preg_replace('/[^0-9]/', '', $phoneNumber);
+        return $phone;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Commands\HealthCheck::class,
         \App\Console\Commands\SendSubscriptionExpirationReminders::class,
         \App\Console\Commands\TestWhatsAppIntegrations::class,
+        \App\Console\Commands\TestWhatsAppMessage::class,
         \App\Console\Commands\RunAllScheduledTasks::class,
 
     ];

--- a/app/Http/Controllers/Api/markting/MarketingChannelController.php
+++ b/app/Http/Controllers/Api/markting/MarketingChannelController.php
@@ -582,6 +582,7 @@ class MarketingChannelController extends BaseApiController
         }
     }
 
+
     /**
      * Handle WhatsApp webhook
      */
@@ -1067,6 +1068,239 @@ class MarketingChannelController extends BaseApiController
             return $this->ok($formattedUsage->all(), 'Usage retrieved successfully');
         } catch (\Exception $e) {
             return $this->fail('Failed to retrieve usage: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Send WhatsApp message to CRM customer
+     */
+    public function sendWhatsAppToCustomer(Request $request): JsonResponse
+    {
+        try {
+            $validator = Validator::make($request->all(), [
+                'customer_id' => 'required|integer|exists:api_customers,id',
+                'message' => 'required|string|max:1000',
+                'channel_id' => 'nullable|integer|exists:marketing_channels,id',
+            ]);
+
+            if ($validator->fails()) {
+                return $this->fail('Validation failed', 422, $validator->errors());
+            }
+
+            $userId = Auth::id();
+            $customerId = $request->customer_id;
+
+            // Get customer and verify ownership
+            $customer = \App\Models\ApiCustomer::where('user_id', $userId)
+                ->where('id', $customerId)
+                ->first();
+
+            if (!$customer) {
+                return $this->fail('Customer not found or does not belong to you', 404);
+            }
+
+            // Check if customer has phone number
+            if (empty($customer->phone_number)) {
+                return $this->fail('Customer does not have a phone number', 400, [
+                    'error_code' => 'NO_PHONE_NUMBER',
+                    'customer_name' => $customer->name,
+                ]);
+            }
+
+            // Get or find WhatsApp marketing channel
+            $channel = null;
+            if ($request->has('channel_id')) {
+                $channel = MarketingChannel::where('user_id', $userId)
+                    ->where('id', $request->channel_id)
+                    ->where('type', 'whatsapp')
+                    ->where('is_connected', true)
+                    ->where('is_verified', true)
+                    ->first();
+            } else {
+                // Auto-find user's WhatsApp channel
+                $channel = MarketingChannel::where('user_id', $userId)
+                    ->where('type', 'whatsapp')
+                    ->where('is_connected', true)
+                    ->where('is_verified', true)
+                    ->first();
+            }
+
+            if (!$channel) {
+                return $this->fail('No active WhatsApp channel found. Please configure and verify your WhatsApp marketing channel first.', 400, [
+                    'error_code' => 'NO_WHATSAPP_CHANNEL',
+                ]);
+            }
+
+            // Format phone number (add country code if missing)
+            $formattedPhone = $this->formatPhoneNumber($customer->phone_number);
+
+            // Calculate credits needed
+            $creditsNeeded = UserCredit::getCostForMessageType('whatsapp');
+
+            // Check and deduct credits
+            $creditResult = CreditController::useCredits(
+                $userId,
+                $creditsNeeded,
+                "WhatsApp message sent to customer: {$customer->name}",
+                [
+                    'channel_id' => $channel->id,
+                    'channel_type' => 'whatsapp',
+                    'recipient' => $formattedPhone,
+                    'customer_id' => $customer->id,
+                    'customer_name' => $customer->name,
+                    'message_type' => 'text',
+                ]
+            );
+
+            if (!$creditResult['success']) {
+                return $this->fail($creditResult['error'], 400, [
+                    'credits_available' => $creditResult['available_credits'] ?? 0,
+                    'credits_required' => $creditsNeeded,
+                ]);
+            }
+
+            // Send message via Meta WhatsApp Business API
+            $messageResult = $this->sendWhatsAppViaMeta($channel, $formattedPhone, $request->message);
+
+            if ($messageResult['success']) {
+                // Update sent message count
+                $channel->increment('sent_messages_count');
+
+                // Log the message sent to customer
+                Log::info('WhatsApp message sent to CRM customer', [
+                    'user_id' => $userId,
+                    'customer_id' => $customer->id,
+                    'customer_name' => $customer->name,
+                    'phone' => $formattedPhone,
+                    'channel_id' => $channel->id,
+                    'message_id' => $messageResult['message_id'],
+                    'credits_used' => $creditsNeeded,
+                ]);
+
+                return $this->ok([
+                    'message_id' => $messageResult['message_id'],
+                    'customer' => [
+                        'id' => $customer->id,
+                        'name' => $customer->name,
+                        'phone_number' => $customer->phone_number,
+                        'formatted_phone' => $formattedPhone,
+                    ],
+                    'channel' => [
+                        'id' => $channel->id,
+                        'name' => $channel->name,
+                    ],
+                    'credits_used' => $creditsNeeded,
+                    'remaining_credits' => $creditResult['remaining_credits'],
+                    'status' => 'sent',
+                ], 'WhatsApp message sent to customer successfully');
+            } else {
+                // Refund credits if message sending failed
+                $this->refundCredits($userId, $creditsNeeded, "Failed to send WhatsApp message to customer: {$customer->name}");
+
+                return $this->fail('Failed to send WhatsApp message: ' . $messageResult['error'], 500, [
+                    'customer_name' => $customer->name,
+                    'phone' => $formattedPhone,
+                ]);
+            }
+
+        } catch (\Exception $e) {
+            Log::error('Error sending WhatsApp message to customer', [
+                'user_id' => Auth::id(),
+                'customer_id' => $request->customer_id ?? null,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            return $this->fail('Failed to send WhatsApp message: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Format phone number - keep as provided without adding country code
+     */
+    private function formatPhoneNumber($phoneNumber)
+    {
+        // Remove all non-numeric characters and return as is
+        $phone = preg_replace('/[^0-9]/', '', $phoneNumber);
+        return $phone;
+    }
+
+    /**
+     * Send WhatsApp message via Meta Business API
+     */
+    private function sendWhatsAppViaMeta($channel, $phoneNumber, $message)
+    {
+        try {
+            // Get Meta API credentials from channel or basic settings
+            $accessToken = $channel->access_token;
+            $phoneNumberId = $channel->phone_id;
+
+            // If channel doesn't have credentials, try to get from basic settings
+            if (!$accessToken || !$phoneNumberId) {
+                $basicSettings = \App\Models\BasicSetting::first();
+                if ($basicSettings && $basicSettings->whatsapp_service === 'meta_cloud') {
+                    $accessToken = $basicSettings->meta_access_token;
+                    $phoneNumberId = $basicSettings->meta_phone_number_id;
+                }
+            }
+
+            if (!$accessToken || !$phoneNumberId) {
+                throw new \Exception('Meta WhatsApp API credentials not configured');
+            }
+
+            // Prepare message payload
+            $payload = [
+                'messaging_product' => 'whatsapp',
+                'to' => $phoneNumber,
+                'type' => 'text',
+                'text' => [
+                    'body' => $message
+                ]
+            ];
+
+            // Send message via Meta API
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $response = \Illuminate\Support\Facades\Http::withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken,
+                'Content-Type' => 'application/json',
+            ])->post("https://graph.facebook.com/{$apiVersion}/{$phoneNumberId}/messages", $payload);
+
+            if ($response->successful()) {
+                $responseData = $response->json();
+                $messageId = $responseData['messages'][0]['id'] ?? null;
+
+                Log::info('Meta WhatsApp message sent successfully', [
+                    'phone' => $phoneNumber,
+                    'message_id' => $messageId,
+                    'response' => $responseData
+                ]);
+
+                return [
+                    'success' => true,
+                    'message_id' => $messageId,
+                    'meta_response' => $responseData,
+                ];
+            } else {
+                $errorData = $response->json();
+                Log::error('Meta WhatsApp API error', [
+                    'phone' => $phoneNumber,
+                    'response' => $errorData,
+                    'status' => $response->status()
+                ]);
+
+                throw new \Exception('Meta API error: ' . ($errorData['error']['message'] ?? 'Unknown error'));
+            }
+
+        } catch (\Exception $e) {
+            Log::error('Meta WhatsApp message exception', [
+                'phone' => $phoneNumber,
+                'error' => $e->getMessage()
+            ]);
+
+            return [
+                'success' => false,
+                'error' => $e->getMessage(),
+            ];
         }
     }
 }

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -24,11 +24,11 @@ class WhatsAppService
         if (!$this->settings || !$this->settings->whatsapp_service || !$this->settings->password_reset_enabled) {
             // Prepare default message
             $message = "رمز إعادة تعيين كلمة المرور: {$code}\n\nهذا الرمز صالح لمدة 15 دقيقة.";
-            
+
             if ($resetUrl) {
                 $message .= "\n\nأو يمكنك الضغط على الرابط التالي:\n{$resetUrl}?code={$code}";
             }
-            
+
             // Log that we're using default message due to service not being configured
             Log::info('WhatsApp service not configured, using default message format', [
                 'phone' => $phoneNumber,
@@ -36,7 +36,7 @@ class WhatsAppService
                 'service_configured' => $this->settings && $this->settings->whatsapp_service ? true : false,
                 'password_reset_enabled' => $this->settings && $this->settings->password_reset_enabled ? true : false
             ]);
-            
+
             // Return the default message (frontend can handle this as a fallback)
             return $message;
         }
@@ -44,7 +44,7 @@ class WhatsAppService
         // Get template - first try with specific template name, then with user language, then fallback
         $template = null;
         $useMetaTemplate = false;
-        
+
         // First, try to get the configured template from settings
         if ($this->settings->password_reset_template) {
             $template = \App\Models\WhatsAppTemplate::where('name', $this->settings->password_reset_template)
@@ -52,7 +52,7 @@ class WhatsAppService
                 ->where('status', true)
                 ->first();
         }
-        
+
         // If no configured template found, try with specific template name parameter
         // But only if we're not using Meta Cloud service
         if (!$template && $templateName && $this->settings->whatsapp_service !== 'meta_cloud') {
@@ -61,7 +61,7 @@ class WhatsAppService
                 ->where('status', true)
                 ->first();
         }
-        
+
         // If no specific template found, try to get template by user language
         if (!$template) {
             $template = \App\Models\WhatsAppTemplate::where('type', 'password_reset')
@@ -70,7 +70,7 @@ class WhatsAppService
                 ->orderBy('created_at', 'desc')
                 ->first();
         }
-        
+
         // If still no template found, try Arabic as fallback
         if (!$template && $userLanguage !== 'ar') {
             $template = \App\Models\WhatsAppTemplate::where('type', 'password_reset')
@@ -79,14 +79,14 @@ class WhatsAppService
                 ->orderBy('created_at', 'desc')
                 ->first();
         }
-        
+
         // If still no template found and using Meta Cloud, check for password_reset template
         if (!$template && $this->settings->whatsapp_service === 'meta_cloud') {
             if ($this->checkMetaTemplateExists('password_reset')) {
                 $useMetaTemplate = true;
             }
         }
-        
+
         // If a specific template name is provided and we're using Meta Cloud, try Meta template first
         if ($templateName && $this->settings->whatsapp_service === 'meta_cloud') {
             Log::info('Checking Meta template for password reset', [
@@ -110,7 +110,7 @@ class WhatsAppService
         // Prepare message content
         if ($template) {
             $message = $template->content;
-            
+
             // Replace variables
             $message = str_replace('{code}', $code, $message);
             $message = str_replace('{name}', $userName ?? 'User', $message);
@@ -120,7 +120,7 @@ class WhatsAppService
         } else {
             // Use configured custom message or fallback to default
             $message = $this->settings->password_reset_text ?? "رمز إعادة تعيين كلمة المرور: {$code}\n\nهذا الرمز صالح لمدة 15 دقيقة.\n\nأو يمكنك الضغط على الرابط التالي:\n{$resetUrl}?code={$code}";
-            
+
             // Replace variables in custom message
             $message = str_replace('{code}', $code, $message);
             $message = str_replace('{name}', $userName ?? 'User', $message);
@@ -174,23 +174,23 @@ class WhatsAppService
                         return true;
                     }
                 }
-                
+
                 // Fallback to database template
                 $dbTemplate = \App\Models\WhatsAppTemplate::where('name', $templateName)
                     ->where('type', 'password_reset')
                     ->where('status', true)
                     ->first();
-                    
+
                 if ($dbTemplate) {
                     Log::info('Using database template for password reset fallback', [
                         'template_name' => $templateName,
                         'template_content' => $dbTemplate->content
                     ]);
-                    
+
                     $templateMessage = $dbTemplate->content;
                     $templateMessage = str_replace('{code}', $code, $templateMessage);
                     $templateMessage = str_replace('{reset_url}', $resetUrl, $templateMessage);
-                    
+
                     return $this->sendRegularMessage($formattedPhone, $templateMessage);
                 }
             }
@@ -217,7 +217,7 @@ class WhatsAppService
                 // Add user name if provided
                 if ($userName) {
                     array_unshift($templateParams, [
-                        "type" => "text", 
+                        "type" => "text",
                         "text" => $userName
                     ]);
                 }
@@ -295,7 +295,7 @@ class WhatsAppService
 
             // Format phone number
             $formattedPhone = $this->formatPhoneNumber($phoneNumber);
-            
+
             Log::info('Evolution API welcome message formatting', [
                 'original' => $phoneNumber,
                 'formatted' => $formattedPhone
@@ -303,7 +303,7 @@ class WhatsAppService
 
             // Add title/header to the message for Evolution API
             $title = "تم التسجيل بنجاح في منصة تعاريف";
-            
+
             // Convert \n to actual line breaks and remove email from message
             $processedMessage = str_replace('\\n', "\n", $message);
             $processedMessage = str_replace('{email}', '', $processedMessage);
@@ -315,11 +315,11 @@ class WhatsAppService
             // Clean up extra line breaks
             $processedMessage = preg_replace('/\n\s*\n/', "\n", $processedMessage);
             $processedMessage = trim($processedMessage);
-            
+
             // Add clickable links from .env
             $appUrl = env('APP_URL', 'https://taearifdev.com');
             $frontendUrl = env('FRONTEND_URL', 'https://app.taearif.com');
-            
+
             $fullMessage = "*{$title}*\n\n{$processedMessage}\n\n🔗 روابط مفيدة:\n🌐 موقعك: {$appUrl}\n📊 لوحة التحكم: {$frontendUrl}";
 
             // Clean message for Evolution API (preserve line breaks)
@@ -335,7 +335,7 @@ class WhatsAppService
             ];
 
             $endpoint = "{$apiUrl}/message/sendText/{$instanceName}";
-            
+
             Log::info('Evolution API welcome message request', [
                 'endpoint' => $endpoint,
                 'payload' => $payload,
@@ -388,7 +388,7 @@ class WhatsAppService
 
             // Format phone number
             $formattedPhone = $this->formatPhoneNumber($phoneNumber);
-            
+
             // Log the phone number formatting for debugging
             Log::info('Phone number formatting', [
                 'original' => $phoneNumber,
@@ -398,7 +398,7 @@ class WhatsAppService
             // Use custom message if provided, otherwise prepare default message
             if (!$message) {
                 $message = "رمز إعادة تعيين كلمة المرور: {$code}\n\nهذا الرمز صالح لمدة 15 دقيقة.";
-                
+
                 // Add reset URL if provided (only code, no identifier)
                 if ($resetUrl) {
                     $message .= "\n\nأو يمكنك الضغط على الرابط التالي:\n{$resetUrl}?code={$code}";
@@ -415,7 +415,7 @@ class WhatsAppService
             ];
 
             $endpoint = "{$apiUrl}/message/sendText/{$instanceName}";
-            
+
             Log::info('Evolution API Request Details', [
                 'endpoint' => $endpoint,
                 'payload' => $payload,
@@ -437,7 +437,7 @@ class WhatsAppService
             } else {
                 $errorResponse = $response->json();
                 $errorMessage = $errorResponse['message'] ?? $errorResponse['error'] ?? 'Unknown error';
-                
+
                 Log::error('Evolution API error', [
                     'phone' => $formattedPhone,
                     'endpoint' => $endpoint,
@@ -464,10 +464,10 @@ class WhatsAppService
     {
         // Remove all non-numeric characters except +
         $phone = preg_replace('/[^0-9+]/', '', $phoneNumber);
-        
+
         // Remove + if present
         $phone = ltrim($phone, '+');
-        
+
         // Handle Egyptian phone numbers first (most specific)
         // If it's 11 digits starting with 01, remove the 0 and add Egyptian country code 20
         if (preg_match('/^01\d{9}$/', $phone)) {
@@ -504,15 +504,15 @@ class WhatsAppService
         elseif (preg_match('/^(\d{1,4})0(\d+)$/', $phone, $matches)) {
             $countryCode = $matches[1];
             $localNumber = $matches[2];
-            
+
             // For common country codes, remove the leading 0 from local number
             $commonCountryCodes = ['20', '966', '1', '44', '33', '49', '39', '34', '7', '81', '86', '91'];
-            
+
             if (in_array($countryCode, $commonCountryCodes)) {
                 $phone = $countryCode . $localNumber;
             }
         }
-        
+
         return $phone;
     }
 
@@ -524,13 +524,13 @@ class WhatsAppService
     {
         // Replace newlines and tabs with spaces
         $message = str_replace(["\r\n", "\r", "\n", "\t"], ' ', $message);
-        
+
         // Replace multiple consecutive spaces with single space
         $message = preg_replace('/\s+/', ' ', $message);
-        
+
         // Trim leading and trailing spaces
         $message = trim($message);
-        
+
         return $message;
     }
 
@@ -542,19 +542,19 @@ class WhatsAppService
     {
         // Normalize line endings
         $message = str_replace(["\r\n", "\r"], "\n", $message);
-        
+
         // Replace tabs with spaces
         $message = str_replace("\t", ' ', $message);
-        
+
         // Replace multiple consecutive spaces with single space (but preserve line breaks)
         $message = preg_replace('/[ ]+/', ' ', $message);
-        
+
         // Remove empty lines (multiple consecutive newlines)
         $message = preg_replace('/\n\s*\n/', "\n", $message);
-        
+
         // Trim leading and trailing whitespace
         $message = trim($message);
-        
+
         return $message;
     }
 
@@ -637,17 +637,17 @@ class WhatsAppService
             $apiUrl = $this->settings->evolution_api_url;
             $apiKey = $this->settings->evolution_api_key;
             $instanceName = $this->settings->evolution_instance_name;
-            
+
             // Test connection to Evolution API
             $response = Http::withHeaders([
                 'apikey' => $apiKey,
                 'Content-Type' => 'application/json',
             ])->timeout(10)->get("{$apiUrl}/instance/connectionState/{$instanceName}");
-            
+
             if ($response->successful()) {
                 $responseData = $response->json();
                 $connectionState = $responseData['instance']['state'] ?? 'unknown';
-                
+
                 return [
                     'status' => 'success',
                     'message' => "Evolution API configuration is complete. Instance state: {$connectionState}"
@@ -685,17 +685,17 @@ class WhatsAppService
                 }
             }
         }
-        
+
         // Replace template variables
         $message = str_replace('{name}', $displayName, $message);
         $message = str_replace('{email}', $userEmail ?? 'N/A', $message);
-        
+
         if ($this->settings->whatsapp_service === 'meta_cloud') {
             return $this->sendMetaCloudMessage($phoneNumber, $message, 'welcome', $displayName, $userEmail);
         } elseif ($this->settings->whatsapp_service === 'evolution_api') {
             return $this->sendWelcomeViaEvolutionApi($phoneNumber, $message, $displayName);
         }
-        
+
         throw new \Exception('No WhatsApp service configured');
     }
 
@@ -707,13 +707,13 @@ class WhatsAppService
         $message = str_replace('{name}', $userName ?? 'User', $message);
         $message = str_replace('{package_name}', $packageName ?? 'Package', $message);
         $message = str_replace('{expiry_date}', $expiryDate ?? 'N/A', $message);
-        
+
         if ($this->settings->whatsapp_service === 'meta_cloud') {
             return $this->sendMetaCloudMessage($phoneNumber, $message, 'subscription_expiration', $userName, null, $packageName, $expiryDate);
         } elseif ($this->settings->whatsapp_service === 'evolution_api') {
             return $this->sendSubscriptionExpirationViaEvolutionApi($phoneNumber, $message, $userName, $packageName, $expiryDate);
         }
-        
+
         throw new \Exception('No WhatsApp service configured');
     }
 
@@ -725,7 +725,7 @@ class WhatsAppService
         $message = str_replace('{name}', $userName ?? 'User', $message);
         $message = str_replace('{package_name}', $packageName ?? 'Package', $message);
         $message = str_replace('{expiry_date}', $expiryDate ?? 'N/A', $message);
-        
+
         // Respect admin's WhatsApp service selection first, then fallback
         if ($this->settings->whatsapp_service === 'meta_cloud') {
             // Primary: Try Meta Cloud as per admin selection
@@ -745,12 +745,12 @@ class WhatsAppService
                     'error' => $e->getMessage()
                 ]);
             }
-            
+
             // Fallback: Try Evolution API if Meta Cloud failed
-            $evolutionAvailable = !empty($this->settings->evolution_api_url) && 
-                                 !empty($this->settings->evolution_api_key) && 
+            $evolutionAvailable = !empty($this->settings->evolution_api_url) &&
+                                 !empty($this->settings->evolution_api_key) &&
                                  !empty($this->settings->evolution_instance_name);
-            
+
             if ($evolutionAvailable) {
                 try {
                     $result = $this->sendSubscriptionExpiredViaEvolutionApi($phoneNumber, $message, $userName, $packageName, $expiryDate);
@@ -771,10 +771,10 @@ class WhatsAppService
             }
         } elseif ($this->settings->whatsapp_service === 'evolution_api') {
             // Primary: Try Evolution API as per admin selection
-            $evolutionAvailable = !empty($this->settings->evolution_api_url) && 
-                                 !empty($this->settings->evolution_api_key) && 
+            $evolutionAvailable = !empty($this->settings->evolution_api_url) &&
+                                 !empty($this->settings->evolution_api_key) &&
                                  !empty($this->settings->evolution_instance_name);
-            
+
             if ($evolutionAvailable) {
                 try {
                     $result = $this->sendSubscriptionExpiredViaEvolutionApi($phoneNumber, $message, $userName, $packageName, $expiryDate);
@@ -793,7 +793,7 @@ class WhatsAppService
                     ]);
                 }
             }
-            
+
             // Fallback: Try Meta Cloud if Evolution API failed
             try {
                 $result = $this->sendMetaCloudMessage($phoneNumber, $message, 'subscription_expired', $userName, null, $packageName, $expiryDate);
@@ -812,25 +812,25 @@ class WhatsAppService
                 ]);
             }
         }
-        
+
         // Final fallback: Use database template as regular message
         Log::info('Using database template fallback for subscription expired', [
             'phone' => $phoneNumber,
             'service' => 'database_fallback'
         ]);
-        
+
         // Get database template
         $template = \App\Models\WhatsAppTemplate::where('name', 'subscription_expired_notice')
             ->where('type', 'subscription_expired')
             ->where('status', true)
             ->first();
-            
+
         if ($template) {
             $templateMessage = $template->content;
             $templateMessage = str_replace('{name}', $userName ?? 'User', $templateMessage);
             $templateMessage = str_replace('{package_name}', $packageName ?? 'Package', $templateMessage);
             $templateMessage = str_replace('{expiry_date}', $expiryDate ?? 'N/A', $templateMessage);
-            
+
             // Try to send via current WhatsApp service as regular message
             if ($this->settings->whatsapp_service === 'meta_cloud') {
                 return $this->sendRegularMessage($phoneNumber, $templateMessage);
@@ -840,11 +840,11 @@ class WhatsAppService
                     $apiUrl = $this->settings->evolution_api_url;
                     $apiKey = $this->settings->evolution_api_key;
                     $instanceName = $this->settings->evolution_instance_name;
-                    
+
                     if ($apiUrl && $apiKey && $instanceName) {
                         $formattedPhone = $this->formatPhoneNumber($phoneNumber);
                         $cleanedMessage = $this->cleanRegularMessageForWhatsApp($templateMessage);
-                        
+
                         $payload = [
                             "number" => $formattedPhone,
                             "text" => $cleanedMessage,
@@ -853,13 +853,13 @@ class WhatsAppService
                                 "presence" => "composing"
                             ]
                         ];
-                        
+
                         $endpoint = "{$apiUrl}/message/sendText/{$instanceName}";
                         $response = \Illuminate\Support\Facades\Http::withHeaders([
                             'apikey' => $apiKey,
                             'Content-Type' => 'application/json',
                         ])->post($endpoint, $payload);
-                        
+
                         return $response->successful();
                     }
                 } catch (\Exception $e) {
@@ -872,7 +872,7 @@ class WhatsAppService
                 return $this->sendRegularMessage($phoneNumber, $templateMessage);
             }
         }
-        
+
         // Ultimate fallback: Send the original message as regular text
         return $this->sendRegularMessage($phoneNumber, $message);
     }
@@ -893,7 +893,7 @@ class WhatsAppService
 
             // Format phone number
             $formattedPhone = $this->formatPhoneNumber($phoneNumber);
-            
+
             Log::info('Evolution API subscription expiration message formatting', [
                 'original' => $phoneNumber,
                 'formatted' => $formattedPhone
@@ -901,14 +901,14 @@ class WhatsAppService
 
             // Add title/header to the message for Evolution API
             $title = "تنبيه انتهاء الاشتراك";
-            
+
             // Convert \n to actual line breaks
             $processedMessage = str_replace('\\n', "\n", $message);
-            
+
             // Add links from .env
             $appUrl = env('APP_URL', 'https://taearifdev.com');
             $frontendUrl = env('FRONTEND_URL', 'https://app.taearif.com');
-            
+
             $fullMessage = "*{$title}*\n\n{$processedMessage}\n\n🔗 روابط مفيدة:\n🌐 موقعك: {$appUrl}\n📊 لوحة التحكم: {$frontendUrl}";
 
             // Clean message for Evolution API (preserve line breaks)
@@ -924,7 +924,7 @@ class WhatsAppService
             ];
 
             $endpoint = "{$apiUrl}/message/sendText/{$instanceName}";
-            
+
             Log::info('Evolution API subscription expiration message request', [
                 'endpoint' => $endpoint,
                 'payload' => $payload,
@@ -976,7 +976,7 @@ class WhatsAppService
 
             // Format phone number
             $formattedPhone = $this->formatPhoneNumber($phoneNumber);
-            
+
             Log::info('Evolution API subscription expired message formatting', [
                 'original' => $phoneNumber,
                 'formatted' => $formattedPhone
@@ -984,14 +984,14 @@ class WhatsAppService
 
             // Add title/header to the message for Evolution API
             $title = "انتهت صلاحية الاشتراك";
-            
+
             // Convert \n to actual line breaks
             $processedMessage = str_replace('\\n', "\n", $message);
-            
+
             // Add links from .env
             $appUrl = env('APP_URL', 'https://taearifdev.com');
             $frontendUrl = env('FRONTEND_URL', 'https://app.taearif.com');
-            
+
             $fullMessage = "*{$title}*\n\n{$processedMessage}\n\n🔗 روابط مفيدة:\n🌐 موقعك: {$appUrl}\n📊 لوحة التحكم: {$frontendUrl}";
 
             // Clean message for Evolution API (preserve line breaks)
@@ -1007,7 +1007,7 @@ class WhatsAppService
             ];
 
             $endpoint = "{$apiUrl}/message/sendText/{$instanceName}";
-            
+
             Log::info('Evolution API subscription expired message request', [
                 'endpoint' => $endpoint,
                 'payload' => $payload,
@@ -1050,16 +1050,16 @@ class WhatsAppService
     {
         $templateName = null;
         $templateContent = null;
-        
+
         // Clean message for WhatsApp template parameters
         $message = $this->cleanMessageForWhatsApp($message);
-        
+
         Log::info('Meta Cloud message processing', [
             'phone' => $phoneNumber,
             'message_type' => $messageType,
             'message' => $message
         ]);
-        
+
         // Get template name based on message type
         if ($messageType === 'welcome' && !empty($this->settings->welcome_message_template)) {
             $templateName = $this->settings->welcome_message_template;
@@ -1108,7 +1108,7 @@ class WhatsAppService
             'formatted_phone' => $formattedPhone,
             'template_name' => $templateName,
             'message_type' => $messageType,
-            'sending_method' => $templateName && $messageType === 'welcome' ? 'approved_meta_template' : 
+            'sending_method' => $templateName && $messageType === 'welcome' ? 'approved_meta_template' :
                               ($templateName && $templateContent ? 'database_template' : 'regular_message')
         ]);
 
@@ -1120,7 +1120,7 @@ class WhatsAppService
                 'user_email' => $userEmail,
                 'user_name' => $userName
             ]);
-            
+
             switch ($messageType) {
                 case 'welcome':
                     return $this->sendWelcomeMetaTemplate($formattedPhone, $templateName, $userEmail, $userName);
@@ -1134,7 +1134,7 @@ class WhatsAppService
                         'phone' => $formattedPhone,
                         'reason' => 'template_delivery_issues'
                     ]);
-                    
+
                     $customMessage = "إشعار بانتهاء الاشتراك\n\n" . $message . "\n\nمنصة تعاريف لبناء المواقع العقارية\n\nللدخول: " . env('FRONTEND_URL', 'https://app.taearif.com') . "/login";
                     return $this->sendRegularMessage($formattedPhone, $customMessage);
                 default:
@@ -1145,7 +1145,7 @@ class WhatsAppService
                     break;
             }
         }
-        
+
         if ($templateName && $templateContent) {
             // For other message types, use database template content
             $processedContent = $templateContent;
@@ -1153,7 +1153,7 @@ class WhatsAppService
             $processedContent = str_replace('{email}', $userEmail ?? 'N/A', $processedContent);
             $processedContent = str_replace('{package_name}', $packageName ?? 'Package', $processedContent);
             $processedContent = str_replace('{expiry_date}', $expiryDate ?? 'N/A', $processedContent);
-            
+
             Log::info('Using database template content for regular message', [
                 'template_name' => $templateName,
                 'template_content' => $templateContent,
@@ -1185,8 +1185,9 @@ class WhatsAppService
     protected function sendTemplateMessage($phoneNumber, $templateName, $message)
     {
         try {
-            $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $url = "https://graph.facebook.com/{$apiVersion}/{$this->settings->meta_phone_number_id}/messages";
+
             $data = [
                 'messaging_product' => 'whatsapp',
                 'to' => $phoneNumber,
@@ -1256,8 +1257,9 @@ class WhatsAppService
     protected function sendApprovedTemplateMessage($phoneNumber, $templateName, $userEmail, $userName = null)
     {
         try {
-            $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $url = "https://graph.facebook.com/{$apiVersion}/{$this->settings->meta_phone_number_id}/messages";
+
             // Use exact Postman format
             $data = [
                 'messaging_product' => 'whatsapp',
@@ -1341,8 +1343,9 @@ class WhatsAppService
     protected function sendWelcomeMetaTemplate($phoneNumber, $templateName, $userEmail, $userName = null)
     {
         try {
-            $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $url = "https://graph.facebook.com/{$apiVersion}/{$this->settings->meta_phone_number_id}/messages";
+
             $data = [
                 'messaging_product' => 'whatsapp',
                 'to' => $phoneNumber,
@@ -1426,7 +1429,7 @@ class WhatsAppService
     {
         try {
             $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+
             // subscription_expiry_reminder template has no parameters, just header and body
             $data = [
                 'messaging_product' => 'whatsapp',
@@ -1489,7 +1492,7 @@ class WhatsAppService
     {
         try {
             $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+
             // subscription_expired_notice template structure: header, body, footer, and URL button (no parameters needed)
             $data = [
                 'messaging_product' => 'whatsapp',
@@ -1552,7 +1555,7 @@ class WhatsAppService
     {
         try {
             $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+
             // Get company name from user_basic_settings table
             $companyName = 'المستخدم'; // Default fallback
             if ($userId) {
@@ -1571,7 +1574,7 @@ class WhatsAppService
             } elseif ($userName) {
                 $companyName = $userName; // Fallback to provided user name
             }
-            
+
             // password_reset template uses positional parameters
             $data = [
                 'messaging_product' => 'whatsapp',
@@ -1658,10 +1661,10 @@ class WhatsAppService
     {
         try {
             $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+
             // Clean message for regular WhatsApp messages (preserve line breaks)
             $cleanedMessage = $this->cleanRegularMessageForWhatsApp($message);
-            
+
             $data = [
                 'messaging_product' => 'whatsapp',
                 'to' => $phoneNumber,
@@ -1721,10 +1724,10 @@ class WhatsAppService
     {
         try {
             $url = "https://graph.facebook.com/v20.0/{$this->settings->meta_phone_number_id}/messages";
-            
+
             // Clean message for regular WhatsApp messages (preserve line breaks)
             $cleanedMessage = $this->cleanRegularMessageForWhatsApp($message);
-            
+
             $data = [
                 'messaging_product' => 'whatsapp',
                 'to' => $phoneNumber,
@@ -1783,8 +1786,9 @@ class WhatsAppService
                 throw new \Exception('Meta Cloud API configuration incomplete');
             }
 
-            $url = "https://graph.facebook.com/v20.0/{$businessAccountId}/message_templates";
-            
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $url = "https://graph.facebook.com/{$apiVersion}/{$businessAccountId}/message_templates";
+
             $response = Http::withHeaders([
                 'Authorization' => 'Bearer ' . $accessToken,
                 'Content-Type' => 'application/json',
@@ -1795,7 +1799,7 @@ class WhatsAppService
             if ($response->successful()) {
                 $data = $response->json();
                 $templates = [];
-                
+
                 if (isset($data['data'])) {
                     foreach ($data['data'] as $template) {
                         // Only include approved templates
@@ -1809,7 +1813,7 @@ class WhatsAppService
                         }
                     }
                 }
-                
+
                 return $templates;
             } else {
                 Log::error('Meta API template fetch error', [
@@ -1828,19 +1832,97 @@ class WhatsAppService
     }
 
     /**
+     * Public generic sender for Meta WhatsApp templates with dynamic body params
+     */
+    public function sendTemplateToPhone(string $phoneNumber, string $templateName, string $language = 'ar', array $bodyParams = [])
+    {
+        try {
+            $accessToken = $this->settings->meta_access_token;
+            $phoneNumberId = $this->settings->meta_phone_number_id;
+
+            if (!$accessToken || !$phoneNumberId) {
+                return [
+                    'success' => false,
+                    'message' => 'Meta Cloud API configuration incomplete'
+                ];
+            }
+
+            // Map body params into template parameters
+            $parameters = [];
+            foreach ($bodyParams as $param) {
+                $parameters[] = [
+                    'type' => 'text',
+                    'text' => (string) $param,
+                ];
+            }
+
+            $apiVersion = config('services.meta.api_version', 'v20.0');
+            $url = "https://graph.facebook.com/{$apiVersion}/{$phoneNumberId}/messages";
+
+            $payload = [
+                'messaging_product' => 'whatsapp',
+                'to' => $phoneNumber,
+                'type' => 'template',
+                'template' => [
+                    'name' => $templateName,
+                    'language' => [
+                        'policy' => 'deterministic',
+                        'code' => $language,
+                    ],
+                ],
+            ];
+
+            if (!empty($parameters)) {
+                $payload['template']['components'] = [
+                    [
+                        'type' => 'body',
+                        'parameters' => $parameters,
+                    ],
+                ];
+            }
+
+            $response = \Illuminate\Support\Facades\Http::withHeaders([
+                'Authorization' => 'Bearer ' . $accessToken,
+                'Content-Type' => 'application/json',
+            ])->post($url, $payload);
+
+            if ($response->successful()) {
+                $json = $response->json();
+                return [
+                    'success' => true,
+                    'message_id' => $json['messages'][0]['id'] ?? null,
+                    'response' => $json,
+                ];
+            }
+
+            $err = $response->json();
+            return [
+                'success' => false,
+                'message' => $err['error']['message'] ?? 'Failed to send template',
+                'response' => $err,
+            ];
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
      * Check if a specific Meta template exists
      */
     public function checkMetaTemplateExists($templateName)
     {
         try {
             $templates = $this->fetchMetaTemplates();
-            
+
             foreach ($templates as $template) {
                 if ($template['name'] === $templateName && $template['status'] === 'APPROVED') {
                     return true;
                 }
             }
-            
+
             return false;
         } catch (\Exception $e) {
             // If we can't fetch templates, assume template doesn't exist
@@ -1901,7 +1983,8 @@ class WhatsAppService
             ];
         }
 
-        $url = "https://graph.facebook.com/v20.0/{$phoneNumberId}/messages";
+        $apiVersion = config('services.meta.api_version', 'v20.0');
+        $url = "https://graph.facebook.com/{$apiVersion}/{$phoneNumberId}/messages";
 
         $payload = [
             'messaging_product' => 'whatsapp',

--- a/config/services.php
+++ b/config/services.php
@@ -61,4 +61,12 @@ return [
         'redirect' => env('GOOGLE_REDIRECT_URL'),
     ],
 
+    // Meta (Facebook) WhatsApp Cloud API
+    'meta' => [
+        // API version, e.g. v20.0
+        'api_version' => env('META_API_VERSION', 'v20.0'),
+        // Optional default Business Account ID (WABA) if not taken from DB settings
+        'business_account_id' => env('META_BUSINESS_ACCOUNT_ID'),
+    ],
+
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -640,28 +640,30 @@ Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
         Route::delete('cards/{id}', [CrmCardController::class, 'destroy']);
     });
 
-        // Marketing Channels Routes
-        Route::prefix('marketing')->group(function () {
-            Route::get('channels', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'index']);
-            Route::post('channels', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'store']);
-            Route::get('channels/types', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getChannelTypes']);
-            // i want to return for each channel calc how much credits used and how much messages sent all channels return it as object
-            Route::get('channels/usage', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getUsage']);
-            Route::get('channels/{id}', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'show']);
-            Route::put('channels/{id}', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'update']);
-            Route::patch('channels/{id}/status', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'updateStatus']);
-            Route::get('channels/{id}/statistics', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'statistics']);
-            Route::get('channels/{id}/stats', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'stats']);
-            Route::post('channels/{id}/sync-verified', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'syncVerified']);
-            Route::post('channels/{id}/send-message', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'sendMessage']);
-            Route::delete('channels/{id}', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'destroy']);
+    // Marketing Channels Routes
+    Route::prefix('marketing')->group(function () {
+        Route::get('channels', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'index']);
+        Route::post('channels', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'store']);
+        Route::get('channels/types', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getChannelTypes']);
+        // i want to return for each channel calc how much credits used and how much messages sent all channels return it as object
+        Route::get('channels/usage', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getUsage']);
+        Route::get('channels/{id}', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'show']);
+        Route::put('channels/{id}', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'update']);
+        Route::patch('channels/{id}/status', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'updateStatus']);
+        Route::get('channels/{id}/statistics', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'statistics']);
+        Route::get('channels/{id}/stats', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'stats']);
+        Route::post('channels/{id}/sync-verified', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'syncVerified']);
+        Route::post('channels/{id}/send-message', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'sendMessage']);
+        Route::post('channels/send-whatsapp-to-customer', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'sendWhatsAppToCustomer']);
+        Route::delete('channels/{id}', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'destroy']);
 
-            // Marketing Settings Routes
-            Route::get('settings', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getAllMarketingSettings']);
-            Route::get('channels/{id}/settings', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getMarketingSettings']);
-            Route::put('channels/{id}/settings', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'updateMarketingSettings']);
-            Route::patch('channels/{id}/system-integrations', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'updateSystemIntegrationSettings']);
-        });
+        // Marketing Settings Routes
+        Route::get('settings', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getAllMarketingSettings']);
+        Route::get('channels/{id}/settings', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'getMarketingSettings']);
+        Route::put('channels/{id}/settings', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'updateMarketingSettings']);
+        Route::patch('channels/{id}/system-integrations', [\App\Http\Controllers\Api\markting\MarketingChannelController::class, 'updateSystemIntegrationSettings']);
+
+    });
 
     // Marketing Webhooks Routes (no auth required for webhooks)
     Route::prefix('marketing/webhooks')->group(function () {


### PR DESCRIPTION
- Introduced a new console command `TestWhatsAppMessage` to facilitate testing WhatsApp messaging for specific users, including credit checks and message sending via the Meta API.
- Updated the `Kernel` class to register the new command, enhancing the console's functionality for WhatsApp integration.
- Added a new route in `MarketingChannelController` for sending WhatsApp messages to customers, improving the API's capabilities for customer communication.
- Updated the `WhatsAppService` to support dynamic template messaging and improved error handling for API interactions.
- Enhanced the `services.php` configuration to include Meta API versioning, ensuring flexibility in API usage.