### PR TITLE
Enhance PropertyController and ApiUserCategory for improved category …

### DIFF
--- a/app/Http/Controllers/Api/property/PropertyController.php
+++ b/app/Http/Controllers/Api/property/PropertyController.php
@@ -927,10 +927,14 @@ class PropertyController extends Controller
         // Reduced TTL from 1 hour to 5 minutes to reduce stale data risk
         // Observer now handles automatic invalidation on category changes
         $categories = Cache::remember('api_property_categories_list', 300, function () {
-            return ApiUserCategory::where('is_active', true)
+            return ApiUserCategory::query()
+                ->where('is_active', true)
                 ->where('type', 'property')
-                ->get(['id', 'name'])
-                ->toArray();
+                ->get(['id', 'name', 'slug'])
+                ->sortBy(fn (ApiUserCategory $cat) => [$cat->isOtherCategory() ? 1 : 0, $cat->name])
+                ->values()
+                ->map(fn (ApiUserCategory $cat) => ['id' => $cat->id, 'name' => $cat->name])
+                ->all();
         });
 
         return response()->json([

--- a/app/Models/User/RealestateManagement/ApiUserCategory.php
+++ b/app/Models/User/RealestateManagement/ApiUserCategory.php
@@ -87,6 +87,17 @@ class ApiUserCategory extends Model
         return self::where('slug', 'other')->value('id');
     }
 
+    public function isOtherCategory(): bool
+    {
+        if ($this->slug === 'other') {
+            return true;
+        }
+
+        $name = mb_strtolower(trim((string) $this->name));
+
+        return in_array($name, ['أخرى', 'آخرى', 'other', 'etc', 'etc..'], true);
+    }
+
     public function scopeVisibleForUser($query, $userId)
     {
         return $query

--- a/tests/Feature/Api/PropertyCategoriesApiTest.php
+++ b/tests/Feature/Api/PropertyCategoriesApiTest.php
@@ -96,6 +96,30 @@ class PropertyCategoriesApiTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_other_category_last(): void
+    {
+        ApiUserCategory::updateOrCreate(
+            ['slug' => 'other'],
+            ['name' => 'أخرى', 'type' => 'property', 'is_active' => 1, 'icon' => null]
+        );
+        ApiUserCategory::updateOrCreate(
+            ['slug' => 'duplex'],
+            ['name' => 'دوبلكس', 'type' => 'property', 'is_active' => 1, 'icon' => null]
+        );
+
+        Cache::forget('api_property_categories_list');
+
+        Sanctum::actingAs($this->user);
+        $resp = $this->getJson('/api/properties/categories');
+
+        $resp->assertOk();
+        $names = collect($resp->json('data'))->pluck('name')->values()->all();
+
+        $this->assertSame('أخرى', end($names));
+        $this->assertNotSame('أخرى', $names[0]);
+    }
+
+    /** @test */
     public function it_is_idempotent_by_slug_and_does_not_create_duplicates(): void
     {
         $rows = [


### PR DESCRIPTION
…handling

Updated the PropertyController to include a new method for retrieving property categories, now sorting categories to ensure 'other' categories appear last. Introduced the isOtherCategory method in ApiUserCategory to identify 'other' categories based on slug and name. Added a test to verify the correct ordering of categories in the API response. This update improves data integrity and user experience when accessing property categories.