### PR TITLE
Enhance project and location management with new features and improvements

### DIFF
--- a/Modules/WhatsappAI/Http/Controllers/WebhookController.php
+++ b/Modules/WhatsappAI/Http/Controllers/WebhookController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Log;
+use App\Domain\Communication\WhatsApp\Services\SyncWhatsappAiConversationToCommunicationService;
 use Modules\WhatsappAI\Jobs\ForwardWebhook;
 use App\Models\WhatsappUser;
 use Modules\WhatsappAI\Entities\WhatsappConversation;
@@ -15,6 +16,9 @@ use Modules\WhatsappAI\Jobs\TranscribeAudio;
 
 class WebhookController extends Controller
 {
+    public function __construct(
+        private readonly SyncWhatsappAiConversationToCommunicationService $communicationSyncService,
+    ) {}
     /**
      * Handle incoming WhatsApp webhook
      * This is a PASSIVE collector - no auto-reply
@@ -35,101 +39,45 @@ class WebhookController extends Controller
                 return $this->verifyWebhook($request);
             }
 
-            // Extract Meta webhook data
-            $entry = $request->input('entry.0.changes.0.value');
-
-            if (!$entry || empty($entry['messages'])) {
+            $entries = $request->input('entry', []);
+            if (! is_array($entries) || $entries === []) {
                 return response()->json(['status' => 'ok', 'message' => 'No messages in payload']);
             }
 
-            $phoneNumberId = $entry['metadata']['phone_number_id'] ?? null;
-            $displayPhoneNumber = $entry['metadata']['display_phone_number'] ?? null;
-            $wabaId = $request->input('entry.0.id');
-            $message = $entry['messages'][0] ?? null;
-            $customerPhone = $message['from'] ?? null;
+            $processed = 0;
+            $storedConversationId = null;
+            $storedMessageCount = null;
 
-            if (!$phoneNumberId || !$message || !$customerPhone) {
-                return response()->json(['status' => 'ignored', 'message' => 'Missing required fields'], 400);
+            foreach ($entries as $webhookEntry) {
+                $changes = $webhookEntry['changes'] ?? [];
+                if (! is_array($changes)) {
+                    continue;
+                }
+
+                foreach ($changes as $change) {
+                    $entry = $change['value'] ?? null;
+                    if (! is_array($entry) || empty($entry['messages']) || ! is_array($entry['messages'])) {
+                        continue;
+                    }
+
+                    foreach ($entry['messages'] as $message) {
+                        if (! is_array($message)) {
+                            continue;
+                        }
+
+                        $result = $this->storeIncomingMessage($entry, $message, $webhookEntry['id'] ?? null);
+                        if ($result !== null) {
+                            $processed++;
+                            $storedConversationId = $result['conversation_id'];
+                            $storedMessageCount = $result['message_count'];
+                        }
+                    }
+                }
             }
 
-            // Find WhatsApp user by phone_number_id
-            $whatsappUser = WhatsappUser::where('phone_id', $phoneNumberId)
-                ->where('status', 'active')
-                ->first();
-
-            if (!$whatsappUser) {
-                $knownWhatsappUser = WhatsappUser::where('phone_id', $phoneNumberId)->first();
-
-                Log::warning('WhatsApp user not found', [
-                    'phone_id' => $phoneNumberId,
-                    'display_phone_number' => $displayPhoneNumber,
-                    'waba_id' => $wabaId,
-                    'customer_phone' => $customerPhone,
-                    'message_id' => $message['id'] ?? null,
-                    'message_type' => $message['type'] ?? null,
-                    'known_whatsapp_user_id' => $knownWhatsappUser?->id,
-                    'known_user_id' => $knownWhatsappUser?->user_id,
-                    'known_status' => $knownWhatsappUser?->status,
-                ]);
-
-                return response()->json(['status' => 'ignored', 'message' => 'WhatsApp user not found']);
+            if ($processed === 0) {
+                return response()->json(['status' => 'ok', 'message' => 'No messages in payload']);
             }
-
-            // Get or create conversation
-            $conversation = WhatsappConversation::firstOrCreate(
-                [
-                    'whatsapp_user_id' => $whatsappUser->id,
-                    'customer_phone' => $customerPhone,
-                ],
-                [
-                    'user_id' => $whatsappUser->user_id,
-                    'status' => 'collecting',
-                    'customer_name' => $entry['contacts'][0]['profile']['name'] ?? null,
-                ]
-            );
-
-            // Extract message content based on type
-            $incomingMessageType = $message['type'] ?? 'text';
-            $storedMessageType = $this->normalizeMessageTypeForStorage($incomingMessageType);
-            $content = $this->extractMessageContent($message, $incomingMessageType);
-
-            // Extract media URL based on message type
-            $mediaUrl = null;
-            if (in_array($incomingMessageType, ['image', 'document', 'audio', 'video']) && isset($message[$incomingMessageType]['url'])) {
-                $mediaUrl = $message[$incomingMessageType]['url'];
-            }
-
-            // Store the message
-            $storedMessage = WhatsappMessage::create([
-                'conversation_id' => $conversation->id,
-                'whatsapp_message_id' => $message['id'] ?? null,
-                // Ensure we only store values supported by the DB enum.
-                // The original WhatsApp type is preserved in raw_payload (and in content for unsupported types).
-                'message_type' => $storedMessageType,
-                'content' => $content,
-                'media_url' => $mediaUrl,
-                'raw_payload' => $message,
-            ]);
-
-            // Dispatch audio transcription immediately so the transcript is ready
-            // before ProcessConversation runs (which is delayed by session_timeout).
-            if ($storedMessageType === 'audio') {
-                TranscribeAudio::dispatch($storedMessage->id)
-                    ->onQueue(config('whatsappai.queue', 'default'));
-            }
-
-            // Update conversation
-            $conversation->increment('message_count');
-            $conversation->update([
-                'last_message_at' => now(),
-                'status' => 'collecting', // Reset to collecting if it was processed
-            ]);
-
-            // Dispatch delayed job to process conversation (5 minutes)
-            $delayMinutes = config('whatsappai.session_timeout', 5);
-            ProcessConversation::dispatch($conversation->id)
-                ->delay(now()->addMinutes($delayMinutes))
-                ->onQueue(config('whatsappai.queue', 'default'));
 
             // Log::info('Message stored and job scheduled', [
             //     'conversation_id' => $conversation->id,
@@ -139,8 +87,9 @@ class WebhookController extends Controller
 
             return response()->json([
                 'status' => 'stored',
-                'conversation_id' => $conversation->id,
-                'message_count' => $conversation->message_count,
+                'conversation_id' => $storedConversationId,
+                'message_count' => $storedMessageCount,
+                'processed' => $processed,
             ]);
 
         } catch (\Throwable $e) {
@@ -154,6 +103,136 @@ class WebhookController extends Controller
                 'message' => 'Internal server error',
             ], 500);
         }
+    }
+
+    /**
+     * @return array{conversation_id: int, message_count: int}|null
+     */
+    private function storeIncomingMessage(array $entry, array $message, mixed $wabaId): ?array
+    {
+        $phoneNumberId = $entry['metadata']['phone_number_id'] ?? null;
+        $displayPhoneNumber = $entry['metadata']['display_phone_number'] ?? null;
+        $customerPhone = $message['from'] ?? null;
+
+        if (!$phoneNumberId || !$customerPhone) {
+            Log::warning('WhatsApp AI webhook missing required fields', [
+                'phone_id' => $phoneNumberId,
+                'display_phone_number' => $displayPhoneNumber,
+                'waba_id' => $wabaId,
+                'customer_phone' => $customerPhone,
+                'message_id' => $message['id'] ?? null,
+                'message_type' => $message['type'] ?? null,
+            ]);
+
+            return null;
+        }
+
+        $whatsappUser = WhatsappUser::where('phone_id', $phoneNumberId)
+            ->where('status', 'active')
+            ->first();
+
+        if (!$whatsappUser) {
+            $knownWhatsappUser = WhatsappUser::where('phone_id', $phoneNumberId)->first();
+
+            Log::warning('WhatsApp user not found', [
+                'phone_id' => $phoneNumberId,
+                'display_phone_number' => $displayPhoneNumber,
+                'waba_id' => $wabaId,
+                'customer_phone' => $customerPhone,
+                'message_id' => $message['id'] ?? null,
+                'message_type' => $message['type'] ?? null,
+                'known_whatsapp_user_id' => $knownWhatsappUser?->id,
+                'known_user_id' => $knownWhatsappUser?->user_id,
+                'known_status' => $knownWhatsappUser?->status,
+            ]);
+
+            return null;
+        }
+
+        $conversation = WhatsappConversation::firstOrCreate(
+            [
+                'whatsapp_user_id' => $whatsappUser->id,
+                'customer_phone' => $customerPhone,
+            ],
+            [
+                'user_id' => $whatsappUser->user_id,
+                'status' => 'collecting',
+                'customer_name' => $entry['contacts'][0]['profile']['name'] ?? null,
+            ]
+        );
+
+        $incomingMessageType = $message['type'] ?? 'text';
+        $storedMessageType = $this->normalizeMessageTypeForStorage($incomingMessageType);
+        $content = $this->extractMessageContent($message, $incomingMessageType);
+
+        $mediaUrl = null;
+        if (in_array($incomingMessageType, ['image', 'document', 'audio', 'video'], true) && isset($message[$incomingMessageType]['url'])) {
+            $mediaUrl = $message[$incomingMessageType]['url'];
+        }
+
+        $providerMessageId = $message['id'] ?? null;
+        $messageWasNew = true;
+
+        if ($providerMessageId !== null && $providerMessageId !== '') {
+            $storedMessage = WhatsappMessage::firstOrCreate(
+                ['whatsapp_message_id' => (string) $providerMessageId],
+                [
+                    'conversation_id' => $conversation->id,
+                    'message_type' => $storedMessageType,
+                    'content' => $content,
+                    'media_url' => $mediaUrl,
+                    'raw_payload' => $message,
+                ]
+            );
+            $messageWasNew = $storedMessage->wasRecentlyCreated;
+        } else {
+            $storedMessage = WhatsappMessage::create([
+                'conversation_id' => $conversation->id,
+                'whatsapp_message_id' => null,
+                'message_type' => $storedMessageType,
+                'content' => $content,
+                'media_url' => $mediaUrl,
+                'raw_payload' => $message,
+            ]);
+        }
+
+        try {
+            $this->communicationSyncService->sync(
+                $conversation,
+                $storedMessage,
+                is_array($entry['metadata'] ?? null) ? $entry['metadata'] : null,
+                incrementUnread: $messageWasNew,
+            );
+        } catch (\Throwable $syncError) {
+            Log::error('whatsapp_ai.communication_sync.exception', [
+                'error' => $syncError->getMessage(),
+                'whatsapp_conversation_id' => $conversation->id,
+                'whatsapp_message_id' => $storedMessage->id,
+            ]);
+        }
+
+        if ($messageWasNew) {
+            if ($storedMessageType === 'audio') {
+                TranscribeAudio::dispatch($storedMessage->id)
+                    ->onQueue(config('whatsappai.queue', 'default'));
+            }
+
+            $conversation->increment('message_count');
+            $conversation->update([
+                'last_message_at' => now(),
+                'status' => 'collecting',
+            ]);
+
+            $delayMinutes = config('whatsappai.session_timeout', 5);
+            ProcessConversation::dispatch($conversation->id)
+                ->delay(now()->addMinutes($delayMinutes))
+                ->onQueue(config('whatsappai.queue', 'default'));
+        }
+
+        return [
+            'conversation_id' => (int) $conversation->id,
+            'message_count' => (int) $conversation->message_count,
+        ];
     }
 
     private function mirrorWebhookToForwardUrl(Request $request): void

--- a/app/Console/Commands/BackfillWhatsappAiToCommunication.php
+++ b/app/Console/Commands/BackfillWhatsappAiToCommunication.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Communication\WhatsApp\Services\SyncWhatsappAiConversationToCommunicationService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Modules\WhatsappAI\Entities\WhatsappConversation;
+
+class BackfillWhatsappAiToCommunication extends Command
+{
+    protected $signature = 'whatsapp:backfill-ai-to-communication
+                            {--user-id= : Limit backfill to one tenant user id}
+                            {--conversation-id= : Limit backfill to one WhatsappAI conversation id}
+                            {--since= : Only conversations updated on/after this date (Y-m-d)}
+                            {--chunk=100 : Chunk size for conversation iteration}
+                            {--dry-run : Count rows without writing}';
+
+    protected $description = 'Backfill WhatsappAI conversations/messages into Communication v1 inbox tables';
+
+    public function handle(SyncWhatsappAiConversationToCommunicationService $syncService): int
+    {
+        if (! Schema::hasTable('whatsapp_conversations') || ! Schema::hasTable('whatsapp_messages')) {
+            $this->error('whatsapp_conversations and whatsapp_messages tables are required.');
+
+            return self::FAILURE;
+        }
+
+        if (! Schema::hasTable('conversations') || ! Schema::hasTable('messages') || ! Schema::hasTable('wa_conversation_states')) {
+            $this->error('Communication v1 tables (conversations, messages, wa_conversation_states) are required.');
+
+            return self::FAILURE;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $chunk = max(1, (int) $this->option('chunk'));
+
+        $stats = [
+            'conversations_scanned' => 0,
+            'messages_scanned' => 0,
+            'messages_synced' => 0,
+            'messages_skipped_duplicate' => 0,
+            'messages_failed' => 0,
+            'unresolved_wa_number' => 0,
+        ];
+
+        $query = WhatsappConversation::query()->with(['messages' => function ($q) {
+            $q->orderBy('created_at')->orderBy('id');
+        }]);
+
+        if ($this->option('user-id') !== null) {
+            $query->where('user_id', (int) $this->option('user-id'));
+        }
+
+        if ($this->option('conversation-id') !== null) {
+            $query->where('id', (int) $this->option('conversation-id'));
+        }
+
+        if ($this->option('since') !== null) {
+            $since = Carbon::parse((string) $this->option('since'))->startOfDay();
+            $query->where('updated_at', '>=', $since);
+        }
+
+        $this->info($dryRun ? 'Dry run: no writes will be performed.' : 'Starting backfill...');
+
+        $query->orderBy('id')->chunkById($chunk, function ($conversations) use ($syncService, $dryRun, &$stats) {
+            foreach ($conversations as $conversation) {
+                $stats['conversations_scanned']++;
+
+                foreach ($conversation->messages as $message) {
+                    $stats['messages_scanned']++;
+
+                    if ($dryRun) {
+                        continue;
+                    }
+
+                    $beforeCount = \App\Models\Message::query()
+                        ->where('user_id', (int) $conversation->user_id)
+                        ->where('provider_message_id', $message->whatsapp_message_id)
+                        ->count();
+
+                    $result = $syncService->sync(
+                        $conversation,
+                        $message,
+                        webhookMetadata: null,
+                        incrementUnread: false,
+                    );
+
+                    if ($result === null) {
+                        $stats['messages_failed']++;
+                        continue;
+                    }
+
+                    if ($beforeCount > 0) {
+                        $stats['messages_skipped_duplicate']++;
+                    } else {
+                        $stats['messages_synced']++;
+                    }
+
+                    $meta = is_array($result->meta) ? $result->meta : [];
+                    if (($meta['wa_number_id'] ?? null) === null) {
+                        $stats['unresolved_wa_number']++;
+                    }
+                }
+            }
+        });
+
+        $this->table(
+            ['Metric', 'Count'],
+            collect($stats)->map(fn ($count, $key) => [$key, $count])->values()->all()
+        );
+
+        if ($dryRun) {
+            $this->warn('Dry run complete. Re-run without --dry-run to apply changes.');
+        } else {
+            $this->info('Backfill complete.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Communication/Contracts/CommunicationService.php
+++ b/app/Domain/Communication/Contracts/CommunicationService.php
@@ -4,6 +4,7 @@ namespace App\Domain\Communication\Contracts;
 
 use App\Domain\Communication\DTOs\SendMessageDto;
 use App\Models\Message;
+use DateTimeInterface;
 
 interface CommunicationService
 {
@@ -13,7 +14,9 @@ interface CommunicationService
         string $content,
         string $channel = 'whatsapp',
         ?string $providerMessageId = null,
-        array $meta = []
+        array $meta = [],
+        ?DateTimeInterface $createdAt = null,
+        bool $incrementUnread = true,
     ): ?Message;
 
     public function sendMessage(SendMessageDto $dto, string $idempotencyKey): Message;

--- a/app/Domain/Communication/Services/CommunicationServiceImpl.php
+++ b/app/Domain/Communication/Services/CommunicationServiceImpl.php
@@ -39,7 +39,9 @@ class CommunicationServiceImpl implements CommunicationService
         string $content,
         string $channel = 'whatsapp',
         ?string $providerMessageId = null,
-        array $meta = []
+        array $meta = [],
+        ?\DateTimeInterface $createdAt = null,
+        bool $incrementUnread = true,
     ): ?Message {
         try {
             if ($userId <= 0 || trim($externalPartyIdentifier) === '' || trim($content) === '') {
@@ -61,6 +63,7 @@ class CommunicationServiceImpl implements CommunicationService
 
             $channel = strtolower(trim($channel));
             $normalizedIdentifier = $this->normalizeExternalPartyIdentifier($externalPartyIdentifier);
+            $skipUnreadIncrement = ! $incrementUnread || ! empty($meta['skip_unread_increment']);
 
             if ($providerMessageId !== null && $providerMessageId !== '') {
                 $existing = Message::where('provider_message_id', $providerMessageId)
@@ -86,6 +89,8 @@ class CommunicationServiceImpl implements CommunicationService
                 $content,
                 $providerMessageId,
                 $meta,
+                $createdAt,
+                $skipUnreadIncrement,
                 &$message,
                 &$conversationNewlyCreated,
                 &$conversation
@@ -100,6 +105,8 @@ class CommunicationServiceImpl implements CommunicationService
                 );
                 $conversationNewlyCreated = $conversation->wasRecentlyCreated;
 
+                $messageAt = $createdAt !== null ? \Illuminate\Support\Carbon::parse($createdAt) : now();
+
                 $message = Message::create([
                     'conversation_id' => $conversation->id,
                     'user_id' => $userId,
@@ -108,9 +115,11 @@ class CommunicationServiceImpl implements CommunicationService
                     'status' => 'received',
                     'provider_message_id' => $providerMessageId,
                     'meta' => $meta,
+                    'created_at' => $messageAt,
+                    'updated_at' => $messageAt,
                 ]);
 
-                $conversation->update(['last_message_at' => now()]);
+                $conversation->update(['last_message_at' => $messageAt]);
 
                 // Always create/update WaConversationState for WhatsApp so the conversation appears in api/v1/whatsapp/conversations
                 $waNumberId = isset($meta['wa_number_id']) ? (int) $meta['wa_number_id'] : null;
@@ -175,10 +184,12 @@ class CommunicationServiceImpl implements CommunicationService
                     }
 
                     $preview = is_scalar($content) ? (string) $content : (string) json_encode($content ?? '');
-                    $state->increment('unread_count');
+                    if (! $skipUnreadIncrement) {
+                        $state->increment('unread_count');
+                    }
                     $state->update([
                         'last_message_preview' => \Illuminate\Support\Str::limit($preview, 500),
-                        'last_message_time' => now(),
+                        'last_message_time' => $messageAt,
                     ]);
                 }
 

--- a/app/Domain/Communication/WhatsApp/Services/SyncWhatsappAiConversationToCommunicationService.php
+++ b/app/Domain/Communication/WhatsApp/Services/SyncWhatsappAiConversationToCommunicationService.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace App\Domain\Communication\WhatsApp\Services;
+
+use App\Domain\Communication\Contracts\CommunicationService;
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\WaConversationState;
+use App\Models\WaNumber;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Modules\WhatsappAI\Entities\WhatsappConversation;
+use Modules\WhatsappAI\Entities\WhatsappMessage;
+
+class SyncWhatsappAiConversationToCommunicationService
+{
+    public function __construct(
+        private readonly CommunicationService $communicationService,
+        private readonly WhatsAppWebhookService $webhookService,
+    ) {}
+
+    /**
+     * Mirror a WhatsappAI conversation message into Communication v1 tables.
+     *
+     * @param  array<string, mixed>|null  $webhookMetadata  Meta webhook metadata (phone_number_id, display_phone_number)
+     */
+    public function sync(
+        WhatsappConversation $aiConversation,
+        WhatsappMessage $aiMessage,
+        ?array $webhookMetadata = null,
+        bool $incrementUnread = true,
+    ): ?Message {
+        $userId = (int) $aiConversation->user_id;
+        if ($userId <= 0) {
+            Log::warning('whatsapp_ai.communication_sync.skipped', [
+                'reason' => 'missing_user_id',
+                'whatsapp_conversation_id' => $aiConversation->id,
+                'whatsapp_message_id' => $aiMessage->id,
+            ]);
+
+            return null;
+        }
+
+        $externalParty = $this->normalizePhone((string) $aiConversation->customer_phone);
+        $content = $this->resolveContent($aiMessage);
+        $providerMessageId = $this->resolveProviderMessageId($aiMessage);
+
+        $waNumberId = $this->resolveWaNumberId($aiConversation, $webhookMetadata);
+
+        $meta = [
+            'source' => 'whatsapp_ai_webhook',
+            'whatsapp_ai_conversation_id' => (int) $aiConversation->id,
+            'whatsapp_ai_message_id' => (int) $aiMessage->id,
+            'whatsapp_message_type' => (string) $aiMessage->message_type,
+            'media_url' => $aiMessage->media_url,
+            'raw_payload' => $aiMessage->raw_payload,
+        ];
+        if ($waNumberId !== null) {
+            $meta['wa_number_id'] = $waNumberId;
+        }
+        if (! $incrementUnread) {
+            $meta['skip_unread_increment'] = true;
+        }
+
+        $existingBefore = null;
+        if ($providerMessageId !== null) {
+            $existingBefore = Message::query()
+                ->where('user_id', $userId)
+                ->where('provider_message_id', $providerMessageId)
+                ->first();
+        }
+
+        $message = $this->communicationService->recordInboundMessage(
+            $userId,
+            $externalParty,
+            $content,
+            'whatsapp',
+            $providerMessageId,
+            $meta,
+            $aiMessage->created_at ? Carbon::parse($aiMessage->created_at) : null,
+            $incrementUnread,
+        );
+
+        if ($message === null) {
+            Log::warning('whatsapp_ai.communication_sync.failed', [
+                'whatsapp_conversation_id' => $aiConversation->id,
+                'whatsapp_message_id' => $aiMessage->id,
+                'user_id' => $userId,
+            ]);
+
+            return null;
+        }
+
+        $wasNew = $existingBefore === null;
+
+        if ($wasNew && $aiMessage->created_at !== null) {
+            $this->applyHistoricalTimestamps($message, Carbon::parse($aiMessage->created_at));
+        }
+
+        Log::info('whatsapp_ai.communication_sync.completed', [
+            'whatsapp_conversation_id' => $aiConversation->id,
+            'whatsapp_message_id' => $aiMessage->id,
+            'communication_message_id' => $message->id,
+            'communication_conversation_id' => $message->conversation_id,
+            'was_new' => $wasNew,
+            'wa_number_id' => $waNumberId,
+        ]);
+
+        return $message->fresh();
+    }
+
+    private function resolveProviderMessageId(WhatsappMessage $aiMessage): string
+    {
+        if ($aiMessage->whatsapp_message_id !== null && trim((string) $aiMessage->whatsapp_message_id) !== '') {
+            return (string) $aiMessage->whatsapp_message_id;
+        }
+
+        return 'whatsapp_ai:'.$aiMessage->id;
+    }
+
+    private function resolveWaNumberId(WhatsappConversation $aiConversation, ?array $webhookMetadata): ?int
+    {
+        $userId = (int) $aiConversation->user_id;
+        if ($webhookMetadata === null || $webhookMetadata === []) {
+            return $this->resolveWaNumberIdFromWhatsappUser($aiConversation);
+        }
+
+        $tenant = $this->webhookService->resolveTenantFromPayload([
+            'metadata' => $webhookMetadata,
+            'phone_number_id' => $webhookMetadata['phone_number_id'] ?? null,
+            'display_phone_number' => $webhookMetadata['display_phone_number'] ?? null,
+        ], 'meta');
+
+        if ($tenant === null || (int) ($tenant['user_id'] ?? 0) !== $userId) {
+            return null;
+        }
+
+        $waNumberId = (int) ($tenant['wa_number_id'] ?? 0);
+
+        if ($waNumberId > 0) {
+            return $waNumberId;
+        }
+
+        return $this->resolveWaNumberIdFromWhatsappUser($aiConversation);
+    }
+
+    private function resolveWaNumberIdFromWhatsappUser(WhatsappConversation $aiConversation): ?int
+    {
+        $whatsappUser = $aiConversation->relationLoaded('whatsappUser')
+            ? $aiConversation->whatsappUser
+            : $aiConversation->whatsappUser()->first();
+
+        if (! $whatsappUser) {
+            return null;
+        }
+
+        $query = WaNumber::query()
+            ->where('user_id', (int) $aiConversation->user_id)
+            ->where('provider', 'meta');
+
+        if (! empty($whatsappUser->phone_id)) {
+            $waNumber = (clone $query)
+                ->where('phone_number_id', (string) $whatsappUser->phone_id)
+                ->first();
+            if ($waNumber) {
+                return (int) $waNumber->id;
+            }
+        }
+
+        if (! empty($whatsappUser->number)) {
+            $normalized = $this->normalizePhone((string) $whatsappUser->number);
+            $waNumber = (clone $query)
+                ->where('phone_number', $normalized)
+                ->first();
+            if ($waNumber) {
+                return (int) $waNumber->id;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveContent(WhatsappMessage $aiMessage): string
+    {
+        $content = is_string($aiMessage->content) ? trim($aiMessage->content) : '';
+        if ($content !== '') {
+            return $content;
+        }
+
+        return match ((string) $aiMessage->message_type) {
+            'image' => '[image]',
+            'audio' => '[audio]',
+            'video' => '[video]',
+            'document' => '[document]',
+            'location' => '[location]',
+            'contacts' => '[contacts]',
+            'reaction' => '[reaction]',
+            'edit' => '[edit]',
+            default => '[message]',
+        };
+    }
+
+    private function normalizePhone(string $value): string
+    {
+        $value = trim($value);
+        $value = preg_replace('/[\s\-]+/', '', $value) ?? $value;
+        if (preg_match('/^\+?\d+$/', $value)) {
+            $value = ltrim($value, '+');
+            if (strlen($value) > 0 && $value[0] !== '0') {
+                $value = '+'.$value;
+            }
+        }
+
+        return $value;
+    }
+
+    private function applyHistoricalTimestamps(Message $message, Carbon $createdAt): void
+    {
+        $message->forceFill([
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ])->saveQuietly();
+
+        $conversation = Conversation::find($message->conversation_id);
+        if ($conversation !== null) {
+            $lastAt = $conversation->last_message_at;
+            if ($lastAt === null || $createdAt->greaterThan(Carbon::parse($lastAt))) {
+                $conversation->forceFill(['last_message_at' => $createdAt])->saveQuietly();
+            }
+        }
+
+        $state = WaConversationState::where('conversation_id', $message->conversation_id)->first();
+        if ($state !== null) {
+            $preview = is_scalar($message->content)
+                ? (string) $message->content
+                : (string) json_encode($message->content ?? '');
+            $lastTime = $state->last_message_time;
+            if ($lastTime === null || $createdAt->greaterThan(Carbon::parse($lastTime))) {
+                $state->forceFill([
+                    'last_message_preview' => Str::limit($preview, 500),
+                    'last_message_time' => $createdAt,
+                ])->saveQuietly();
+            }
+        }
+    }
+}

--- a/app/Domain/Communication/WhatsApp/Services/WhatsAppConversationService.php
+++ b/app/Domain/Communication/WhatsApp/Services/WhatsAppConversationService.php
@@ -12,7 +12,8 @@ class WhatsAppConversationService
     {
         $query = WaConversationState::query()
             ->with(['conversation', 'waNumber'])
-            ->where('user_id', $userId);
+            ->where('user_id', $userId)
+            ->whereHas('conversation', fn ($q) => $q->where('channel', 'whatsapp'));
 
         if (isset($filters['status']) && $filters['status'] !== null && $filters['status'] !== '') {
             $query->where('status', (string) $filters['status']);
@@ -27,7 +28,17 @@ class WhatsAppConversationService
             });
         }
 
+        $allowedSortColumns = [
+            'last_message_time',
+            'unread_count',
+            'status',
+            'created_at',
+            'updated_at',
+        ];
         $sortBy = $filters['sort_by'] ?? 'last_message_time';
+        if (! in_array($sortBy, $allowedSortColumns, true)) {
+            $sortBy = 'last_message_time';
+        }
         $sortDir = strtolower($filters['sort_dir'] ?? 'desc') === 'asc' ? 'asc' : 'desc';
         $query->orderBy($sortBy, $sortDir);
 
@@ -40,6 +51,7 @@ class WhatsAppConversationService
             ->with(['conversation', 'waNumber'])
             ->where('user_id', $userId)
             ->where('conversation_id', $conversationId)
+            ->whereHas('conversation', fn ($q) => $q->where('channel', 'whatsapp'))
             ->first();
     }
 

--- a/app/Http/Controllers/Admin/LocationManagementController.php
+++ b/app/Http/Controllers/Admin/LocationManagementController.php
@@ -22,13 +22,26 @@ class LocationManagementController extends Controller
         $perPage = 25;
         $cityPage = max(1, (int) $request->query('city_page', 1));
 
-        $totalCities = (int) DB::table('user_districts')
-            ->whereNotNull('city_id')
+        $cityGroupsQuery = DB::table('user_districts')->whereNotNull('city_id');
+
+        if ($request->filled('city_search')) {
+            $term = $request->query('city_search');
+            $cityGroupsQuery->where(function ($q) use ($term) {
+                $q->where('city_name_ar', 'like', '%' . $term . '%')
+                    ->orWhere('city_name_en', 'like', '%' . $term . '%')
+                    ->orWhere('country_name_ar', 'like', '%' . $term . '%')
+                    ->orWhere('country_name_en', 'like', '%' . $term . '%');
+                if (ctype_digit((string) $term)) {
+                    $q->orWhere('city_id', (int) $term);
+                }
+            });
+        }
+
+        $totalCities = (int) (clone $cityGroupsQuery)
             ->selectRaw('COUNT(DISTINCT city_id) as aggregate')
             ->value('aggregate');
 
-        $cityGroups = DB::table('user_districts')
-            ->whereNotNull('city_id')
+        $cityGroups = (clone $cityGroupsQuery)
             ->selectRaw('
                 city_id,
                 MAX(city_name_ar) as city_name_ar,

--- a/app/Http/Controllers/Api/V1/WhatsApp/MessageController.php
+++ b/app/Http/Controllers/Api/V1/WhatsApp/MessageController.php
@@ -33,7 +33,10 @@ class MessageController extends BaseApiController
     {
         $tenantOwnerId = (int) auth()->user()->tenantOwnerId();
 
-        $conversation = Conversation::where('user_id', $tenantOwnerId)->find($id);
+        $conversation = Conversation::query()
+            ->where('user_id', $tenantOwnerId)
+            ->where('channel', 'whatsapp')
+            ->find($id);
         if (! $conversation) {
             return response()->json(['status' => 'error', 'code' => 'WA_CONVERSATION_NOT_FOUND', 'message' => 'Conversation not found.'], 404);
         }

--- a/app/Http/Controllers/Api/project/ProjectController.php
+++ b/app/Http/Controllers/Api/project/ProjectController.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Storage;
 use App\Http\Requests\Api\Project\StoreProjectRequest;
 use App\Http\Requests\Api\Project\UpdateProjectRequest;
 use App\Models\User\RealestateManagement\Amenity;
+use App\Http\Resources\Api\ProjectPropertyResource;
 use App\Models\User\RealestateManagement\Project;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\ProjectType;
@@ -578,42 +579,7 @@ class ProjectController extends Controller
      */
     private function formatProperty($property): array
     {
-        $content = $property->contents->first();
-
-        return [
-            'id' => $property->id,
-            'project_id' => $property->project_id,
-            'title' => optional($content)->title ?? '',
-            'slug' => optional($content)->slug ?? '',
-            'address' => optional($content)->address ?? '',
-            'description' => optional($content)->description ?? '',
-            'price' => $property->price,
-            'pricePerMeter' => $property->pricePerMeter,
-            'purpose' => $property->purpose,
-            'property_type' => $property->property_type,
-            'beds' => $property->beds,
-            'bath' => $property->bath,
-            'area' => $property->area,
-            'size' => $property->size,
-            'featured_image' => $property->featured_image ? asset($property->featured_image) : null,
-            'gallery' => $property->galleryImages->map(fn($img) => asset($img->image))->toArray(),
-            'location' => [
-                'latitude' => $property->latitude,
-                'longitude' => $property->longitude,
-            ],
-            'status' => (bool) $property->status,
-            'featured' => (bool) $property->featured,
-            'show_reservations' => (bool) $property->show_reservations,
-            'property_status' => $property->property_status,
-            'features' => $property->features ?? [],
-            'faqs' => $property->faqs ?? [],
-            'category_id' => $property->category_id,
-            'payment_method' => $property->payment_method,
-            'video_url' => $property->video_url ? asset($property->video_url) : null,
-            'virtual_tour' => $property->virtual_tour ? asset($property->virtual_tour) : null,
-            'created_at' => $property->created_at?->toISOString(),
-            'updated_at' => $property->updated_at?->toISOString(),
-        ];
+        return (new ProjectPropertyResource($property))->resolve();
     }
 
 

--- a/app/Http/Controllers/Api/project/ProjectPropertyController.php
+++ b/app/Http/Controllers/Api/project/ProjectPropertyController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Http\Controllers\Api\project;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Project\Properties\AttachProjectPropertiesRequest;
+use App\Http\Requests\Api\Project\Properties\StoreProjectPropertyRequest;
+use App\Http\Requests\Api\Project\Properties\UpdateProjectPropertyRequest;
+use App\Http\Resources\Api\ProjectPropertyResource;
+use App\Models\User;
+use App\Services\Project\ProjectPropertyService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ProjectPropertyController extends Controller
+{
+    public function __construct(
+        private readonly ProjectPropertyService $projectPropertyService,
+    ) {
+    }
+
+    public function index(Request $request, int $project): JsonResponse
+    {
+        try {
+            $owner = $this->resolveTenantOwner();
+            $perPage = max(1, min((int) $request->query('per_page', 25), 100));
+            $properties = $this->projectPropertyService->listForProject($owner->id, $project, $perPage);
+
+            return response()->json([
+                'status' => 'success',
+                'data' => [
+                    'properties' => ProjectPropertyResource::collection($properties->items()),
+                    'pagination' => [
+                        'current_page' => $properties->currentPage(),
+                        'per_page' => $properties->perPage(),
+                        'total' => $properties->total(),
+                        'last_page' => $properties->lastPage(),
+                    ],
+                ],
+            ]);
+        } catch (ModelNotFoundException $e) {
+            return $this->notFoundResponse($e->getMessage() ?: 'Project not found for this tenant.');
+        }
+    }
+
+    public function store(StoreProjectPropertyRequest $request, int $project): JsonResponse
+    {
+        try {
+            $user = auth()->user();
+            $owner = $this->resolveTenantOwner();
+            $property = $this->projectPropertyService->createForProject(
+                $owner->id,
+                $project,
+                $request->validated(),
+                $user->id,
+            );
+
+            return response()->json([
+                'status' => 'success',
+                'message' => 'Property created successfully',
+                'data' => [
+                    'property' => new ProjectPropertyResource($property),
+                ],
+            ], 201);
+        } catch (ModelNotFoundException $e) {
+            return $this->notFoundResponse($e->getMessage() ?: 'Project not found for this tenant.');
+        } catch (AccessDeniedHttpException $e) {
+            return response()->json([
+                'status' => 'fail',
+                'message' => $e->getMessage(),
+            ], 403);
+        } catch (HttpException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], $e->getStatusCode());
+        }
+    }
+
+    public function attach(AttachProjectPropertiesRequest $request, int $project): JsonResponse
+    {
+        try {
+            $owner = $this->resolveTenantOwner();
+            $properties = $this->projectPropertyService->attachMany(
+                $owner->id,
+                $project,
+                $request->validated('property_ids'),
+            );
+
+            return response()->json([
+                'status' => 'success',
+                'data' => [
+                    'properties' => ProjectPropertyResource::collection($properties),
+                ],
+            ]);
+        } catch (ModelNotFoundException $e) {
+            return $this->notFoundResponse($e->getMessage() ?: 'Project or property not found for this tenant.');
+        } catch (ConflictHttpException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 409);
+        }
+    }
+
+    public function update(UpdateProjectPropertyRequest $request, int $project, int $property): JsonResponse
+    {
+        try {
+            $owner = $this->resolveTenantOwner();
+            $updatedProperty = $this->projectPropertyService->updateForProject(
+                $owner->id,
+                $project,
+                $property,
+                $request->validated(),
+            );
+
+            return response()->json([
+                'status' => 'success',
+                'message' => 'Property updated successfully',
+                'data' => [
+                    'property' => new ProjectPropertyResource($updatedProperty),
+                ],
+            ]);
+        } catch (ModelNotFoundException $e) {
+            return $this->notFoundResponse($e->getMessage() ?: 'Project or property not found for this tenant.');
+        }
+    }
+
+    public function destroy(Request $request, int $project, int $property): JsonResponse
+    {
+        try {
+            $owner = $this->resolveTenantOwner();
+            $hardDelete = filter_var($request->query('hard_delete', false), FILTER_VALIDATE_BOOLEAN);
+
+            $this->projectPropertyService->detachFromProject(
+                $owner->id,
+                $project,
+                $property,
+                $hardDelete,
+            );
+
+            return response()->json([
+                'status' => 'success',
+                'data' => [
+                    'detached' => !$hardDelete,
+                    'deleted' => $hardDelete,
+                    'property_id' => $property,
+                ],
+            ]);
+        } catch (ModelNotFoundException $e) {
+            return $this->notFoundResponse($e->getMessage() ?: 'Project or property not found for this tenant.');
+        } catch (ConflictHttpException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 409);
+        }
+    }
+
+    private function resolveTenantOwner(): User
+    {
+        $user = auth()->user();
+
+        return method_exists($user, 'tenantOwner') ? $user->tenantOwner() : $user;
+    }
+
+    private function notFoundResponse(string $message): JsonResponse
+    {
+        return response()->json([
+            'status' => 'error',
+            'message' => $message,
+        ], 404);
+    }
+}

--- a/app/Http/Requests/Api/Project/Properties/AttachProjectPropertiesRequest.php
+++ b/app/Http/Requests/Api/Project/Properties/AttachProjectPropertiesRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Api\Project\Properties;
+
+use App\Http\Requests\Api\BaseApiFormRequest;
+
+class AttachProjectPropertiesRequest extends BaseApiFormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'property_ids' => 'required|array|min:1',
+            'property_ids.*' => 'required|integer|distinct|min:1',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/Project/Properties/Concerns/NormalizesProjectPropertyLocation.php
+++ b/app/Http/Requests/Api/Project/Properties/Concerns/NormalizesProjectPropertyLocation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Api\Project\Properties\Concerns;
+
+use Illuminate\Validation\Validator;
+
+trait NormalizesProjectPropertyLocation
+{
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('district_id') && !$this->filled('state_id')) {
+            $this->merge(['state_id' => $this->input('district_id')]);
+        }
+
+        if ($this->has('property_type')) {
+            $this->request->remove('property_type');
+        }
+
+        if ($this->has('project_id')) {
+            $this->request->remove('project_id');
+        }
+    }
+
+    protected function locationRules(bool $districtRequired = true): array
+    {
+        $districtRule = $districtRequired ? 'required' : 'sometimes';
+
+        return [
+            'district_id' => [$districtRule, 'required_without:state_id', 'integer', 'exists:user_districts,id'],
+            'state_id' => [$districtRule, 'required_without:district_id', 'integer', 'exists:user_districts,id'],
+            'city_id' => ['nullable', 'integer'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $districtId = $this->input('state_id') ?? $this->input('district_id');
+            if ($districtId === null || $districtId === '') {
+                return;
+            }
+
+            $district = \App\Models\User\UserDistrict::query()->find((int) $districtId);
+            if (!$district) {
+                return;
+            }
+
+            if ($this->filled('city_id') && (int) $this->input('city_id') !== (int) $district->city_id) {
+                $validator->errors()->add('city_id', 'The city_id must match the selected district city.');
+            }
+        });
+    }
+}

--- a/app/Http/Requests/Api/Project/Properties/StoreProjectPropertyRequest.php
+++ b/app/Http/Requests/Api/Project/Properties/StoreProjectPropertyRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Api\Project\Properties;
+
+use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Http\Requests\Api\Project\Properties\Concerns\NormalizesProjectPropertyLocation;
+
+class StoreProjectPropertyRequest extends BaseApiFormRequest
+{
+    use NormalizesProjectPropertyLocation;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return array_merge([
+            'title' => 'required|max:255',
+            'address' => 'required',
+            'description' => 'required',
+            'featured_image' => 'required|string',
+            'gallery' => 'nullable|array',
+            'gallery.*' => 'string',
+            'price' => 'nullable|numeric',
+            'pricePerMeter' => 'nullable|numeric',
+            'purpose' => 'nullable|in:sale,rent,sold,rented',
+            'area' => 'nullable|numeric',
+            'status' => 'nullable',
+            'latitude' => ['nullable', 'numeric', 'regex:/^[-]?((([0-8]?[0-9])\.(\d+))|(90(\.0+)?))$/'],
+            'longitude' => ['nullable', 'numeric', 'regex:/^[-]?((([1]?[0-7]?[0-9])\.(\d+))|([0-9]?[0-9])\.(\d+)|(180(\.0+)?))$/'],
+            'category_id' => 'nullable|integer',
+            'advertising_license' => 'nullable|string',
+            'featured' => 'nullable|boolean',
+            'property_type' => 'prohibited',
+            'project_id' => 'prohibited',
+        ], $this->locationRules(true));
+    }
+}

--- a/app/Http/Requests/Api/Project/Properties/StoreProjectPropertyRequest.php
+++ b/app/Http/Requests/Api/Project/Properties/StoreProjectPropertyRequest.php
@@ -18,7 +18,7 @@ class StoreProjectPropertyRequest extends BaseApiFormRequest
     {
         return array_merge([
             'title' => 'required|max:255',
-            'address' => 'required',
+            'address' => 'nullable|string|max:255',
             'description' => 'required',
             'featured_image' => 'required|string',
             'gallery' => 'nullable|array',

--- a/app/Http/Requests/Api/Project/Properties/UpdateProjectPropertyRequest.php
+++ b/app/Http/Requests/Api/Project/Properties/UpdateProjectPropertyRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Api\Project\Properties;
+
+use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Http\Requests\Api\Project\Properties\Concerns\NormalizesProjectPropertyLocation;
+
+class UpdateProjectPropertyRequest extends BaseApiFormRequest
+{
+    use NormalizesProjectPropertyLocation;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return array_merge([
+            'title' => 'sometimes|required|max:255',
+            'address' => 'sometimes|required',
+            'description' => 'sometimes|required',
+            'featured_image' => 'sometimes|required|string',
+            'gallery' => 'sometimes|nullable|array',
+            'gallery.*' => 'string',
+            'price' => 'sometimes|nullable|numeric',
+            'pricePerMeter' => 'sometimes|nullable|numeric',
+            'purpose' => 'sometimes|nullable|in:sale,rent,sold,rented',
+            'area' => 'sometimes|nullable|numeric',
+            'status' => 'sometimes|nullable',
+            'latitude' => ['sometimes', 'nullable', 'numeric', 'regex:/^[-]?((([0-8]?[0-9])\.(\d+))|(90(\.0+)?))$/'],
+            'longitude' => ['sometimes', 'nullable', 'numeric', 'regex:/^[-]?((([1]?[0-7]?[0-9])\.(\d+))|([0-9]?[0-9])\.(\d+)|(180(\.0+)?))$/'],
+            'category_id' => 'sometimes|nullable|integer',
+            'advertising_license' => 'sometimes|nullable|string',
+            'featured' => 'sometimes|nullable|boolean',
+            'property_type' => 'prohibited',
+            'project_id' => 'prohibited',
+        ], $this->locationRules(false));
+    }
+}

--- a/app/Http/Resources/Api/ProjectPropertyResource.php
+++ b/app/Http/Resources/Api/ProjectPropertyResource.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectPropertyResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $property = $this->resource;
+        $content = $property->contents->first();
+        $districtId = optional($content)->state_id;
+
+        return [
+            'id' => $property->id,
+            'project_id' => $property->project_id,
+            'title' => optional($content)->title ?? '',
+            'slug' => optional($content)->slug ?? '',
+            'address' => optional($content)->address ?? '',
+            'description' => optional($content)->description ?? '',
+            'price' => $property->price,
+            'pricePerMeter' => $property->pricePerMeter,
+            'purpose' => $property->purpose,
+            'property_type' => $property->property_type,
+            'beds' => $property->beds,
+            'bath' => $property->bath,
+            'area' => $property->area,
+            'size' => $property->size,
+            'featured_image' => $property->featured_image ? asset($property->featured_image) : null,
+            'gallery' => $property->relationLoaded('galleryImages')
+                ? $property->galleryImages->map(fn ($image) => asset($image->image))->toArray()
+                : [],
+            'location' => [
+                'latitude' => $property->latitude,
+                'longitude' => $property->longitude,
+            ],
+            'city_id' => optional($content)->city_id,
+            'state_id' => $districtId,
+            'district_id' => $districtId,
+            'status' => (bool) $property->status,
+            'featured' => (bool) $property->featured,
+            'show_reservations' => (bool) $property->show_reservations,
+            'property_status' => $property->property_status,
+            'features' => $property->features ?? [],
+            'faqs' => $property->faqs ?? [],
+            'category_id' => $property->category_id,
+            'payment_method' => $property->payment_method,
+            'video_url' => $property->video_url ? asset($property->video_url) : null,
+            'virtual_tour' => $property->virtual_tour ? asset($property->virtual_tour) : null,
+            'advertising_license' => $property->advertising_license,
+            'created_at' => $property->created_at?->toISOString(),
+            'updated_at' => $property->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Services/Project/ProjectPropertyService.php
+++ b/app/Services/Project/ProjectPropertyService.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Models\User\Language;
 use App\Models\User\RealestateManagement\ApiUserCategory;
 use App\Models\User\RealestateManagement\Project;
+use App\Models\User\RealestateManagement\ProjectContent;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
 use App\Models\User\RealestateManagement\PropertySliderImg;
@@ -44,6 +45,21 @@ class ProjectPropertyService
         $this->assertPropertyQuota($tenantOwnerId);
         $project = $this->resolveProjectForTenant($tenantOwnerId, $projectId);
         $defaultLanguage = $this->resolveDefaultLanguage($tenantOwnerId);
+        $projectContent = ProjectContent::query()
+            ->where('project_id', $project->id)
+            ->where('language_id', $defaultLanguage->id)
+            ->first();
+
+        $payload = $this->mergeInheritedProjectLocation($project, $projectContent, $payload);
+
+        $effectiveAddress = trim((string) ($payload['address'] ?? ''));
+        if ($effectiveAddress === '') {
+            throw new HttpException(422, 'Address is required when not provided by the project content.');
+        }
+        if (strlen($effectiveAddress) > 255) {
+            throw new HttpException(422, 'The address may not be greater than 255 characters.');
+        }
+
         $location = $this->normalizeLocation($payload);
 
         $property = null;
@@ -319,6 +335,39 @@ class ProjectPropertyService
         }
 
         return $language;
+    }
+
+    private function mergeInheritedProjectLocation(
+        Project $project,
+        ?ProjectContent $projectContent,
+        array $payload,
+    ): array {
+        $out = array_merge([], $payload);
+
+        $trimmedRequestAddress = array_key_exists('address', $out)
+            ? trim((string) $out['address'])
+            : '';
+        if ($trimmedRequestAddress !== '') {
+            $out['address'] = $trimmedRequestAddress;
+        } elseif ($projectContent && trim((string) ($projectContent->address ?? '')) !== '') {
+            $out['address'] = trim((string) $projectContent->address);
+        } else {
+            $out['address'] = $trimmedRequestAddress;
+        }
+
+        foreach (['latitude', 'longitude'] as $coord) {
+            $hasKey = array_key_exists($coord, $out);
+            $val = $hasKey ? $out[$coord] : null;
+            $missing = !$hasKey || $val === null || $val === '';
+            if ($missing) {
+                $inherited = $project->{$coord};
+                if ($inherited !== null && $inherited !== '') {
+                    $out[$coord] = $inherited;
+                }
+            }
+        }
+
+        return $out;
     }
 
     private function buildPropertyPayload(array $payload, int $projectId, bool $includeProjectId = true): array

--- a/app/Services/Project/ProjectPropertyService.php
+++ b/app/Services/Project/ProjectPropertyService.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace App\Services\Project;
+
+use App\Models\Membership;
+use App\Models\User;
+use App\Models\User\Language;
+use App\Models\User\RealestateManagement\ApiUserCategory;
+use App\Models\User\RealestateManagement\Project;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\PropertyContent;
+use App\Models\User\RealestateManagement\PropertySliderImg;
+use App\Models\User\UserDistrict;
+use App\Services\MembershipCacheService;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ProjectPropertyService
+{
+    public function listForProject(int $tenantOwnerId, int $projectId, int $perPage = 25): LengthAwarePaginator
+    {
+        $this->resolveProjectForTenant($tenantOwnerId, $projectId);
+
+        return Property::query()
+            ->where('project_id', $projectId)
+            ->whereIn('user_id', $this->allowedUserIds($tenantOwnerId))
+            ->with(['contents', 'galleryImages', 'category'])
+            ->orderByDesc('id')
+            ->paginate($perPage);
+    }
+
+    public function createForProject(
+        int $tenantOwnerId,
+        int $projectId,
+        array $payload,
+        ?int $actorUserId = null,
+    ): Property {
+        $this->assertPropertyQuota($tenantOwnerId);
+        $project = $this->resolveProjectForTenant($tenantOwnerId, $projectId);
+        $defaultLanguage = $this->resolveDefaultLanguage($tenantOwnerId);
+        $location = $this->normalizeLocation($payload);
+
+        $property = null;
+
+        DB::transaction(function () use (
+            $tenantOwnerId,
+            $project,
+            $projectId,
+            $payload,
+            $location,
+            $defaultLanguage,
+            $actorUserId,
+            &$property
+        ): void {
+            $propertyData = array_merge([
+                'price' => null,
+                'area' => null,
+                'status' => 0,
+                'latitude' => null,
+                'longitude' => null,
+            ], $this->buildPropertyPayload($payload, $projectId));
+            $featured = $payload['featured'] ?? false;
+            $floorPlanningImage = $payload['floor_planning_image'] ?? null;
+
+            $property = Property::storeProperty(
+                $tenantOwnerId,
+                $propertyData,
+                $payload['featured_image'],
+                $floorPlanningImage,
+                $payload['video_image'] ?? null,
+                $featured,
+                $actorUserId ?? auth()->id(),
+            );
+
+            if (!empty($payload['gallery']) && is_array($payload['gallery'])) {
+                foreach ($payload['gallery'] as $imagePath) {
+                    PropertySliderImg::storeSliderImage($tenantOwnerId, $property->id, $imagePath);
+                }
+            }
+
+            PropertyContent::storePropertyContent($tenantOwnerId, $property->id, [
+                'language_id' => $defaultLanguage->id,
+                'category_id' => $payload['category_id'] ?? ApiUserCategory::where('slug', 'other')->value('id'),
+                'state_id' => $location['state_id'],
+                'city_id' => $location['city_id'],
+                'title' => $payload['title'],
+                'slug' => str_replace('.', '', Str::slug($payload['title'])),
+                'address' => $payload['address'],
+                'description' => $payload['description'],
+                'meta_keyword' => $payload['meta_keyword'] ?? null,
+                'meta_description' => $payload['meta_description'] ?? null,
+            ]);
+        });
+
+        return $property->load(['contents', 'galleryImages', 'category']);
+    }
+
+    public function attachMany(int $tenantOwnerId, int $projectId, array $propertyIds): Collection
+    {
+        $this->resolveProjectForTenant($tenantOwnerId, $projectId);
+        $allowedUserIds = $this->allowedUserIds($tenantOwnerId);
+        $uniqueIds = array_values(array_unique(array_map('intval', $propertyIds)));
+
+        $properties = Property::query()
+            ->whereIn('id', $uniqueIds)
+            ->whereIn('user_id', $allowedUserIds)
+            ->get();
+
+        if ($properties->count() !== count($uniqueIds)) {
+            throw new ModelNotFoundException('One or more properties were not found for this tenant.');
+        }
+
+        foreach ($properties as $property) {
+            if ($property->project_id !== null && (int) $property->project_id !== $projectId) {
+                throw new ConflictHttpException('Property is already linked to another project.');
+            }
+        }
+
+        DB::transaction(function () use ($properties, $projectId): void {
+            foreach ($properties as $property) {
+                if ((int) $property->project_id !== $projectId) {
+                    $property->update(['project_id' => $projectId]);
+                }
+            }
+        });
+
+        return Property::query()
+            ->whereIn('id', $uniqueIds)
+            ->with(['contents', 'galleryImages', 'category'])
+            ->get();
+    }
+
+    public function updateForProject(
+        int $tenantOwnerId,
+        int $projectId,
+        int $propertyId,
+        array $payload,
+    ): Property {
+        $this->resolveProjectForTenant($tenantOwnerId, $projectId);
+        $property = $this->resolvePropertyForTenant($tenantOwnerId, $propertyId);
+        $this->assertPropertyOnProject($property, $projectId);
+
+        $defaultLanguage = $this->resolveDefaultLanguage($tenantOwnerId);
+        $location = $this->normalizeLocation($payload, false);
+
+        DB::transaction(function () use ($property, $payload, $location, $defaultLanguage, $tenantOwnerId): void {
+            $propertyData = $this->buildPropertyPayload($payload, (int) $property->project_id, false);
+            if ($propertyData !== []) {
+                $propertyData['project_id'] = $property->project_id;
+                $property->updateProperty($propertyData);
+            }
+
+            if (array_key_exists('gallery', $payload) && is_array($payload['gallery'])) {
+                PropertySliderImg::where('property_id', $property->id)->delete();
+                foreach ($payload['gallery'] as $imagePath) {
+                    PropertySliderImg::storeSliderImage($tenantOwnerId, $property->id, $imagePath);
+                }
+            }
+
+            $content = $property->contents()
+                ->where('language_id', $defaultLanguage->id)
+                ->first();
+
+            $contentPayload = $this->buildContentPayload($payload, $location, $defaultLanguage->id, $content);
+
+            if ($contentPayload !== []) {
+                if ($content) {
+                    $content->update($contentPayload);
+                } else {
+                    PropertyContent::storePropertyContent($tenantOwnerId, $property->id, array_merge([
+                        'category_id' => $property->category_id ?? ApiUserCategory::where('slug', 'other')->value('id'),
+                        'title' => $payload['title'] ?? 'Untitled',
+                        'slug' => str_replace('.', '', Str::slug($payload['title'] ?? 'untitled-' . $property->id)),
+                        'address' => $payload['address'] ?? '',
+                        'description' => $payload['description'] ?? '',
+                    ], $contentPayload));
+                }
+            }
+        });
+
+        return $property->fresh(['contents', 'galleryImages', 'category']);
+    }
+
+    public function detachFromProject(
+        int $tenantOwnerId,
+        int $projectId,
+        int $propertyId,
+        bool $hardDelete = false,
+    ): void {
+        $this->resolveProjectForTenant($tenantOwnerId, $projectId);
+        $property = $this->resolvePropertyForTenant($tenantOwnerId, $propertyId);
+        $this->assertPropertyOnProject($property, $projectId);
+
+        if ($hardDelete) {
+            if ($property->activeRentals()->exists()) {
+                throw new ConflictHttpException('Property cannot be deleted while active rentals exist.');
+            }
+
+            DB::transaction(function () use ($property): void {
+                $property->galleryImages()->delete();
+                $property->proertyAmenities()->delete();
+                $property->contents()->delete();
+                $property->wishlists()->delete();
+                $property->delete();
+            });
+
+            return;
+        }
+
+        $property->update(['project_id' => null]);
+    }
+
+    public function resolveProjectForTenant(int $tenantOwnerId, int $projectId): Project
+    {
+        $project = Project::query()
+            ->whereIn('user_id', $this->allowedUserIds($tenantOwnerId))
+            ->where('id', $projectId)
+            ->first();
+
+        if (!$project) {
+            throw new ModelNotFoundException('Project not found for this tenant.');
+        }
+
+        return $project;
+    }
+
+    public function resolvePropertyForTenant(int $tenantOwnerId, int $propertyId): Property
+    {
+        $property = Property::query()
+            ->whereIn('user_id', $this->allowedUserIds($tenantOwnerId))
+            ->where('id', $propertyId)
+            ->first();
+
+        if (!$property) {
+            throw new ModelNotFoundException('Property not found for this tenant.');
+        }
+
+        return $property;
+    }
+
+    public function assertPropertyOnProject(Property $property, int $projectId): void
+    {
+        if ((int) $property->project_id !== $projectId) {
+            throw new ModelNotFoundException('Property is not linked to this project.');
+        }
+    }
+
+    public function normalizeLocation(array $payload, bool $required = true): array
+    {
+        $districtId = $payload['state_id'] ?? $payload['district_id'] ?? null;
+
+        if ($districtId === null || $districtId === '') {
+            if ($required) {
+                throw new HttpException(422, 'A district_id or state_id is required.');
+            }
+
+            return [];
+        }
+
+        $district = UserDistrict::query()->findOrFail((int) $districtId);
+
+        return [
+            'state_id' => (int) $district->id,
+            'city_id' => isset($payload['city_id']) ? (int) $payload['city_id'] : (int) $district->city_id,
+        ];
+    }
+
+    public function assertPropertyQuota(int $tenantOwnerId): void
+    {
+        $membership = MembershipCacheService::getActiveMembership($tenantOwnerId);
+
+        if (!($membership instanceof Membership) || !$membership->package) {
+            throw new AccessDeniedHttpException('No active package found for the user.');
+        }
+
+        $realEstateLimit = $membership->package->real_estate_limit_number;
+        $currentPropertyCount = Property::query()
+            ->where('user_id', $tenantOwnerId)
+            ->where('completion_status', 'complete')
+            ->count();
+
+        if (!is_null($realEstateLimit) && $currentPropertyCount >= $realEstateLimit) {
+            throw new AccessDeniedHttpException('You have reached your property listing limit.');
+        }
+    }
+
+    private function allowedUserIds(int $tenantOwnerId): array
+    {
+        $allowedUserIds = [$tenantOwnerId];
+
+        try {
+            $employeeIds = User::query()
+                ->where('tenant_id', $tenantOwnerId)
+                ->pluck('id')
+                ->all();
+            $allowedUserIds = array_values(array_unique(array_merge($allowedUserIds, $employeeIds)));
+        } catch (\Throwable $e) {
+            // Fall back to tenant owner only.
+        }
+
+        return $allowedUserIds;
+    }
+
+    private function resolveDefaultLanguage(int $tenantOwnerId): Language
+    {
+        $language = Language::query()
+            ->where('user_id', $tenantOwnerId)
+            ->where('is_default', 1)
+            ->first();
+
+        if (!$language) {
+            throw new ModelNotFoundException('Default language not configured for this tenant.');
+        }
+
+        return $language;
+    }
+
+    private function buildPropertyPayload(array $payload, int $projectId, bool $includeProjectId = true): array
+    {
+        $fields = [
+            'price',
+            'pricePerMeter',
+            'purpose',
+            'area',
+            'status',
+            'latitude',
+            'longitude',
+            'category_id',
+            'advertising_license',
+            'featured',
+            'featured_image',
+            'payment_method',
+            'video_url',
+            'virtual_tour',
+            'building_id',
+            'beds',
+            'bath',
+            'size',
+        ];
+
+        $data = [];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $payload)) {
+                $data[$field] = $payload[$field];
+            }
+        }
+
+        if ($includeProjectId) {
+            $data['project_id'] = $projectId;
+        }
+
+        return $data;
+    }
+
+    private function buildContentPayload(array $payload, array $location, int $languageId, ?PropertyContent $content): array
+    {
+        $data = [];
+
+        foreach (['title', 'address', 'description', 'meta_keyword', 'meta_description'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $data[$field] = $payload[$field];
+            }
+        }
+
+        if (array_key_exists('title', $payload)) {
+            $data['slug'] = PropertyContent::generateUniqueSlug($payload['title'], $content?->property_id);
+        }
+
+        if ($location !== []) {
+            $data['state_id'] = $location['state_id'];
+            $data['city_id'] = $location['city_id'];
+        }
+
+        if (array_key_exists('category_id', $payload)) {
+            $data['category_id'] = $payload['category_id'];
+        }
+
+        if ($data === []) {
+            return [];
+        }
+
+        $data['language_id'] = $languageId;
+
+        return $data;
+    }
+}

--- a/resources/lang/ar/admin.php
+++ b/resources/lang/ar/admin.php
@@ -29,6 +29,7 @@ return [
     'all_cities' => 'كل المدن',
     'search' => 'بحث',
     'district_name' => 'اسم الحي',
+    'city_search_placeholder' => 'المدينة، الدولة (ع/EN)، أو معرف المدينة',
     'apply' => 'تطبيق',
     'reset' => 'إعادة ضبط',
 

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -29,6 +29,7 @@ return [
     'all_cities' => 'All cities',
     'search' => 'Search',
     'district_name' => 'District name',
+    'city_search_placeholder' => 'City, country (AR/EN), or city ID',
     'apply' => 'Apply',
     'reset' => 'Reset',
 

--- a/resources/views/admin/location-management/index.blade.php
+++ b/resources/views/admin/location-management/index.blade.php
@@ -43,10 +43,144 @@
   .main-panel .page-inner {
     direction: rtl !important;
   }
+
+  /* Buttons — black background, white text */
+  .location-management .btn.btn-primary,
+  .location-management-modal .btn.btn-primary,
+  .location-management .btn.btn-location-action,
+  .location-management-modal .btn.btn-location-action {
+    background-color: #000000 !important;
+    background-image: none !important;
+    border: 1px solid #000000 !important;
+    border-color: #000000 !important;
+    color: #ffffff !important;
+    box-shadow: none !important;
+  }
+
+  .location-management .btn.btn-primary:hover,
+  .location-management .btn.btn-primary:focus,
+  .location-management .btn.btn-primary:active,
+  .location-management-modal .btn.btn-primary:hover,
+  .location-management-modal .btn.btn-primary:focus,
+  .location-management-modal .btn.btn-primary:active,
+  .location-management .btn.btn-location-action:hover,
+  .location-management .btn.btn-location-action:focus,
+  .location-management .btn.btn-location-action:active,
+  .location-management-modal .btn.btn-location-action:hover,
+  .location-management-modal .btn.btn-location-action:focus,
+  .location-management-modal .btn.btn-location-action:active {
+    background-color: #1a1a1a !important;
+    background-image: none !important;
+    border-color: #1a1a1a !important;
+    color: #ffffff !important;
+  }
+
+  .location-management .btn.btn-secondary,
+  .location-management-modal .btn.btn-secondary,
+  .location-management a.btn.btn-secondary {
+    background-color: #000000 !important;
+    background-image: none !important;
+    border: 1px solid #000000 !important;
+    border-color: #000000 !important;
+    color: #ffffff !important;
+    box-shadow: none !important;
+  }
+
+  .location-management .btn.btn-secondary:hover,
+  .location-management .btn.btn-secondary:focus,
+  .location-management .btn.btn-secondary:active,
+  .location-management-modal .btn.btn-secondary:hover,
+  .location-management-modal .btn.btn-secondary:focus,
+  .location-management-modal .btn.btn-secondary:active,
+  .location-management a.btn.btn-secondary:hover,
+  .location-management a.btn.btn-secondary:focus {
+    background-color: #1a1a1a !important;
+    background-image: none !important;
+    border-color: #1a1a1a !important;
+    color: #ffffff !important;
+  }
+
+  /* Pagination */
+  .location-management .pagination .page-link {
+    color: #000000 !important;
+    border-color: var(--border-color) !important;
+    background: var(--bg-card) !important;
+  }
+
+  .location-management .pagination .page-item.active .page-link {
+    background-color: #000000 !important;
+    background-image: none !important;
+    border-color: #000000 !important;
+    color: #ffffff !important;
+  }
+
+  .location-management .pagination .page-link:hover {
+    background-color: #1a1a1a !important;
+    border-color: #1a1a1a !important;
+    color: #ffffff !important;
+  }
+
+  /* Status badges */
+  .location-management .badge-success {
+    background: var(--success-light) !important;
+    color: var(--success-color) !important;
+  }
+
+  .location-management .badge-warning {
+    background: rgba(245, 158, 11, 0.12) !important;
+    color: var(--warning-color) !important;
+  }
+
+  /* Tabs */
+  .location-management .nav-tabs .nav-link.active {
+    color: #000000 !important;
+    border-color: var(--border-color) var(--border-color) var(--bg-card) !important;
+  }
+
+  .location-management .nav-tabs .nav-link:hover {
+    color: #000000 !important;
+    border-color: var(--border-color) !important;
+  }
+
+  /* Modal header — space title and × apart (RTL-safe) */
+  .location-management-modal .modal-header {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    padding: 1.25rem 1.5rem !important;
+    gap: 1.5rem;
+  }
+
+  .location-management-modal .modal-header .modal-title {
+    flex: 1 1 auto;
+    margin: 0 !important;
+    padding: 0 !important;
+    line-height: 1.4;
+  }
+
+  [dir="rtl"] .location-management-modal .modal-header .modal-title {
+    text-align: right;
+  }
+
+  .location-management-modal .modal-header .close {
+    position: relative !important;
+    float: none !important;
+    margin: 0 !important;
+    padding: 0.25rem 0.5rem !important;
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+    line-height: 1;
+    opacity: 0.55;
+  }
+
+  .location-management-modal .modal-header .close:hover {
+    opacity: 0.85;
+  }
 </style>
 @endsection
 
 @section('content')
+<div class="location-management">
   <div class="page-header">
     <h4 class="page-title">{{ __('admin.location_management') }}</h4>
     <ul class="breadcrumbs">
@@ -85,7 +219,16 @@
         <div class="card-header pb-0">
           @php
             $hasDistrictQuery = request()->has('filter_city_id') || request()->has('district_search') || request()->has('page');
-            $activeTab = request('tab') === 'districts' || (!request()->has('tab') && $hasDistrictQuery) ? 'districts' : 'cities';
+            $hasCityQuery = request()->has('city_search') || request()->has('city_page');
+            if (request('tab') === 'districts') {
+              $activeTab = 'districts';
+            } elseif (request('tab') === 'cities' || $hasCityQuery) {
+              $activeTab = 'cities';
+            } elseif (!request()->has('tab') && $hasDistrictQuery) {
+              $activeTab = 'districts';
+            } else {
+              $activeTab = 'cities';
+            }
           @endphp
           <ul class="nav nav-tabs" id="locationTabs" role="tablist">
             <li class="nav-item">
@@ -110,6 +253,27 @@
                   <i class="fas fa-plus"></i> {{ __('admin.add_city') }}
                 </button>
               </div>
+
+              <form method="get" action="{{ route('admin.location.index') }}#cities-pane" id="cityFilterForm" class="form-row mb-3">
+                <input type="hidden" name="tab" id="city_tab_param" value="cities">
+                @if (request()->has('page'))
+                  <input type="hidden" name="page" value="{{ request('page') }}">
+                @endif
+                @if (request()->filled('filter_city_id'))
+                  <input type="hidden" name="filter_city_id" value="{{ request('filter_city_id') }}">
+                @endif
+                @if (request()->filled('district_search'))
+                  <input type="hidden" name="district_search" value="{{ request('district_search') }}">
+                @endif
+                <div class="col-md-8 mb-2">
+                  <label class="small d-block">{{ __('admin.search') }}</label>
+                  <input type="text" name="city_search" class="form-control" value="{{ request('city_search') }}" placeholder="{{ __('admin.city_search_placeholder') }}">
+                </div>
+                <div class="col-md-4 mb-2 d-flex align-items-end">
+                  <button type="submit" class="btn btn-primary mr-2">{{ __('admin.apply') }}</button>
+                  <a href="{{ route('admin.location.index', ['tab' => 'cities']) }}#cities-pane" class="btn btn-secondary">{{ __('admin.reset') }}</a>
+                </div>
+              </form>
 
               <div class="table-responsive">
                 <table class="table table-striped table-hover">
@@ -147,18 +311,18 @@
                           @endif
                         </td>
                         <td>
-                          <button type="button" class="btn btn-secondary btn-sm edit-city-btn"
-                            data-city_id="{{ $row->city_id }}"
-                            data-city_name_ar="{{ e($row->city_name_ar) }}"
-                            data-city_name_en="{{ e($row->city_name_en) }}"
-                            data-country_name_ar="{{ e($row->country_name_ar) }}"
-                            data-country_name_en="{{ e($row->country_name_en) }}"
+                          <button type="button" class="btn btn-location-action btn-sm edit-city-btn"
+                            data-city-id="{{ $row->city_id }}"
+                            data-city-name-ar="{{ e($row->city_name_ar) }}"
+                            data-city-name-en="{{ e($row->city_name_en) }}"
+                            data-country-name-ar="{{ e($row->country_name_ar) }}"
+                            data-country-name-en="{{ e($row->country_name_en) }}"
                             data-toggle="modal" data-target="#editCityModal">
                             <i class="fas fa-edit"></i> {{ __('admin.edit_city') }}
                           </button>
                           @if (!$row->in_user_cities)
-                            <button type="button" class="btn btn-success btn-sm sync-city-btn ml-1"
-                              data-city_id="{{ $row->city_id }}"
+                            <button type="button" class="btn btn-primary btn-sm sync-city-btn ml-1"
+                              data-city-id="{{ $row->city_id }}"
                               data-toggle="modal" data-target="#syncCityModal">
                               <i class="fas fa-link"></i> {{ __('admin.sync') }}
                             </button>
@@ -174,7 +338,7 @@
                 </table>
               </div>
               <div class="d-flex justify-content-center">
-                {{ $citiesPaginator->appends(array_merge(request()->query(), ['tab' => 'cities']))->links() }}
+                {{ $citiesPaginator->appends(array_merge(request()->query(), ['tab' => 'cities']))->fragment('cities-pane')->links() }}
               </div>
             </div>
 
@@ -230,10 +394,10 @@
                         </td>
                         <td>{{ $d->name_ar }}<br><small class="text-muted">{{ $d->name_en }}</small></td>
                         <td>
-                          <button type="button" class="btn btn-secondary btn-sm edit-district-btn"
-                            data-district_id="{{ $d->id }}"
-                            data-name_ar="{{ e($d->name_ar) }}"
-                            data-name_en="{{ e($d->name_en) }}"
+                          <button type="button" class="btn btn-location-action btn-sm edit-district-btn"
+                            data-district-id="{{ $d->id }}"
+                            data-name-ar="{{ e($d->name_ar) }}"
+                            data-name-en="{{ e($d->name_en) }}"
                             data-toggle="modal" data-target="#editDistrictModal">
                             <i class="fas fa-edit"></i> {{ __('admin.edit_district') }}
                           </button>
@@ -259,7 +423,10 @@
 
   @include('admin.location-management.partials.city-form')
   @include('admin.location-management.partials.district-form')
+</div>
+@endsection
 
+@section('scripts')
   <script>
     function rememberLocationTab(pane) {
       if (pane !== '#cities-pane' && pane !== '#districts-pane') return;
@@ -301,12 +468,12 @@
         localStorage.setItem(tabStorageKey, '#districts-pane');
       } else {
         var savedPane = localStorage.getItem(tabStorageKey);
-        if (savedPane && $('a[href=\"' + savedPane + '\"]').length) {
-          $('a[href=\"' + savedPane + '\"]').tab('show');
+        if (savedPane && $('a[href="' + savedPane + '"]').length) {
+          $('a[href="' + savedPane + '"]').tab('show');
         }
       }
 
-      $('a[data-toggle=\"tab\"]').on('shown.bs.tab', function (e) {
+      $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
         var pane = $(e.target).attr('href'); // #cities-pane | #districts-pane
         if (pane) {
           localStorage.setItem(tabStorageKey, pane);
@@ -319,27 +486,39 @@
         $('#district_tab_param').val('districts');
       });
 
+      $('#cityFilterForm').on('submit', function () {
+        $('#city_tab_param').val('cities');
+      });
+
       // Keep refresh pinned to the currently visible pane.
       rememberLocationTab($('#locationTabs .nav-link.active').attr('href'));
 
-      $('.edit-city-btn').on('click', function () {
-        var $btn = $(this);
-        $('#edit_city_id').val($btn.data('city_id'));
-        $('#edit_city_name_ar').val($btn.data('city_name_ar'));
-        $('#edit_city_name_en').val($btn.data('city_name_en'));
-        $('#edit_country_name_ar').val($btn.data('country_name_ar'));
-        $('#edit_country_name_en').val($btn.data('country_name_en'));
+      function fillEditCityModal($btn) {
+        var cityId = $btn.attr('data-city-id') || '';
+        $('#edit_city_id').val(cityId);
+        $('#edit_city_id_display').val(cityId);
+        $('#edit_city_name_ar').val($btn.attr('data-city-name-ar') || '');
+        $('#edit_city_name_en').val($btn.attr('data-city-name-en') || '');
+        $('#edit_country_name_ar').val($btn.attr('data-country-name-ar') || '');
+        $('#edit_country_name_en').val($btn.attr('data-country-name-en') || '');
+      }
+
+      function fillEditDistrictModal($btn) {
+        $('#edit_district_id').val($btn.attr('data-district-id') || '');
+        $('#edit_district_name_ar').val($btn.attr('data-name-ar') || '');
+        $('#edit_district_name_en').val($btn.attr('data-name-en') || '');
+      }
+
+      $(document).on('click', '.edit-city-btn', function () {
+        fillEditCityModal($(this));
       });
 
-      $('.sync-city-btn').on('click', function () {
-        $('#sync_city_id').val($(this).data('city_id'));
+      $(document).on('click', '.sync-city-btn', function () {
+        $('#sync_city_id').val($(this).attr('data-city-id') || '');
       });
 
-      $('.edit-district-btn').on('click', function () {
-        var $btn = $(this);
-        $('#edit_district_id').val($btn.data('district_id'));
-        $('#edit_district_name_ar').val($btn.data('name_ar'));
-        $('#edit_district_name_en').val($btn.data('name_en'));
+      $(document).on('click', '.edit-district-btn', function () {
+        fillEditDistrictModal($(this));
       });
 
       var ctx = @json(old('form_context'));

--- a/resources/views/admin/location-management/partials/city-form.blade.php
+++ b/resources/views/admin/location-management/partials/city-form.blade.php
@@ -1,5 +1,5 @@
 {{-- Add city + first district --}}
-<div class="modal fade" id="createCityModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade location-management-modal" id="createCityModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -79,7 +79,7 @@
 </div>
 
 {{-- Edit city group (all snapshot fields on user_districts) --}}
-<div class="modal fade" id="editCityModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade location-management-modal" id="editCityModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -93,6 +93,10 @@
         <input type="hidden" name="form_context" value="edit_city">
         <input type="hidden" name="city_id" id="edit_city_id" value="{{ old('city_id') }}">
         <div class="modal-body">
+          <div class="form-group">
+            <label>{{ __('admin.city_id') }}</label>
+            <input type="text" id="edit_city_id_display" class="form-control" value="{{ old('city_id') }}" readonly disabled>
+          </div>
           <div class="row">
             <div class="col-md-6">
               <div class="form-group">
@@ -136,7 +140,7 @@
 </div>
 
 {{-- Sync city to user_cities --}}
-<div class="modal fade" id="syncCityModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade location-management-modal" id="syncCityModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -194,7 +198,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ __('admin.close') }}</button>
-          <button type="submit" class="btn btn-success">{{ __('admin.sync') }}</button>
+          <button type="submit" class="btn btn-primary">{{ __('admin.sync') }}</button>
         </div>
       </form>
     </div>

--- a/resources/views/admin/location-management/partials/district-form.blade.php
+++ b/resources/views/admin/location-management/partials/district-form.blade.php
@@ -1,5 +1,5 @@
 {{-- Add district --}}
-<div class="modal fade" id="createDistrictModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade location-management-modal" id="createDistrictModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -45,7 +45,7 @@
 </div>
 
 {{-- Edit district (names only) --}}
-<div class="modal fade" id="editDistrictModal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade location-management-modal" id="editDistrictModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,6 +57,7 @@ use App\Http\Controllers\Api\{
     blog\MediaController as BlogMediaController,
     blog\CategoriesController,
     project\ProjectController,
+    project\ProjectPropertyController,
     property\PropertyController,
     content\FooterSettingController,
     content\ApiBannerSettingController,
@@ -345,6 +346,11 @@ Route::middleware('auth:sanctum')->group(function () {
 // --- Projects ---
 Route::middleware(['auth:sanctum', 'audit.ctx'])->group(function () {
     Route::get   ('/projects',            [ProjectController::class, 'index'])->middleware('can:projects.view');
+    Route::get   ('/projects/{project}/properties', [ProjectPropertyController::class, 'index'])->middleware('can:projects.view');
+    Route::post  ('/projects/{project}/properties', [ProjectPropertyController::class, 'store'])->middleware('can:properties.create');
+    Route::post  ('/projects/{project}/properties/attach', [ProjectPropertyController::class, 'attach'])->middleware('can:properties.update');
+    Route::patch ('/projects/{project}/properties/{property}', [ProjectPropertyController::class, 'update'])->middleware('can:properties.update');
+    Route::delete('/projects/{project}/properties/{property}', [ProjectPropertyController::class, 'destroy'])->middleware('can:properties.update');
     Route::get   ('/projects/{id}',       [ProjectController::class, 'show'])->middleware('can:projects.view');
     Route::post  ('/projects',            [ProjectController::class, 'store'])->middleware('can:projects.create');
     Route::post  ('/projects/{id}',       [ProjectController::class, 'update'])->middleware('can:projects.update');

--- a/tests/Feature/Api/ProjectPropertyTest.php
+++ b/tests/Feature/Api/ProjectPropertyTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Membership;
+use App\Models\Package;
+use App\Models\User;
+use App\Models\User\Language;
+use App\Models\User\RealestateManagement\ApiUserCategory;
+use App\Models\User\RealestateManagement\Project;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\PropertyContent;
+use App\Models\User\UserDistrict;
+use App\Services\MembershipCacheService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class ProjectPropertyTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach (['users', 'user_projects', 'user_properties', 'user_property_contents', 'user_districts', 'api_permissions', 'api_model_has_permissions', 'memberships', 'packages', 'user_languages'] as $table) {
+            if (!Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    private function grantPermissions(User $tenant, array $permissions): void
+    {
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->setPermissionsTeamId((int) $tenant->id);
+        $registrar->forgetCachedPermissions();
+
+        foreach ($permissions as $permissionName) {
+            try {
+                $permission = Permission::findByName($permissionName, 'sanctum');
+            } catch (\Throwable $e) {
+                $permission = Permission::create([
+                    'name' => $permissionName,
+                    'guard_name' => 'sanctum',
+                    'team_id' => $tenant->id,
+                ]);
+            }
+
+            $tenant->givePermissionTo($permission);
+        }
+
+        $registrar->forgetCachedPermissions();
+    }
+
+    private function seedTenantContext(User $tenant): void
+    {
+        $package = Package::firstOrCreate(
+            ['title' => 'Project Property Test Package'],
+            [
+                'slug' => 'project-property-test-package',
+                'price' => 0,
+                'term' => 'monthly',
+                'status' => 1,
+                'is_active' => 1,
+                'project_limit_number' => 100,
+                'real_estate_limit_number' => 100,
+                'serial_number' => 998,
+            ]
+        );
+
+        $membership = Membership::firstOrNew(['user_id' => $tenant->id]);
+        $membership->status = 1;
+        $membership->start_date = now()->subDay();
+        $membership->expire_date = now()->addMonth();
+        $membership->package_id = $package->id;
+        $membership->price = 0;
+        $membership->currency = 'USD';
+        $membership->currency_symbol = '$';
+        $membership->payment_method = 'test';
+        $membership->transaction_id = 'project-property-' . uniqid();
+        $membership->save();
+
+        MembershipCacheService::clearCache($tenant->id);
+
+        Language::firstOrCreate(
+            ['user_id' => $tenant->id, 'is_default' => 1],
+            [
+                'name' => 'Arabic',
+                'code' => 'ar',
+                'rtl' => 1,
+            ]
+        );
+
+        ApiUserCategory::firstOrCreate(
+            ['slug' => 'other'],
+            [
+                'name' => 'Other',
+                'type' => 'property',
+                'is_active' => 1,
+            ]
+        );
+    }
+
+    private function createDistrict(): UserDistrict
+    {
+        return UserDistrict::query()->create([
+            'name_ar' => 'حي الاختبار',
+            'name_en' => 'Test District',
+            'city_id' => 101,
+            'city_name_ar' => 'الرياض',
+            'city_name_en' => 'Riyadh',
+            'country_name_ar' => 'السعودية',
+            'country_name_en' => 'Saudi Arabia',
+        ]);
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
+    }
+
+    private function createProperty(User $tenant, ?int $projectId = null): Property
+    {
+        $property = Property::query()->create([
+            'user_id' => $tenant->id,
+            'project_id' => $projectId,
+            'featured_image' => 'properties/test.jpg',
+            'purpose' => 'sale',
+            'area' => 120,
+            'completion_status' => 'complete',
+            'status' => 1,
+        ]);
+
+        PropertyContent::query()->create([
+            'user_id' => $tenant->id,
+            'property_id' => $property->id,
+            'language_id' => Language::query()->where('user_id', $tenant->id)->where('is_default', 1)->value('id'),
+            'title' => 'Existing Unit',
+            'slug' => 'existing-unit-' . $property->id,
+            'address' => 'Existing Address',
+            'description' => 'Existing Description',
+        ]);
+
+        return $property;
+    }
+
+    public function test_create_property_under_project_sets_project_id_and_location(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit A',
+            'address' => 'Tower 1',
+            'description' => 'Project unit description',
+            'featured_image' => 'properties/unit-a.jpg',
+            'district_id' => $district->id,
+            'purpose' => 'sale',
+            'advertising_license' => 'LIC-123',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('status', 'success')
+            ->assertJsonPath('data.property.project_id', $project->id)
+            ->assertJsonPath('data.property.district_id', $district->id)
+            ->assertJsonPath('data.property.city_id', $district->city_id)
+            ->assertJsonPath('data.property.advertising_license', 'LIC-123');
+
+        $this->assertDatabaseHas('user_properties', [
+            'id' => $response->json('data.property.id'),
+            'project_id' => $project->id,
+            'advertising_license' => 'LIC-123',
+        ]);
+    }
+
+    public function test_create_rejects_city_id_mismatch_with_district(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit B',
+            'address' => 'Tower 2',
+            'description' => 'Another unit',
+            'featured_image' => 'properties/unit-b.jpg',
+            'district_id' => $district->id,
+            'city_id' => $district->city_id + 1,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 'error');
+    }
+
+    public function test_attach_existing_property_is_idempotent_and_blocks_other_project(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.update']);
+        Sanctum::actingAs($tenant);
+
+        $projectA = $this->createProject($tenant);
+        $projectB = $this->createProject($tenant);
+        $property = $this->createProperty($tenant, $projectB->id);
+
+        $this->postJson("/api/projects/{$projectA->id}/properties/attach", [
+            'property_ids' => [$property->id],
+        ])->assertStatus(409);
+
+        $property->update(['project_id' => null]);
+
+        $this->postJson("/api/projects/{$projectA->id}/properties/attach", [
+            'property_ids' => [$property->id],
+        ])->assertOk()
+            ->assertJsonPath('data.properties.0.project_id', $projectA->id);
+
+        $this->postJson("/api/projects/{$projectA->id}/properties/attach", [
+            'property_ids' => [$property->id],
+        ])->assertOk();
+    }
+
+    public function test_update_and_detach_project_property(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.update']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $district = $this->createDistrict();
+        $property = $this->createProperty($tenant, $project->id);
+
+        $this->patchJson("/api/projects/{$project->id}/properties/{$property->id}", [
+            'title' => 'Updated Unit',
+            'advertising_license' => 'LIC-999',
+            'district_id' => $district->id,
+        ])->assertOk()
+            ->assertJsonPath('data.property.title', 'Updated Unit')
+            ->assertJsonPath('data.property.advertising_license', 'LIC-999');
+
+        $this->deleteJson("/api/projects/{$project->id}/properties/{$property->id}")
+            ->assertOk()
+            ->assertJsonPath('data.detached', true);
+
+        $this->assertDatabaseHas('user_properties', [
+            'id' => $property->id,
+            'project_id' => null,
+        ]);
+    }
+
+    public function test_update_returns_not_found_when_property_not_on_project(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.update']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $otherProject = $this->createProject($tenant);
+        $property = $this->createProperty($tenant, $otherProject->id);
+
+        $this->patchJson("/api/projects/{$project->id}/properties/{$property->id}", [
+            'title' => 'Should Fail',
+        ])->assertNotFound();
+    }
+}

--- a/tests/Feature/Api/ProjectPropertyTest.php
+++ b/tests/Feature/Api/ProjectPropertyTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use App\Models\User\Language;
 use App\Models\User\RealestateManagement\ApiUserCategory;
 use App\Models\User\RealestateManagement\Project;
+use App\Models\User\RealestateManagement\ProjectContent;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
 use App\Models\User\UserDistrict;
@@ -27,7 +28,7 @@ class ProjectPropertyTest extends TestCase
 
     private function skipIfMissingSchema(): void
     {
-        foreach (['users', 'user_projects', 'user_properties', 'user_property_contents', 'user_districts', 'api_permissions', 'api_model_has_permissions', 'memberships', 'packages', 'user_languages'] as $table) {
+        foreach (['users', 'user_projects', 'user_project_contents', 'user_properties', 'user_property_contents', 'user_districts', 'api_permissions', 'api_model_has_permissions', 'memberships', 'packages', 'user_languages'] as $table) {
             if (!Schema::hasTable($table)) {
                 $this->markTestSkipped("Missing DB table: {$table}.");
             }
@@ -160,6 +161,23 @@ class ProjectPropertyTest extends TestCase
         return $property;
     }
 
+    private function seedDefaultLanguageProjectContent(User $tenant, Project $project, ?string $address): ProjectContent
+    {
+        $languageId = Language::query()
+            ->where('user_id', $tenant->id)
+            ->where('is_default', 1)
+            ->value('id');
+
+        return ProjectContent::query()->create([
+            'user_id' => $tenant->id,
+            'project_id' => $project->id,
+            'language_id' => $languageId,
+            'title' => 'Project marketing ' . $project->id,
+            'slug' => 'project-marketing-' . $project->id,
+            'address' => $address,
+        ]);
+    }
+
     public function test_create_property_under_project_sets_project_id_and_location(): void
     {
         $this->skipIfMissingSchema();
@@ -219,6 +237,174 @@ class ProjectPropertyTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonPath('status', 'error');
+    }
+
+    public function test_create_inherits_address_and_coordinates_from_project_when_omitted(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $project->update([
+            'latitude' => 24.7136,
+            'longitude' => 46.6753,
+        ]);
+        $this->seedDefaultLanguageProjectContent($tenant, $project, 'Inherited From Project Content');
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit Inherit',
+            'description' => 'Inherited coords and address',
+            'featured_image' => 'properties/unit-inherit.jpg',
+            'district_id' => $district->id,
+            'purpose' => 'sale',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.property.address', 'Inherited From Project Content');
+
+        $this->assertEqualsWithDelta(24.7136, (float) $response->json('data.property.location.latitude'), 0.00001);
+        $this->assertEqualsWithDelta(46.6753, (float) $response->json('data.property.location.longitude'), 0.00001);
+
+        $propertyId = (int) $response->json('data.property.id');
+        $this->assertDatabaseHas('user_properties', [
+            'id' => $propertyId,
+            'project_id' => $project->id,
+            'latitude' => 24.7136,
+            'longitude' => 46.6753,
+        ]);
+        $this->assertDatabaseHas('user_property_contents', [
+            'property_id' => $propertyId,
+            'address' => 'Inherited From Project Content',
+        ]);
+    }
+
+    public function test_create_overrides_inherited_address_and_coordinates(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $project->update([
+            'latitude' => 1.111,
+            'longitude' => 2.222,
+        ]);
+        $this->seedDefaultLanguageProjectContent($tenant, $project, 'Should Not Appear');
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit Override',
+            'address' => 'Request Address Line',
+            'description' => 'Override test',
+            'featured_image' => 'properties/unit-override.jpg',
+            'district_id' => $district->id,
+            'purpose' => 'sale',
+            'latitude' => 25.2048,
+            'longitude' => 55.2708,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.property.address', 'Request Address Line');
+
+        $this->assertEqualsWithDelta(25.2048, (float) $response->json('data.property.location.latitude'), 0.00001);
+        $this->assertEqualsWithDelta(55.2708, (float) $response->json('data.property.location.longitude'), 0.00001);
+
+        $propertyId = (int) $response->json('data.property.id');
+        $this->assertDatabaseHas('user_properties', [
+            'id' => $propertyId,
+            'latitude' => 25.2048,
+            'longitude' => 55.2708,
+        ]);
+        $this->assertDatabaseHas('user_property_contents', [
+            'property_id' => $propertyId,
+            'address' => 'Request Address Line',
+        ]);
+    }
+
+    public function test_create_returns_422_when_address_missing_after_merge(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $this->seedDefaultLanguageProjectContent($tenant, $project, '   ');
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit No Address',
+            'description' => 'No usable address',
+            'featured_image' => 'properties/unit-no-addr.jpg',
+            'district_id' => $district->id,
+            'purpose' => 'sale',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 'error')
+            ->assertJsonPath('message', 'Address is required when not provided by the project content.');
+    }
+
+    public function test_create_returns_422_when_address_missing_and_no_project_content_row(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit No Content',
+            'description' => 'No project content row',
+            'featured_image' => 'properties/unit-no-content.jpg',
+            'district_id' => $district->id,
+            'purpose' => 'sale',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('message', 'Address is required when not provided by the project content.');
+    }
+
+    public function test_create_rejects_address_longer_than_255_characters(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, ['projects.view', 'properties.create']);
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $district = $this->createDistrict();
+
+        $response = $this->postJson("/api/projects/{$project->id}/properties", [
+            'title' => 'Unit Long Address',
+            'address' => str_repeat('a', 256),
+            'description' => 'Too long',
+            'featured_image' => 'properties/unit-long.jpg',
+            'district_id' => $district->id,
+            'purpose' => 'sale',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 'error')
+            ->assertJsonPath('message', 'Validation failed');
+
+        $this->assertArrayHasKey('address', $response->json('errors'));
     }
 
     public function test_attach_existing_property_is_idempotent_and_blocks_other_project(): void

--- a/tests/Feature/WhatsappAI/BackfillWhatsappAiToCommunicationTest.php
+++ b/tests/Feature/WhatsappAI/BackfillWhatsappAiToCommunicationTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\WhatsappAI;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use App\Models\WaConversationState;
+use App\Models\WaNumber;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Modules\WhatsappAI\Entities\WhatsappConversation;
+use Modules\WhatsappAI\Entities\WhatsappMessage;
+use Tests\TestCase;
+
+class BackfillWhatsappAiToCommunicationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function requireTables(): void
+    {
+        foreach ([
+            'whatsapp_conversations',
+            'whatsapp_messages',
+            'whatsapp_users',
+            'conversations',
+            'messages',
+            'wa_conversation_states',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("{$table} table required.");
+            }
+        }
+    }
+
+    private function seedAiConversation(User $tenant, int $whatsappUserId): WhatsappConversation
+    {
+        $conversation = WhatsappConversation::create([
+            'user_id' => $tenant->id,
+            'whatsapp_user_id' => $whatsappUserId,
+            'customer_phone' => '966507' . random_int(1000000, 9999999),
+            'customer_name' => 'Backfill Customer',
+            'status' => 'processed',
+            'message_count' => 2,
+            'last_message_at' => now()->subHour(),
+        ]);
+
+        WhatsappMessage::create([
+            'conversation_id' => $conversation->id,
+            'whatsapp_message_id' => 'wamid.backfill.' . uniqid(),
+            'message_type' => 'text',
+            'content' => 'First backfill message',
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(10),
+        ]);
+
+        WhatsappMessage::create([
+            'conversation_id' => $conversation->id,
+            'whatsapp_message_id' => 'wamid.backfill.' . uniqid(),
+            'message_type' => 'text',
+            'content' => 'Second backfill message',
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        return $conversation;
+    }
+
+    /** @test */
+    public function backfill_command_syncs_existing_whatsapp_ai_messages(): void
+    {
+        $this->requireTables();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+        $whatsappUserId = (int) \DB::table('whatsapp_users')->insertGetId([
+            'user_id' => $tenant->id,
+            'phone_id' => 'phone_backfill_' . uniqid(),
+            'number' => '+966501234567',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $aiConversation = $this->seedAiConversation($tenant, $whatsappUserId);
+
+        $exitCode = Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+        ]);
+        $this->assertSame(0, $exitCode);
+
+        $conversation = Conversation::where('user_id', $tenant->id)
+            ->where('channel', 'whatsapp')
+            ->first();
+        $this->assertNotNull($conversation);
+
+        $this->assertGreaterThanOrEqual(2, Message::where('conversation_id', $conversation->id)->count());
+        $this->assertDatabaseHas('wa_conversation_states', [
+            'conversation_id' => $conversation->id,
+            'user_id' => $tenant->id,
+        ]);
+
+        $state = WaConversationState::where('conversation_id', $conversation->id)->first();
+        $this->assertNotNull($state);
+        $this->assertSame(0, (int) $state->unread_count);
+    }
+
+    /** @test */
+    public function backfill_dry_run_does_not_create_communication_rows(): void
+    {
+        $this->requireTables();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+        $whatsappUserId = (int) \DB::table('whatsapp_users')->insertGetId([
+            'user_id' => $tenant->id,
+            'phone_id' => 'phone_backfill_dry_' . uniqid(),
+            'number' => '+966501234567',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $aiConversation = $this->seedAiConversation($tenant, $whatsappUserId);
+
+        $before = Message::where('user_id', $tenant->id)->count();
+
+        Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame($before, Message::where('user_id', $tenant->id)->count());
+    }
+
+    /** @test */
+    public function backfill_is_repeatable_without_duplicating_messages(): void
+    {
+        $this->requireTables();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+        $whatsappUserId = (int) \DB::table('whatsapp_users')->insertGetId([
+            'user_id' => $tenant->id,
+            'phone_id' => 'phone_backfill_repeat_' . uniqid(),
+            'number' => '+966501234567',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $aiConversation = $this->seedAiConversation($tenant, $whatsappUserId);
+
+        Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+        ]);
+
+        $countAfterFirst = Message::where('user_id', $tenant->id)->count();
+
+        Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+        ]);
+
+        $this->assertSame($countAfterFirst, Message::where('user_id', $tenant->id)->count());
+    }
+
+    /** @test */
+    public function backfill_is_repeatable_for_whatsapp_ai_messages_without_provider_id(): void
+    {
+        $this->requireTables();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+        $whatsappUserId = (int) \DB::table('whatsapp_users')->insertGetId([
+            'user_id' => $tenant->id,
+            'phone_id' => 'phone_backfill_null_' . uniqid(),
+            'number' => '+966501234567',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $aiConversation = WhatsappConversation::create([
+            'user_id' => $tenant->id,
+            'whatsapp_user_id' => $whatsappUserId,
+            'customer_phone' => '966506' . random_int(1000000, 9999999),
+            'customer_name' => 'No Provider Customer',
+            'status' => 'processed',
+        ]);
+
+        $aiMessage = WhatsappMessage::create([
+            'conversation_id' => $aiConversation->id,
+            'whatsapp_message_id' => null,
+            'message_type' => 'text',
+            'content' => 'Message without provider id',
+        ]);
+
+        Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+        ]);
+        Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+        ]);
+
+        $this->assertSame(
+            1,
+            Message::where('user_id', $tenant->id)
+                ->where('provider_message_id', 'whatsapp_ai:' . $aiMessage->id)
+                ->count()
+        );
+    }
+
+    /** @test */
+    public function backfill_resolves_wa_number_from_whatsapp_user_phone_id(): void
+    {
+        $this->requireTables();
+
+        $tenant = User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+        $phoneId = 'phone_backfill_resolve_' . uniqid();
+        $whatsappUserId = (int) \DB::table('whatsapp_users')->insertGetId([
+            'user_id' => $tenant->id,
+            'phone_id' => $phoneId,
+            'number' => '+966501234567',
+            'status' => 'active',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $waNumber = WaNumber::create([
+            'user_id' => $tenant->id,
+            'provider' => 'meta',
+            'phone_number' => '+966501234567',
+            'phone_number_id' => $phoneId,
+            'name' => 'Main',
+            'status' => 'active',
+        ]);
+
+        $aiConversation = $this->seedAiConversation($tenant, $whatsappUserId);
+
+        Artisan::call('whatsapp:backfill-ai-to-communication', [
+            '--user-id' => $tenant->id,
+            '--conversation-id' => $aiConversation->id,
+        ]);
+
+        $conversation = Conversation::where('user_id', $tenant->id)
+            ->where('channel', 'whatsapp')
+            ->first();
+        $this->assertNotNull($conversation);
+
+        $this->assertDatabaseHas('wa_conversation_states', [
+            'conversation_id' => $conversation->id,
+            'user_id' => $tenant->id,
+            'wa_number_id' => $waNumber->id,
+        ]);
+    }
+}

--- a/tests/Feature/WhatsappAI/WhatsappAiWebhookCommunicationSyncTest.php
+++ b/tests/Feature/WhatsappAI/WhatsappAiWebhookCommunicationSyncTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\WhatsappAI;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use App\Models\WaConversationState;
+use App\Models\WaNumber;
+use App\Models\WhatsappUser;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Modules\WhatsappAI\Entities\WhatsappConversation;
+use Modules\WhatsappAI\Entities\WhatsappMessage;
+use Modules\WhatsappAI\Jobs\ProcessConversation;
+use Modules\WhatsappAI\Jobs\TranscribeAudio;
+use Tests\TestCase;
+
+class WhatsappAiWebhookCommunicationSyncTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function requireTables(): void
+    {
+        foreach ([
+            'whatsapp_conversations',
+            'whatsapp_messages',
+            'whatsapp_users',
+            'conversations',
+            'messages',
+            'wa_conversation_states',
+            'wa_numbers',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("{$table} table required.");
+            }
+        }
+    }
+
+    private function createTenant(): User
+    {
+        return User::factory()->create([
+            'account_type' => 'tenant',
+            'tenant_id' => null,
+            'rbac_version' => (int) config('rbac.version', 1),
+            'rbac_seeded_at' => now(),
+        ]);
+    }
+
+    private function createWhatsappUser(User $tenant, string $phoneId = 'phone_test_123'): WhatsappUser
+    {
+        return WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'phone_id' => $phoneId,
+            'number' => '+966501111111',
+            'status' => 'active',
+        ]);
+    }
+
+    private function webhookPayload(string $phoneId, string $customerPhone, string $messageId, string $body = 'Hello from test'): array
+    {
+        return [
+            'entry' => [
+                [
+                    'id' => 'waba_test',
+                    'changes' => [
+                        [
+                            'value' => [
+                                'metadata' => [
+                                    'phone_number_id' => $phoneId,
+                                    'display_phone_number' => '+966501111111',
+                                ],
+                                'contacts' => [
+                                    ['profile' => ['name' => 'Test Customer']],
+                                ],
+                                'messages' => [
+                                    [
+                                        'id' => $messageId,
+                                        'from' => $customerPhone,
+                                        'type' => 'text',
+                                        'text' => ['body' => $body],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function multiMessageWebhookPayload(string $phoneId, string $customerPhone, array $messages): array
+    {
+        return [
+            'entry' => [
+                [
+                    'id' => 'waba_test',
+                    'changes' => [
+                        [
+                            'value' => [
+                                'metadata' => [
+                                    'phone_number_id' => $phoneId,
+                                    'display_phone_number' => '+966501111111',
+                                ],
+                                'messages' => $messages,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /** @test */
+    public function whatsapp_ai_webhook_syncs_into_communication_v1_tables(): void
+    {
+        $this->requireTables();
+        Queue::fake();
+
+        $tenant = $this->createTenant();
+        $phoneId = 'phone_sync_' . uniqid();
+        $this->createWhatsappUser($tenant, $phoneId);
+
+        WaNumber::create([
+            'user_id' => $tenant->id,
+            'provider' => 'meta',
+            'phone_number' => '+966501111111',
+            'phone_number_id' => $phoneId,
+            'name' => 'Main',
+            'status' => 'active',
+        ]);
+
+        $customerPhone = '966509' . random_int(1000000, 9999999);
+        $messageId = 'wamid.sync.' . uniqid();
+
+        $response = $this->postJson('/api/whatsapp-ai/webhook', $this->webhookPayload($phoneId, $customerPhone, $messageId));
+        $response->assertOk()->assertJsonPath('status', 'stored');
+
+        $this->assertDatabaseHas('whatsapp_conversations', [
+            'user_id' => $tenant->id,
+            'customer_phone' => $customerPhone,
+        ]);
+
+        $aiConversation = WhatsappConversation::where('user_id', $tenant->id)
+            ->where('customer_phone', $customerPhone)
+            ->first();
+        $this->assertNotNull($aiConversation);
+
+        $this->assertDatabaseHas('whatsapp_messages', [
+            'conversation_id' => $aiConversation->id,
+            'whatsapp_message_id' => $messageId,
+        ]);
+
+        $conversation = Conversation::where('user_id', $tenant->id)
+            ->where('channel', 'whatsapp')
+            ->where('external_party_identifier', '+' . ltrim($customerPhone, '+'))
+            ->first();
+        $this->assertNotNull($conversation);
+
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'user_id' => $tenant->id,
+            'provider_message_id' => $messageId,
+            'direction' => 'inbound',
+        ]);
+
+        $this->assertDatabaseHas('wa_conversation_states', [
+            'conversation_id' => $conversation->id,
+            'user_id' => $tenant->id,
+        ]);
+
+        Sanctum::actingAs($tenant);
+        $list = $this->getJson('/api/v1/whatsapp/conversations');
+        $list->assertOk();
+        $this->assertGreaterThan(0, $list->json('data.pagination.total'));
+
+        $messages = $this->getJson('/api/v1/whatsapp/conversations/' . $conversation->id . '/messages');
+        $messages->assertOk();
+        $this->assertNotEmpty($messages->json('data.data.messages'));
+
+        Queue::assertPushed(ProcessConversation::class);
+        Queue::assertNotPushed(TranscribeAudio::class);
+    }
+
+    /** @test */
+    public function duplicate_webhook_does_not_duplicate_messages_or_increment_unread_twice(): void
+    {
+        $this->requireTables();
+        Queue::fake();
+
+        $tenant = $this->createTenant();
+        $phoneId = 'phone_dup_' . uniqid();
+        $this->createWhatsappUser($tenant, $phoneId);
+
+        $customerPhone = '966508' . random_int(1000000, 9999999);
+        $messageId = 'wamid.dup.' . uniqid();
+        $payload = $this->webhookPayload($phoneId, $customerPhone, $messageId);
+
+        $this->postJson('/api/whatsapp-ai/webhook', $payload)->assertOk();
+        $this->postJson('/api/whatsapp-ai/webhook', $payload)->assertOk();
+
+        $this->assertSame(1, WhatsappMessage::where('whatsapp_message_id', $messageId)->count());
+        $this->assertSame(1, Message::where('provider_message_id', $messageId)->where('user_id', $tenant->id)->count());
+
+        $conversation = Conversation::where('user_id', $tenant->id)
+            ->where('channel', 'whatsapp')
+            ->first();
+        $this->assertNotNull($conversation);
+
+        $state = WaConversationState::where('conversation_id', $conversation->id)->first();
+        $this->assertNotNull($state);
+        $this->assertSame(1, (int) $state->unread_count);
+
+        Queue::assertPushed(ProcessConversation::class, 1);
+    }
+
+    /** @test */
+    public function messages_endpoint_rejects_non_whatsapp_conversation_channel(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+        $otherTenant = $this->createTenant();
+
+        $emailConversation = Conversation::create([
+            'user_id' => $tenant->id,
+            'channel' => 'email',
+            'external_party_identifier' => 'user@example.com',
+            'last_message_at' => now(),
+        ]);
+
+        Sanctum::actingAs($tenant);
+        $this->getJson('/api/v1/whatsapp/conversations/' . $emailConversation->id . '/messages')
+            ->assertStatus(404);
+
+        $whatsappConversation = Conversation::create([
+            'user_id' => $otherTenant->id,
+            'channel' => 'whatsapp',
+            'external_party_identifier' => '+966509999999',
+            'last_message_at' => now(),
+        ]);
+
+        $this->getJson('/api/v1/whatsapp/conversations/' . $whatsappConversation->id . '/messages')
+            ->assertStatus(404);
+    }
+
+    /** @test */
+    public function webhook_processes_all_messages_in_payload(): void
+    {
+        $this->requireTables();
+        Queue::fake();
+
+        $tenant = $this->createTenant();
+        $phoneId = 'phone_multi_' . uniqid();
+        $this->createWhatsappUser($tenant, $phoneId);
+
+        $customerPhone = '966505' . random_int(1000000, 9999999);
+        $firstId = 'wamid.multi.first.' . uniqid();
+        $secondId = 'wamid.multi.second.' . uniqid();
+
+        $response = $this->postJson('/api/whatsapp-ai/webhook', $this->multiMessageWebhookPayload($phoneId, $customerPhone, [
+            [
+                'id' => $firstId,
+                'from' => $customerPhone,
+                'type' => 'text',
+                'text' => ['body' => 'First message'],
+            ],
+            [
+                'id' => $secondId,
+                'from' => $customerPhone,
+                'type' => 'text',
+                'text' => ['body' => 'Second message'],
+            ],
+        ]));
+
+        $response->assertOk()->assertJsonPath('processed', 2);
+
+        $this->assertSame(2, WhatsappMessage::whereIn('whatsapp_message_id', [$firstId, $secondId])->count());
+        $this->assertSame(2, Message::where('user_id', $tenant->id)
+            ->whereIn('provider_message_id', [$firstId, $secondId])
+            ->count());
+
+        Queue::assertPushed(ProcessConversation::class, 2);
+    }
+
+    /** @test */
+    public function conversation_list_excludes_states_for_non_whatsapp_conversations(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+
+        $whatsappConversation = Conversation::create([
+            'user_id' => $tenant->id,
+            'channel' => 'whatsapp',
+            'external_party_identifier' => '+966501111111',
+            'last_message_at' => now(),
+        ]);
+        WaConversationState::create([
+            'conversation_id' => $whatsappConversation->id,
+            'user_id' => $tenant->id,
+            'status' => 'active',
+            'is_starred' => false,
+            'unread_count' => 0,
+            'last_message_time' => now(),
+        ]);
+
+        $emailConversation = Conversation::create([
+            'user_id' => $tenant->id,
+            'channel' => 'email',
+            'external_party_identifier' => 'customer@example.com',
+            'last_message_at' => now(),
+        ]);
+        WaConversationState::create([
+            'conversation_id' => $emailConversation->id,
+            'user_id' => $tenant->id,
+            'status' => 'active',
+            'is_starred' => false,
+            'unread_count' => 0,
+            'last_message_time' => now()->addMinute(),
+        ]);
+
+        Sanctum::actingAs($tenant);
+        $response = $this->getJson('/api/v1/whatsapp/conversations');
+        $response->assertOk();
+
+        $this->assertSame(1, (int) $response->json('data.pagination.total'));
+    }
+}


### PR DESCRIPTION
This branch adds project-scoped property management APIs, improves admin location management, and syncs WhatsappAI webhook traffic into the Communication v1 inbox so messages appear in the unified WhatsApp conversation UI.

### Project properties API
- Add `ProjectPropertyController` with CRUD-style endpoints: list, create, attach, update, and delete properties under a project.
- Introduce `ProjectPropertyService`, form requests, `ProjectPropertyResource`, and location normalization helpers.
- Allow nullable `address` on create; inherit project location/address when the client omits them.
- Add feature tests covering listing, creation, attach, update, delete, and address/location inheritance.

### Admin location management
- Add city search (filter by name or ID) in the location management admin UI.
- Improve styling for buttons, pagination, and modals; add AR/EN search placeholders.

### WhatsApp AI → Communication sync
- Refactor WhatsappAI `WebhookController` for multi-entry payloads, stronger validation, and clearer error handling.
- Add `SyncWhatsappAiConversationToCommunicationService` to mirror WhatsappAI conversations/messages into Communication v1 tables.
- Add `whatsapp:backfill-ai-to-communication` artisan command for historical data (supports `--dry-run`, `--user-id`, `--conversation-id`, `--since`).
- Extend `CommunicationService` / related services for sync support.
- Add feature tests for webhook-driven sync and backfill behavior.

## API changes

| Method | Endpoint | Permission |
|--------|----------|------------|
| GET | `/api/.../projects/{project}/properties` | `projects.view` |
| POST | `/api/.../projects/{project}/properties` | `properties.create` |
| POST | `/api/.../projects/{project}/properties/attach` | `properties.update` |
| PATCH | `/api/.../projects/{project}/properties/{property}` | `properties.update` |
| DELETE | `/api/.../projects/{project}/properties/{property}` | `properties.update` |

## Test plan

- [ ] Run `php artisan test --filter=ProjectPropertyTest`
- [ ] Run `php artisan test --filter=WhatsappAiWebhookCommunicationSyncTest`
- [ ] Run `php artisan test --filter=BackfillWhatsappAiToCommunicationTest`
- [ ] **Project properties:** Create a property without `address` and confirm it inherits from the project; override address/coordinates and confirm they persist.
- [ ] **Project properties:** Attach an existing property to a project; update and delete; verify permissions for users without `properties.create` / `properties.update`.
- [ ] **Admin:** Open location management, search cities by name and ID, confirm pagination and modals still work.
- [ ] **WhatsApp:** Send an inbound webhook message; confirm it appears in Communication v1 inbox (`conversations` / `messages`).
- [ ] **Backfill:** Run `php artisan whatsapp:backfill-ai-to-communication --dry-run`, then without `--dry-run` on a staging tenant; verify counts and inbox data.

## Notes

- No database migrations in this diff; backfill/sync assumes Communication v1 and WhatsappAI tables already exist.
- Backfill command should be run on staging before production if historical WhatsappAI messages must appear in the unified inbox.