### PR TITLE
Refactor caching mechanism in ActionsAggregatorService and RequestsCo…

### DIFF
--- a/app/Domain/CustomersHub/Services/ActionsAggregatorService.php
+++ b/app/Domain/CustomersHub/Services/ActionsAggregatorService.php
@@ -3,6 +3,7 @@
 namespace App\Domain\CustomersHub\Services;
 
 use App\Models\ApiCustomer;
+use App\Domain\CustomersHub\Services\CustomersHubCacheVersion;
 use App\Support\PhoneNormalizer;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -25,6 +26,13 @@ use Illuminate\Support\Facades\DB;
  */
 class ActionsAggregatorService
 {
+    private CustomersHubCacheVersion $cacheVersion;
+
+    public function __construct(CustomersHubCacheVersion $cacheVersion)
+    {
+        $this->cacheVersion = $cacheVersion;
+    }
+
     /**
      * Action type constants
      */
@@ -166,7 +174,7 @@ class ActionsAggregatorService
         $countFilters = $filters;
         unset($countFilters['limit'], $countFilters['offset'], $countFilters['sort_by'], $countFilters['sort_dir']);
 
-        $cacheKey = 'ch:total:' . $userId . ':' . md5(json_encode($countFilters));
+        $cacheKey = 'ch:total:' . $userId . ':v' . $this->cacheVersion->getVersion($userId) . ':' . md5(json_encode($countFilters));
 
         return Cache::remember($cacheKey, 60, function () use ($userId, $countFilters) {
             return (int) $this->getUnifiedQuery($userId, $countFilters)->count();
@@ -178,7 +186,7 @@ class ActionsAggregatorService
      */
     public function getStats(int $userId, array $filters = []): array
     {
-        $cacheKey = 'ch_stats_' . $userId . '_' . md5(json_encode($filters));
+        $cacheKey = 'ch_stats_' . $userId . '_v' . $this->cacheVersion->getVersion($userId) . '_' . md5(json_encode($filters));
         
         return Cache::remember($cacheKey, 30, function () use ($userId, $filters) {
             $query = $this->getUnifiedQuery($userId, $filters);
@@ -212,7 +220,7 @@ class ActionsAggregatorService
      */
     public function getComparisonStats(int $userId, array $filters = []): array
     {
-        $cacheKey = 'ch_comparison_stats_' . $userId . '_' . md5(json_encode($filters));
+        $cacheKey = 'ch_comparison_stats_' . $userId . '_v' . $this->cacheVersion->getVersion($userId) . '_' . md5(json_encode($filters));
         
         return Cache::remember($cacheKey, 300, function () use ($userId, $filters) {
             $now = Carbon::now();
@@ -252,7 +260,7 @@ class ActionsAggregatorService
      */
     public function getStageStats(int $userId, array $filters = []): array
     {
-        $cacheKey = 'ch_stage_stats_' . $userId . '_' . md5(json_encode($filters));
+        $cacheKey = 'ch_stage_stats_' . $userId . '_v' . $this->cacheVersion->getVersion($userId) . '_' . md5(json_encode($filters));
         
         return Cache::remember($cacheKey, 30, function () use ($userId, $filters) {
             try {
@@ -650,6 +658,10 @@ class ActionsAggregatorService
             return false;
         }
 
+        // These writes use raw DB::table() updates and bypass Eloquent model events,
+        // so bump the tenant's cache version explicitly to invalidate list/stats/count caches.
+        $this->cacheVersion->bump($userId);
+
         $now = Carbon::now();
 
         switch ($parsed['table']) {
@@ -718,7 +730,11 @@ class ActionsAggregatorService
             return false;
         }
 
+        // Raw DB::table() updates bypass Eloquent model events; bump explicitly.
+        $this->cacheVersion->bump($userId);
+
         $now = Carbon::now();
+
 
         switch ($parsed['table']) {
             case 'api_customer_inquiry':
@@ -783,6 +799,9 @@ class ActionsAggregatorService
         if (!$parsed) {
             return false;
         }
+
+        // Raw DB::table() updates bypass Eloquent model events; bump explicitly.
+        $this->cacheVersion->bump($userId);
 
         $now = Carbon::now();
         $payload = ['updated_at' => $now];
@@ -1096,6 +1115,8 @@ class ActionsAggregatorService
                 }
                 break;
             case 'assign':
+                // Raw DB::table() updates bypass Eloquent model events; bump explicitly.
+                $this->cacheVersion->bump($userId);
                 $customerMap = $this->getCustomerIdsForActionIds($userId, $actionIds);
                 $assignedTo = (int) $data['assignedTo'];
                 foreach ($actionIds as $actionId) {
@@ -1275,6 +1296,10 @@ class ActionsAggregatorService
         if (!$parsed) {
             return false;
         }
+
+        // Raw DB::table() updates bypass Eloquent model events; bump explicitly.
+        $this->cacheVersion->bump($userId);
+
         $until = Carbon::parse($snoozedUntil);
         $now = Carbon::now();
 

--- a/app/Domain/CustomersHub/Services/CustomersHubCacheVersion.php
+++ b/app/Domain/CustomersHub/Services/CustomersHubCacheVersion.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Domain\CustomersHub\Services;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * CustomersHubCacheVersion
+ *
+ * Driver-agnostic cache invalidation for Customers Hub list/stats/count caches.
+ *
+ * These caches are parameterized by arbitrary filter/pagination combinations
+ * (viewer id, viewed-at, unread ids, filters hash, limit/offset, ...), so
+ * there is no way to enumerate and forget every possible key on write. The
+ * cache driver in use (`file`, see .env CACHE_DRIVER) does not support cache
+ * tags either, so tag-based flushing is not an option.
+ *
+ * Instead, every affected cache key embeds the tenant's current "version".
+ * Bumping the version (on any create/update/delete of a UserPropertyRequest
+ * or ApiCustomerInquiry) makes all previously cached entries for that tenant
+ * unreachable on the very next read, regardless of filter/pagination
+ * combination, without needing to enumerate keys. Existing TTLs are kept as
+ * a safety net.
+ */
+class CustomersHubCacheVersion
+{
+    private const KEY_PREFIX = 'ch:cache_version:';
+
+    /**
+     * TTL for the version marker itself. Not meant to expire in normal
+     * operation (versions are only ever bumped forward), but bounded so the
+     * `file` cache driver doesn't accumulate stale entries forever.
+     */
+    private const VERSION_TTL_DAYS = 30;
+
+    /**
+     * Read the current cache version for a tenant. Defaults to 1 when unset
+     * (no write-on-read, to avoid races between concurrent first reads).
+     */
+    public function getVersion(int $userId): int
+    {
+        return (int) (Cache::get(self::key($userId)) ?? 1);
+    }
+
+    /**
+     * Invalidate all Customers Hub list/stats/count caches for a tenant by
+     * bumping its version marker.
+     *
+     * Deliberately does not rely solely on Cache::increment(): on several
+     * drivers/stores (e.g. the `array` store used in tests), incrementing a
+     * missing key seeds it at the increment amount (1) — identical to the
+     * implicit default returned by getVersion() for an absent key — so the
+     * very first bump would be a no-op. Reading the current value first and
+     * writing back current+1 guarantees the version always changes.
+     */
+    public function bump(int $userId): void
+    {
+        $key = self::key($userId);
+        $current = (int) (Cache::get($key) ?? 1);
+
+        Cache::put($key, $current + 1, now()->addDays(self::VERSION_TTL_DAYS));
+    }
+
+    private static function key(int $userId): string
+    {
+        return self::KEY_PREFIX . $userId;
+    }
+}

--- a/app/Http/Controllers/Api/V2/CustomersHub/RequestsController.php
+++ b/app/Http/Controllers/Api/V2/CustomersHub/RequestsController.php
@@ -16,6 +16,7 @@ use App\Http\Requests\Api\V2\CustomersHub\RequestsBulkRequest;
 use App\Http\Requests\Api\V2\CustomersHub\DismissRequest;
 use App\Http\Requests\Api\V2\CustomersHub\SnoozeRequest;
 use App\Domain\CustomersHub\Services\ActionsAggregatorService;
+use App\Domain\CustomersHub\Services\CustomersHubCacheVersion;
 use App\Domain\CustomersHub\Services\CustomersHubNotificationService;
 use App\Domain\CustomersHub\Services\CustomersHubPropertyRequestNotifier;
 use App\Domain\CustomersHub\Services\PropertyRequestDetailBuilder;
@@ -66,16 +67,20 @@ class RequestsController extends ApiController
 
     private CustomersHubNotificationService $notificationService;
 
+    private CustomersHubCacheVersion $cacheVersion;
+
     public function __construct(
         ActionsAggregatorService $aggregator,
         PropertyRequestDetailBuilder $propertyRequestDetailBuilder,
         CustomersHubPropertyRequestNotifier $propertyRequestNotifier,
-        CustomersHubNotificationService $notificationService
+        CustomersHubNotificationService $notificationService,
+        CustomersHubCacheVersion $cacheVersion
     ) {
         $this->aggregator = $aggregator;
         $this->propertyRequestDetailBuilder = $propertyRequestDetailBuilder;
         $this->propertyRequestNotifier = $propertyRequestNotifier;
         $this->notificationService = $notificationService;
+        $this->cacheVersion = $cacheVersion;
     }
 
     /**
@@ -114,7 +119,8 @@ class RequestsController extends ApiController
         $unreadSourceIdSet = array_flip($unreadPropertyRequestSourceIds);
 
         $cacheKey = 'ch:reqs:list:'
-            . $userId . ':'
+            . $userId . ':v'
+            . $this->cacheVersion->getVersion($userId) . ':'
             . $viewerId . ':'
             . ($viewedAt?->toIso8601String() ?? 'null') . ':'
             . md5(json_encode(array_values($unreadPropertyRequestSourceIds))) . ':'
@@ -856,11 +862,15 @@ class RequestsController extends ApiController
                     ->where('id', $action->sourceId)
                     ->where('user_id', $userId)
                     ->update(['customers_hub_stage_id' => $stageIdString, 'updated_at' => now()]);
+                // Raw DB::table() update bypasses Eloquent model events; bump explicitly.
+                $this->cacheVersion->bump($userId);
             } elseif (($action->sourceTable ?? '') === 'api_customer_inquiry' && !empty($action->sourceId)) {
                 DB::table('api_customer_inquiry')
                     ->where('id', $action->sourceId)
                     ->where('user_id', $userId)
                     ->update(['stage_id' => $stageIdString, 'updated_at' => now()]);
+                // Raw DB::table() update bypasses Eloquent model events; bump explicitly.
+                $this->cacheVersion->bump($userId);
             }
         }
 

--- a/app/Models/Api/ApiCustomerInquiry.php
+++ b/app/Models/Api/ApiCustomerInquiry.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Api;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Domain\CustomersHub\Services\CustomersHubCacheVersion;
 use App\Models\ApiCustomer;
 use App\Models\CustomersHub\CrmHubNote;
 use App\Models\CustomersHub\CustomersHubStage;
@@ -68,6 +69,25 @@ class ApiCustomerInquiry extends Model
                 $model->stage_id = CustomersHubStage::getDefaultStageId();
             }
         });
+
+        // Inquiries feed the same Customers Hub UNION query as property requests,
+        // so bump the tenant's cache version on every create/update/delete so
+        // list/stats/count caches (which can't be individually forgotten, since
+        // they're parameterized by arbitrary filter/pagination combos) invalidate
+        // immediately instead of waiting for TTL expiry.
+        $bumpCacheVersion = function (ApiCustomerInquiry $model): void {
+            $ids = array_filter(
+                [$model->getOriginal('user_id'), $model->user_id],
+                fn ($v) => $v !== null
+            );
+            $cacheVersion = app(CustomersHubCacheVersion::class);
+            foreach (array_unique($ids) as $id) {
+                $cacheVersion->bump((int) $id);
+            }
+        };
+
+        static::saved($bumpCacheVersion);
+        static::deleted($bumpCacheVersion);
     }
 
     protected $casts = [

--- a/app/Models/Api/UserPropertyRequest.php
+++ b/app/Models/Api/UserPropertyRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Api;
 
+use App\Domain\CustomersHub\Services\CustomersHubCacheVersion;
 use App\Models\ApiCustomer;
 use App\Models\CustomersHub\CrmHubNote;
 use App\Models\CustomersHub\CustomersHubStage;
@@ -33,11 +34,16 @@ class UserPropertyRequest extends Model
                 [$model->getOriginal('user_id'), $model->user_id],
                 fn ($v) => $v !== null
             );
+            $cacheVersion = app(CustomersHubCacheVersion::class);
             foreach (array_unique($ids) as $id) {
                 Cache::forget('property_requests_statistics_' . $id);
                 PropertyRequestFilterOptionsCache::forgetFilterDataForOwner($id);
                 Cache::forget("property_request_filter_options_meta_{$id}");
                 Cache::forget("ch:reqs:filter-options:{$id}");
+                // Bump the Customers Hub cache version so list/stats/count caches
+                // (parameterized by arbitrary filter/pagination combos, so they
+                // cannot be individually forgotten) become invalid immediately.
+                $cacheVersion->bump((int) $id);
             }
         };
 

--- a/tests/Feature/V2/CustomersHub/RequestsListCacheInvalidationTest.php
+++ b/tests/Feature/V2/CustomersHub/RequestsListCacheInvalidationTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V2\CustomersHub;
+
+use App\Models\Api\UserPropertyRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Regression test for the Customers Hub caching bug: newly created/updated
+ * property requests did not appear in /api/v2/customers-hub/requests/list
+ * until the underlying 30-60s TTL caches expired.
+ *
+ * These tests deliberately prime the caches with an initial list() call and
+ * then mutate data via Eloquent (mirroring ApiPropertyRequestController::store())
+ * and via the update/complete/dismiss endpoints, asserting the very next
+ * list() call (well inside the old TTL window) reflects the change.
+ */
+class RequestsListCacheInvalidationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function requirePropertyRequestTable(): void
+    {
+        if (!Schema::hasTable('users_property_requests')) {
+            $this->markTestSkipped('users_property_requests table required.');
+        }
+    }
+
+    private function createTenant(): User
+    {
+        return User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+    }
+
+    /** @test */
+    public function newly_created_property_request_appears_immediately_in_list(): void
+    {
+        $this->requirePropertyRequestTable();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        // Prime the list/stats/count caches with an empty result set.
+        $res = $this->postJson('/api/v2/customers-hub/requests/list', [
+            'limit' => 50,
+            'offset' => 0,
+        ]);
+        $res->assertOk();
+        $this->assertEquals(0, $res->json('data.pagination.total'));
+
+        // Create a property request the same way ApiPropertyRequestController::store() does:
+        // via the Eloquent model (triggers the saved() cache-busting hook).
+        UserPropertyRequest::create([
+            'full_name' => 'New Requester',
+            'phone' => '+966501234567',
+            'user_id' => $tenant->id,
+            'is_active' => 1,
+        ]);
+
+        // Well within the old 30-60s TTL window: the new request must be visible now.
+        $res2 = $this->postJson('/api/v2/customers-hub/requests/list', [
+            'limit' => 50,
+            'offset' => 0,
+        ]);
+        $res2->assertOk();
+        $this->assertEquals(1, $res2->json('data.pagination.total'));
+        $actions = $res2->json('data.actions');
+        $this->assertCount(1, $actions);
+        $this->assertEquals('property_request', $actions[0]['objectType']);
+    }
+
+    /** @test */
+    public function completing_a_request_is_immediately_reflected_in_list(): void
+    {
+        $this->requirePropertyRequestTable();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $propertyRequest = UserPropertyRequest::create([
+            'full_name' => 'Requester To Complete',
+            'phone' => '+966501234568',
+            'user_id' => $tenant->id,
+            'is_active' => 1,
+        ]);
+
+        // Prime the cache with the request in its initial (pending) stage.
+        $res = $this->postJson('/api/v2/customers-hub/requests/list', [
+            'limit' => 50,
+            'offset' => 0,
+        ]);
+        $res->assertOk();
+        $this->assertNotEquals('deal_completed', $res->json('data.actions.0.customers_hub_stage_id'));
+
+        $completeRes = $this->postJson(
+            "/api/v2/customers-hub/requests/property_request_{$propertyRequest->id}/complete"
+        );
+        $completeRes->assertOk();
+
+        // Immediately re-list: must reflect the completed stage, not the stale cached copy.
+        $res2 = $this->postJson('/api/v2/customers-hub/requests/list', [
+            'limit' => 50,
+            'offset' => 0,
+        ]);
+        $res2->assertOk();
+        $actions = $res2->json('data.actions');
+        $this->assertCount(1, $actions);
+        $this->assertEquals('deal_completed', $actions[0]['customers_hub_stage_id']);
+    }
+
+    /** @test */
+    public function dismissing_a_request_is_immediately_reflected_in_list(): void
+    {
+        $this->requirePropertyRequestTable();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $propertyRequest = UserPropertyRequest::create([
+            'full_name' => 'Requester To Dismiss',
+            'phone' => '+966501234569',
+            'user_id' => $tenant->id,
+            'is_active' => 1,
+        ]);
+
+        // Prime the cache.
+        $res = $this->postJson('/api/v2/customers-hub/requests/list', [
+            'limit' => 50,
+            'offset' => 0,
+        ]);
+        $res->assertOk();
+
+        $dismissRes = $this->postJson(
+            "/api/v2/customers-hub/requests/property_request_{$propertyRequest->id}/dismiss",
+            ['reason' => 'Not a fit']
+        );
+        $dismissRes->assertOk();
+
+        $res2 = $this->postJson('/api/v2/customers-hub/requests/list', [
+            'limit' => 50,
+            'offset' => 0,
+        ]);
+        $res2->assertOk();
+        $actions = $res2->json('data.actions');
+        $this->assertCount(1, $actions);
+        $this->assertEquals('deal_rejected', $actions[0]['customers_hub_stage_id']);
+    }
+}


### PR DESCRIPTION
…ntroller

- Introduced CustomersHubCacheVersion to manage cache versioning for user-specific data.
- Updated cache key generation in ActionsAggregatorService methods to include cache version.
- Bumped cache version on create/update/delete operations in ApiCustomerInquiry and UserPropertyRequest models to ensure immediate cache invalidation.
- Enhanced RequestsController to utilize cache versioning for request list caching.