### PR TITLE
Implement OTP test bypass functionality in OtpController

### DIFF
--- a/app/Http/Controllers/Api/OtpController.php
+++ b/app/Http/Controllers/Api/OtpController.php
@@ -132,6 +132,17 @@ class OtpController extends Controller
 
     private function deliverOtp(string $phone, string $plainOtp): JsonResponse
     {
+        if (OtpVerification::isTestBypassActive()) {
+            Log::warning('OTP test bypass delivery skipped', [
+                'phone_masked' => strlen($phone) < 4 ? '****' : '****' . substr($phone, -4),
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'OTP sent.',
+            ], 200);
+        }
+
         $sent = app(WhatsAppService::class)->sendRegistrationOtp($phone, $plainOtp);
 
         if (!$sent) {

--- a/app/Models/OtpVerification.php
+++ b/app/Models/OtpVerification.php
@@ -279,7 +279,7 @@ class OtpVerification extends Model
         return self::DEFAULT_MAX_SENDS_PER_HOUR;
     }
 
-    protected static function isTestBypassOtp(string $plainOtp, string $context): bool
+    public static function isTestBypassActive(string $context = self::CONTEXT_REGISTRATION): bool
     {
         if ($context !== self::CONTEXT_REGISTRATION) {
             return false;
@@ -295,6 +295,17 @@ class OtpVerification extends Model
         if (!$enabled || $code === '') {
             return false;
         }
+
+        return true;
+    }
+
+    protected static function isTestBypassOtp(string $plainOtp, string $context): bool
+    {
+        if (!self::isTestBypassActive($context)) {
+            return false;
+        }
+
+        $code = (string) config('api.otp.registration.test_bypass_code', '');
 
         return hash_equals($code, $plainOtp);
     }


### PR DESCRIPTION
- Added a test bypass feature in the deliverOtp method of OtpController to allow OTP delivery to be skipped during testing.
- Updated OtpVerification model to rename and enhance the isTestBypassActive method, improving the logic for determining when to bypass OTP verification.
- These changes facilitate easier testing of OTP functionality without sending actual messages.