### PR TITLE
Enhance DistrictController for public district lookups with city filt…

### DIFF
--- a/app/Http/Controllers/Api/CityController.php
+++ b/app/Http/Controllers/Api/CityController.php
@@ -3,26 +3,30 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Models\User\UserDistrict;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class CityController extends Controller
 {
     /**
-     * GET /api/user/cities?country_id=1
-     * Returns distinct cities from user_districts (table: user_districts).
-     * Optional country_id filters via city relation when present.
+     * GET /api/cities
+     * GET /api/cities?country_id=1
+     *
+     * Returns distinct cities from user_districts. country_id is optional.
      */
-    public function index(Request $request)
+    public function index(Request $request): JsonResponse
     {
-        $countryId = $request->query('country_id');
+        $request->validate([
+            'country_id' => ['sometimes', 'nullable', 'integer', 'exists:user_cities,country_id'],
+        ]);
 
         $cities = UserDistrict::query()
             ->whereNotNull('city_id')
             ->whereNotNull('city_name_ar')
-            ->when($countryId, function ($query) use ($countryId) {
-                $query->whereHas('city', function ($q) use ($countryId) {
-                    $q->where('country_id', $countryId);
+            ->when($request->filled('country_id'), function ($query) use ($request) {
+                $query->whereHas('city', function ($q) use ($request) {
+                    $q->where('country_id', (int) $request->input('country_id'));
                 });
             })
             ->select('city_id as id', 'city_name_ar as name_ar', 'city_name_en as name_en')

--- a/app/Http/Controllers/Api/DistrictController.php
+++ b/app/Http/Controllers/Api/DistrictController.php
@@ -3,21 +3,29 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\User\UserDistrict;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class DistrictController extends Controller
 {
-    //
-    public function index(Request $request)
+    /**
+     * GET /api/districts
+     * GET /api/districts?city_id=1
+     *
+     * Public lookup of rows from user_districts. city_id is optional.
+     */
+    public function index(Request $request): JsonResponse
     {
-        $cityId = $request->query('city_id');
+        $request->validate([
+            'city_id' => ['sometimes', 'nullable', 'integer', 'exists:user_districts,city_id'],
+        ]);
 
-        $districts = DB::table('user_districts')
-            ->when($cityId, function ($query) use ($cityId) {
-                $query->where('city_id', $cityId);
+        $districts = UserDistrict::query()
+            ->when($request->filled('city_id'), function ($query) use ($request) {
+                $query->where('city_id', (int) $request->input('city_id'));
             })
-            ->orderBy('id')
+            ->orderBy('name_ar')
             ->get();
 
         return response()->json(['data' => $districts]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -642,6 +642,10 @@ Route::post('/whatsapp/webhook', [ChatController::class, 'handleWhatsappWebhook'
 // Isthara (public)
 Route::post('/isthara', [IstharaController::class, 'store']);
 
+// Location lookups (public)
+Route::get('/districts', [DistrictController::class, 'index'])
+    ->middleware('throttle:api_standard_60');
+
 // Property requests (public)
 Route::post('/v1/property-requests/public', [ApiPropertyRequestController::class, 'store']);
 // Property interest (public - no authentication required)

--- a/routes/api.php
+++ b/routes/api.php
@@ -643,6 +643,8 @@ Route::post('/whatsapp/webhook', [ChatController::class, 'handleWhatsappWebhook'
 Route::post('/isthara', [IstharaController::class, 'store']);
 
 // Location lookups (public)
+Route::get('/cities', [CityController::class, 'index'])
+    ->middleware('throttle:api_standard_60');
 Route::get('/districts', [DistrictController::class, 'index'])
     ->middleware('throttle:api_standard_60');
 


### PR DESCRIPTION
…ering

Updated the DistrictController to support public API lookups for districts, allowing optional city_id filtering. Implemented request validation for city_id and refactored the query to use the UserDistrict model instead of raw database queries. Adjusted the response to order districts by name in Arabic. Added a new route for accessing the districts endpoint with throttling middleware for improved performance.