### PR TITLE
Enhance api_permissions migration to conditionally add description, n…

### DIFF
--- a/database/migrations/2025_10_07_162105_add_description_column_to_api_permissions_table.php
+++ b/database/migrations/2025_10_07_162105_add_description_column_to_api_permissions_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
     public function up()
     {
         Schema::table('api_permissions', function (Blueprint $table) {
-            $table->text('description')->nullable()->after('guard_name');
+            if (!Schema::hasColumn('api_permissions', 'description')) {
+                $table->text('description')->nullable()->after('guard_name');
+            }
         });
     }
 

--- a/database/migrations/2025_10_07_171619_add_name_ar_and_name_en_to_api_permissions_table.php
+++ b/database/migrations/2025_10_07_171619_add_name_ar_and_name_en_to_api_permissions_table.php
@@ -14,8 +14,12 @@ return new class extends Migration
     public function up()
     {
         Schema::table('api_permissions', function (Blueprint $table) {
-            $table->string('name_ar')->nullable()->after('name')->comment('Arabic display name');
-            $table->string('name_en')->nullable()->after('name_ar')->comment('English display name');
+            if (!Schema::hasColumn('api_permissions', 'name_ar')) {
+                $table->string('name_ar')->nullable()->after('name')->comment('Arabic display name');
+            }
+            if (!Schema::hasColumn('api_permissions', 'name_en')) {
+                $table->string('name_en')->nullable()->after('name_ar')->comment('English display name');
+            }
         });
     }
 


### PR DESCRIPTION
…ame_ar, and name_en columns

- Updated migrations for the api_permissions table to check for existing columns before adding 'description', 'name_ar', and 'name_en'.
- This change prevents errors during migration if the columns already exist, ensuring smoother database updates.