### PR TITLE
feat: site setup steps progress API

### DIFF
--- a/app/Http/Controllers/Api/AnalyticsDashboardController.php
+++ b/app/Http/Controllers/Api/AnalyticsDashboardController.php
@@ -1260,6 +1260,12 @@ class AnalyticsDashboardController extends Controller
     {
         $data = app(SiteSetupProgressService::class)->getProgress($request->user());
 
+        if ($data === null) {
+            return response()->json([
+                'message' => 'Unable to resolve tenant owner.',
+            ], 403);
+        }
+
         return response()->json($data);
     }
 

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -42,6 +42,7 @@ use App\Models\User\HomePageText;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Api\ApiMenuSetting;
 use App\Services\TempTokenService;
+use App\Services\SiteSetupProgressService;
 use Illuminate\Support\Facades\DB;
 use App\Models\User\UserPermission;
 use App\Services\OnboardingService;
@@ -1115,7 +1116,9 @@ class AuthController extends Controller
                 }
             }
 
-            DB::transaction(function () use ($user, $owner, $validated) {
+            $didCompanyUpdate = false;
+
+            DB::transaction(function () use ($user, $owner, $validated, &$didCompanyUpdate) {
                 $userFields = $this->extractPersonalProfileFields($validated);
 
                 if ($userFields !== []) {
@@ -1130,8 +1133,13 @@ class AuthController extends Controller
 
                 if ($this->hasCompanyFieldUpdates($validated)) {
                     $this->applyCompanyProfileUpdates($owner, $validated);
+                    $didCompanyUpdate = true;
                 }
             });
+
+            if ($didCompanyUpdate && $owner) {
+                app(SiteSetupProgressService::class)->syncContactsSocialInfo($owner);
+            }
 
             CacheInvalidationHelper::clearTenantProfileCachesAuto($ownerId);
 

--- a/app/Http/Controllers/Api/GeneratedApiPathsDoc.php
+++ b/app/Http/Controllers/Api/GeneratedApiPathsDoc.php
@@ -2363,8 +2363,23 @@ namespace App\Http\Controllers\Api;
  *         operationId="get_dashboard_setup_progress_0",
  *         tags={"Dashboard"},
  *         summary="Setup Progress", security={{"sanctum":{}}},
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site"}),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner")
  *     )
  *
  * )
@@ -4178,10 +4193,27 @@ namespace App\Http\Controllers\Api;
  *         tags={"Steps"},
  *         summary="Complete Step", security={{"sanctum":{}}},
  *         @OA\RequestBody(required=true, @OA\JsonContent(type="object", required={"step"},
- *             @OA\Property(property="step", type="string", enum={"banner","footer","homepage_about_update","menu_builder","projects","properties"}),
+ *             @OA\Property(property="step", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site","properties"}),
  *         )),
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="message", type="string", example="Step marked as completed."),
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string"),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner"),
+ *         @OA\Response(response=422, description="Validation error")
  *     )
  *
  * )
@@ -4194,8 +4226,23 @@ namespace App\Http\Controllers\Api;
  *         operationId="get_steps_progress_0",
  *         tags={"Steps"},
  *         summary="Get Steps", security={{"sanctum":{}}},
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site"}),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner")
  *     )
  *
  * )

--- a/app/Http/Controllers/Api/StepProgressController.php
+++ b/app/Http/Controllers/Api/StepProgressController.php
@@ -2,126 +2,54 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Models\UserStep;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\Onboarding\CompleteOnboardingStepRequest;
+use App\Services\SiteSetupProgressService;
+use Illuminate\Http\Request;
 
 class StepProgressController extends Controller
 {
-    /**
-     * Step map configuration - moved to class constant to avoid per-request allocation
-     */
-    private const STEP_MAP = [
-        'banner' => [
-            'path' => '/content/banner',
-            'text' => 'قم بتخصيص البانر الخاص بك',
-        ],
-        'footer' => [
-            'path' => '/content/footer',
-            'text' => 'قم بتخصيص التذييل الخاص بك',
-        ],
-        'homepage_about_update' => [
-            'path' => '/content/about',
-            'text' => 'قم بتحديث قسم من نحن',
-        ],
-        'menu_builder' => [
-            'path' => '/content/menu',
-            'text' => 'قم بإعداد قائمة الموقع',
-        ],
-        'projects' => [
-            'path' => '/projects/add',
-            'text' => 'أضف أول مشروع',
-        ],
-        'properties' => [
-            'path' => '/properties/add',
-            'text' => 'اضف اول عقار الآن',
-        ],
-    ];
+    public function __construct(
+        private readonly SiteSetupProgressService $progressService,
+    ) {}
 
     /**
-     * Display the progress of a specific step for a user.
+     * Display site setup progress for the authenticated user's tenant owner.
      *
-     * @param  Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function getSteps(Request $request)
     {
-        $user = $request->user();
-        
-        // Check if performance optimizations are enabled
-        $useOptimizations = config('performance.enable_api_performance_optimizations');
-        
-        if ($useOptimizations) {
-            // Select only the columns we use to avoid pulling large blobs
-            $stepKeys = array_keys(self::STEP_MAP);
-            $steps = UserStep::select(['user_id', ...$stepKeys])
-                ->firstOrCreate(['user_id' => $user->id], array_fill_keys($stepKeys, false));
-        } else {
-            $steps = UserStep::firstOrCreate(['user_id' => $user->id]);
+        $progress = $this->progressService->getProgress($request->user());
+
+        if ($progress === null) {
+            return response()->json([
+                'message' => 'Unable to resolve tenant owner.',
+            ], 403);
         }
 
-        $stepMap = self::STEP_MAP;
-        $rawData = $steps->only(array_keys($stepMap));
-
-    $stepsWithStatus = [];
-    foreach ($stepMap as $key => $info) {
-        $value = $rawData[$key] ?? null;
-        $stepsWithStatus[$key] = [
-            'status' => $value,
-            'text' => $info['text'],
-        ];
+        return response()->json($progress);
     }
 
-    $progress = collect($stepsWithStatus)->filter(fn($step) => $step['status'])->count();
-    $percentage = intval(($progress / count($stepMap)) * 100);
-
-    $continuePath = collect($stepMap)
-        ->filter(fn($_, $key) => empty($rawData[$key]))
-        ->pluck('path')
-        ->first();
-
-    return response()->json([
-        'steps' => $stepsWithStatus,
-        'progress' => $percentage,
-        'continue_path' => $continuePath,
-    ]);
-}
-
-
+    /**
+     * Mark a setup step complete (owner user_steps write) and return GET-shaped progress.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function completeStep(CompleteOnboardingStepRequest $request)
     {
         $validated = $request->validated();
-        $user = auth()->user();
-        $steps = UserStep::firstOrCreate(['user_id' => $user->id]);
+        $result = $this->progressService->completeStep($request->user(), $validated['step']);
 
-        $steps->{$validated['step']} = true;
-        // Optional: check if all steps are completed now
-        $stepKeys = ['banner', 'footer', 'homepage_about_update', 'menu_builder', 'projects', 'properties'];
-        $remaining = collect($steps->only($stepKeys))->filter(fn ($v) => ! $v);
-
-        if ($remaining->isEmpty() && ! $steps->completed_at) {
-            $steps->completed_at = now();
+        if (! $result['ok']) {
+            return response()->json([
+                'message' => $result['error'] ?? 'Unable to complete step.',
+            ], $result['status'] ?? 422);
         }
 
-        $steps->save();
-
-        $data = $steps->only($stepKeys);
-        $progress = collect($data)->filter(fn ($v) => $v)->count();
-        $percentage = intval(($progress / count($stepKeys)) * 100);
-
-        $continuePath = collect(self::STEP_MAP)
-            ->filter(fn ($_, $key) => empty($data[$key]))
-            ->pluck('path')
-            ->first();
-
-        return response()->json([
-            'message' => 'Step marked as completed.',
-            'steps' => $data,
-            'progress' => $percentage,
-            'continue_path' => $continuePath,
-        ]);
+        return response()->json(array_merge(
+            ['message' => 'Step marked as completed.'],
+            $result['progress']
+        ));
     }
-
-
 }

--- a/app/Http/Requests/Api/Onboarding/CompleteOnboardingStepRequest.php
+++ b/app/Http/Requests/Api/Onboarding/CompleteOnboardingStepRequest.php
@@ -14,7 +14,7 @@ class CompleteOnboardingStepRequest extends BaseApiFormRequest
     public function rules()
     {
         return [
-            'step' => 'required|in:banner,footer,homepage_about_update,menu_builder,projects,properties',
+            'step' => 'required|in:site_identity,contact_info,first_property,integrated_link,connect_site,properties',
         ];
     }
 }

--- a/app/Observers/PropertyObserver.php
+++ b/app/Observers/PropertyObserver.php
@@ -2,9 +2,11 @@
 
 namespace App\Observers;
 
+use App\Models\User;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\Logs\PropertyLog;
 use App\Services\Audit\EntityAuditLogger;
+use App\Services\SiteSetupProgressService;
 use App\Support\AuditContext;
 use App\Support\PropertyAuditFields;
 use App\Support\CacheInvalidationHelper;
@@ -90,6 +92,12 @@ class PropertyObserver
         
         // Clear property-related caches when new property is created
         $this->clearPropertyCachesForUser($m->user_id);
+
+        // Sync owner user_steps.properties for site setup progress (GET still derives from DB).
+        $propertyOwner = User::find($m->user_id);
+        if ($propertyOwner) {
+            app(SiteSetupProgressService::class)->syncPropertiesFlag($propertyOwner);
+        }
     }
     
     public function updated(Property $m): void {

--- a/app/Services/SiteSetupProgressService.php
+++ b/app/Services/SiteSetupProgressService.php
@@ -2,69 +2,279 @@
 
 namespace App\Services;
 
-use App\Domain\Domain\Models\CustomDomain;
+use App\Models\Api\ApiDomainSetting;
+use App\Models\Api\FooterSetting;
 use App\Models\Api\marketing\MarketingChannel;
 use App\Models\User;
+use App\Models\User\BasicSetting;
+use App\Models\User\RealestateManagement\Property;
 use App\Models\UserStep;
+use App\Models\WhatsappUser;
 
 class SiteSetupProgressService
 {
+    private const TOTAL_STEPS = 5;
+
+    private const PLACEHOLDER_PHONES = [
+        '+966 5XXXXXXXX',
+        '+9665XXXXXXXX',
+        '5XXXXXXXX',
+    ];
+
+    private const PLACEHOLDER_EMAILS = [
+        'info@example.com',
+    ];
+
     /**
-     * Site setup checklist for the dashboard widget (5 steps).
-     * Uses tenant owner id so employees see the same progress as the account owner.
+     * Canonical FE setup-progress payload (5 steps).
+     * Derives each status from tenant-owner data; employees share owner progress.
+     *
+     * @return array<string, mixed>|null Null when owner cannot be resolved (fail closed).
      */
-    public function getProgress(User $user): array
+    public function getProgress(User $user): ?array
     {
         $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return null;
+        }
 
-        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
-        $hasDomain = CustomDomain::where('user_id', $ownerId)->exists();
-        $hasWhatsApp = MarketingChannel::where('user_id', $ownerId)
-            ->where('type', MarketingChannel::TYPE_WHATSAPP)
-            ->where('is_connected', true)
-            ->exists();
+        $owner = User::find($ownerId);
+        if (! $owner) {
+            return null;
+        }
+
+        $statuses = [
+            'site_identity' => (bool) $owner->onboarding_completed,
+            'contact_info' => $this->isContactInfoComplete($owner),
+            'first_property' => Property::where('user_id', $ownerId)->exists(),
+            'integrated_link' => $this->hasIntegratedLink($ownerId),
+            'connect_site' => ApiDomainSetting::where('user_id', $ownerId)
+                ->where('status', 'active')
+                ->exists(),
+        ];
 
         $stepDefs = [
             [
-                'key' => 'site_identity',
-                'label' => 'هوية الموقع',
-                'completed' => (bool) ($steps->logo_uploaded && $steps->website_named),
-                'path' => '/basic-settings',
+                'id' => 'site_identity',
+                'label_ar' => 'هوية الموقع',
+                'order' => 1,
+                'href_incomplete' => null,
             ],
             [
-                'key' => 'contact_data',
-                'label' => 'بيانات التواصل',
-                'completed' => (bool) $steps->contacts_social_info,
-                'path' => '/contact-info',
+                'id' => 'contact_info',
+                'label_ar' => 'بيانات التواصل',
+                'order' => 2,
+                'href_incomplete' => '/dashboard/my-account/personal',
             ],
             [
-                'key' => 'first_property',
-                'label' => 'أول عقار',
-                'completed' => (bool) $steps->properties,
-                'path' => '/properties/add',
+                'id' => 'first_property',
+                'label_ar' => 'أول عقار',
+                'order' => 3,
+                'href_incomplete' => '/dashboard/properties/add',
             ],
             [
-                'key' => 'domain_link',
-                'label' => 'ربط الموقع',
-                'completed' => $hasDomain,
-                'path' => '/domain-settings',
+                'id' => 'integrated_link',
+                'label_ar' => 'الرابط المتكامل',
+                'order' => 4,
+                'href_incomplete' => '/dashboard/apps',
             ],
             [
-                'key' => 'integration',
-                'label' => 'الرابط المتكامل',
-                'completed' => $hasWhatsApp,
-                'path' => '/whatsapp',
+                'id' => 'connect_site',
+                'label_ar' => 'ربط الموقع',
+                'order' => 5,
+                'href_incomplete' => '/dashboard/my-account/domains',
             ],
         ];
 
-        $completedCount = collect($stepDefs)->filter(fn ($s) => $s['completed'])->count();
-        $total = count($stepDefs);
+        $steps = [];
+        $done = 0;
+
+        foreach ($stepDefs as $def) {
+            $complete = (bool) ($statuses[$def['id']] ?? false);
+            if ($complete) {
+                $done++;
+            }
+
+            $steps[] = [
+                'id' => $def['id'],
+                'label_ar' => $def['label_ar'],
+                'status' => $complete,
+                'href' => $complete ? null : $def['href_incomplete'],
+                'order' => $def['order'],
+                'locked' => false,
+            ];
+        }
+
+        $progress = self::TOTAL_STEPS > 0
+            ? round($done / self::TOTAL_STEPS, 4)
+            : 0.0;
 
         return [
-            'steps' => $stepDefs,
-            'completed_count' => $completedCount,
-            'total_steps' => $total,
-            'progress_percentage' => $total > 0 ? (int) (($completedCount / $total) * 100) : 0,
+            'progress' => $progress,
+            'done' => $done,
+            'total' => self::TOTAL_STEPS,
+            'headline_key' => $this->headlineKeyForDone($done),
+            'dismissed' => false,
+            'steps' => $steps,
         ];
+    }
+
+    /**
+     * Map POST /steps/complete to owner user_steps flags, then return GET-shaped progress.
+     *
+     * @return array{ok: bool, progress: ?array, error?: string, status?: int}
+     */
+    public function completeStep(User $user, string $step): array
+    {
+        $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return ['ok' => false, 'progress' => null, 'error' => 'Unable to resolve tenant owner.', 'status' => 403];
+        }
+
+        $canonical = $step === 'properties' ? 'first_property' : $step;
+
+        $noopSteps = ['site_identity', 'integrated_link', 'connect_site'];
+        $flagMap = [
+            'first_property' => 'properties',
+            'contact_info' => 'contacts_social_info',
+        ];
+
+        if (in_array($canonical, $noopSteps, true)) {
+            // no-op on user_steps; GET remains source of truth
+        } elseif (isset($flagMap[$canonical])) {
+            $column = $flagMap[$canonical];
+            $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+            $steps->{$column} = true;
+            $steps->save();
+        } else {
+            return [
+                'ok' => false,
+                'progress' => null,
+                'error' => 'The selected step is invalid.',
+                'status' => 422,
+            ];
+        }
+
+        $progress = $this->getProgress($user);
+        if ($progress === null) {
+            return ['ok' => false, 'progress' => null, 'error' => 'Unable to resolve tenant owner.', 'status' => 403];
+        }
+
+        return ['ok' => true, 'progress' => $progress];
+    }
+
+    /**
+     * Sync contacts_social_info on the owner row when contact_info derives true.
+     */
+    public function syncContactsSocialInfo(User $owner): void
+    {
+        $ownerId = (int) ($owner->id ?: 0);
+        if (! $ownerId) {
+            return;
+        }
+
+        if (! $this->isContactInfoComplete($owner)) {
+            return;
+        }
+
+        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+        if ($steps->contacts_social_info) {
+            return;
+        }
+
+        $steps->contacts_social_info = true;
+        $steps->save();
+    }
+
+    /**
+     * Sync properties flag on the owner row after a property is created.
+     * Early-returns if already true.
+     */
+    public function syncPropertiesFlag(User $user): void
+    {
+        $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return;
+        }
+
+        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+        if ($steps->properties) {
+            return;
+        }
+
+        $steps->properties = true;
+        $steps->save();
+    }
+
+    public function isContactInfoComplete(User $owner): bool
+    {
+        $footer = FooterSetting::where('user_id', $owner->id)->first();
+        $general = is_array($footer?->general) ? $footer->general : [];
+
+        $phone = trim((string) ($general['phone'] ?? ''));
+        if ($phone === '' || $this->isPlaceholderPhone($phone)) {
+            return false;
+        }
+
+        $basic = BasicSetting::where('user_id', $owner->id)->first();
+        $basicEmail = trim((string) ($basic?->email ?? ''));
+        $footerEmail = trim((string) ($general['email'] ?? ''));
+
+        $email = $basicEmail !== '' ? $basicEmail : $footerEmail;
+        if ($email === '' || $this->isPlaceholderEmail($email)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hasIntegratedLink(int $ownerId): bool
+    {
+        $whatsappActive = WhatsappUser::where('user_id', $ownerId)
+            ->where('status', 'active')
+            ->exists();
+
+        if ($whatsappActive) {
+            return true;
+        }
+
+        return MarketingChannel::where('user_id', $ownerId)
+            ->where('type', MarketingChannel::TYPE_WHATSAPP)
+            ->where('is_connected', true)
+            ->exists();
+    }
+
+    private function headlineKeyForDone(int $done): string
+    {
+        return match (true) {
+            $done <= 0 => 'start',
+            $done === 1 => 'early',
+            $done <= 3 => 'mid',
+            $done === 4 => 'almost',
+            default => 'done',
+        };
+    }
+
+    private function isPlaceholderPhone(string $phone): bool
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($phone)) ?? '';
+        $compact = preg_replace('/\s+/', '', $normalized) ?? '';
+
+        foreach (self::PLACEHOLDER_PHONES as $placeholder) {
+            $pNorm = preg_replace('/\s+/', ' ', $placeholder) ?? '';
+            $pCompact = preg_replace('/\s+/', '', $placeholder) ?? '';
+            if (strcasecmp($normalized, $pNorm) === 0 || strcasecmp($compact, $pCompact) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPlaceholderEmail(string $email): bool
+    {
+        $email = strtolower(trim($email));
+
+        return in_array($email, array_map('strtolower', self::PLACEHOLDER_EMAILS), true);
     }
 }

--- a/tests/Feature/Api/StepsProgressApiTest.php
+++ b/tests/Feature/Api/StepsProgressApiTest.php
@@ -1,0 +1,589 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Api\ApiDomainSetting;
+use App\Models\Api\FooterSetting;
+use App\Models\Api\marketing\MarketingChannel;
+use App\Models\User;
+use App\Models\User\BasicSetting;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\UserStep;
+use App\Models\WhatsappUser;
+use App\Services\SiteSetupProgressService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class StepsProgressApiTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach ([
+            'users',
+            'user_steps',
+            'user_basic_settings',
+            'api_footer_settings',
+            'user_properties',
+            'whatsapp_users',
+            'marketing_channels',
+            'api_domains_settings',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    private function createTenant(array $overrides = []): User
+    {
+        return User::factory()->tenant()->create(array_merge([
+            'email' => 'steps-' . uniqid('', true) . '@example.com',
+            'username' => 'steps' . substr(md5(uniqid('', true)), 0, 10),
+            'onboarding_completed' => false,
+        ], $overrides));
+    }
+
+    private function createEmployeeFor(User $tenant, array $overrides = []): User
+    {
+        return User::factory()->employee()->create(array_merge([
+            'tenant_id' => $tenant->id,
+            'email' => 'emp-' . uniqid('', true) . '@example.com',
+            'username' => 'emp' . substr(md5(uniqid('', true)), 0, 10),
+        ], $overrides));
+    }
+
+    private function seedPlaceholderContact(User $owner): void
+    {
+        FooterSetting::create([
+            'user_id' => $owner->id,
+            'general' => [
+                'phone' => '+966 5XXXXXXXX',
+                'email' => 'info@example.com',
+            ],
+            'social' => [],
+            'columns' => [],
+            'newsletter' => [],
+            'style' => [],
+            'status' => true,
+        ]);
+
+        BasicSetting::create([
+            'user_id' => $owner->id,
+            'email' => 'info@example.com',
+        ]);
+    }
+
+    private function seedRealContact(User $owner): void
+    {
+        FooterSetting::updateOrCreate(
+            ['user_id' => $owner->id],
+            [
+                'general' => [
+                    'phone' => '+966 512345678',
+                    'email' => 'office@realestate.test',
+                ],
+                'social' => [],
+                'columns' => [],
+                'newsletter' => [],
+                'style' => [],
+                'status' => true,
+            ]
+        );
+
+        BasicSetting::updateOrCreate(
+            ['user_id' => $owner->id],
+            ['email' => 'office@realestate.test']
+        );
+    }
+
+    private function assertProgressShape(array $json): void
+    {
+        $this->assertArrayHasKey('progress', $json);
+        $this->assertArrayHasKey('done', $json);
+        $this->assertArrayHasKey('total', $json);
+        $this->assertArrayHasKey('headline_key', $json);
+        $this->assertArrayHasKey('dismissed', $json);
+        $this->assertArrayHasKey('steps', $json);
+        $this->assertFalse($json['dismissed']);
+        $this->assertSame(5, $json['total']);
+        $this->assertIsFloat((float) $json['progress']);
+        $this->assertSame(
+            (float) $json['done'] / 5,
+            (float) $json['progress']
+        );
+
+        $ids = array_column($json['steps'], 'id');
+        $this->assertSame(
+            ['site_identity', 'contact_info', 'first_property', 'integrated_link', 'connect_site'],
+            $ids
+        );
+
+        foreach ($json['steps'] as $index => $step) {
+            $this->assertArrayHasKey('locked', $step);
+            $this->assertFalse($step['locked']);
+            $this->assertArrayHasKey('href', $step);
+            $this->assertArrayHasKey('status', $step);
+            $this->assertArrayHasKey('label_ar', $step);
+            $this->assertSame($index + 1, $step['order']);
+
+            if ($step['status'] === true) {
+                $this->assertNull($step['href']);
+            } elseif ($step['id'] !== 'site_identity') {
+                $this->assertNotNull($step['href']);
+            }
+        }
+
+        $this->assertSame(4, $json['steps'][3]['order']);
+        $this->assertSame('integrated_link', $json['steps'][3]['id']);
+        $this->assertSame(5, $json['steps'][4]['order']);
+        $this->assertSame('connect_site', $json['steps'][4]['id']);
+    }
+
+    private function stepStatus(array $json, string $id): bool
+    {
+        foreach ($json['steps'] as $step) {
+            if ($step['id'] === $id) {
+                return (bool) $step['status'];
+            }
+        }
+
+        $this->fail("Step {$id} missing from response");
+    }
+
+    public function test_get_progress_returns_fe_shape_and_start_headline(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $response = $this->getJson('/api/steps/progress');
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertProgressShape($json);
+        $this->assertSame(0, $json['done']);
+        $this->assertSame('start', $json['headline_key']);
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+    }
+
+    public function test_placeholders_keep_contact_info_incomplete(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => false]);
+        $this->seedPlaceholderContact($tenant);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+    }
+
+    public function test_site_identity_from_onboarding_completed(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'site_identity'));
+        $this->assertSame(1, $json['done']);
+        $this->assertSame('early', $json['headline_key']);
+    }
+
+    public function test_contact_info_from_real_company_phone_and_email(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $this->seedRealContact($tenant);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'contact_info'));
+        $contact = collect($json['steps'])->firstWhere('id', 'contact_info');
+        $this->assertNull($contact['href']);
+    }
+
+    public function test_first_property_from_draft_property_count(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'price' => 100000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'test.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'first_property'));
+    }
+
+    public function test_integrated_link_from_whatsapp_users_active(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'number' => '966500000001',
+            'name' => 'WA',
+            'status' => 'active',
+            'request_status' => 'active',
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'integrated_link'));
+    }
+
+    public function test_integrated_link_from_marketing_channel_connected(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        MarketingChannel::create([
+            'user_id' => $tenant->id,
+            'name' => 'WhatsApp',
+            'type' => MarketingChannel::TYPE_WHATSAPP,
+            'number' => '966500000002',
+            'is_connected' => true,
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'integrated_link'));
+    }
+
+    public function test_connect_site_from_active_domain(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'active-' . uniqid('', true) . '.example.com',
+            'status' => 'active',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'pending-' . uniqid('', true) . '.example.com',
+            'status' => 'pending',
+            'primary' => false,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'connect_site'));
+    }
+
+    public function test_pending_domain_does_not_complete_connect_site(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'only-pending-' . uniqid('', true) . '.example.com',
+            'status' => 'pending',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'connect_site'));
+    }
+
+    public function test_headline_key_buckets(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $service = app(SiteSetupProgressService::class);
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($tenant);
+
+        $progress = $service->getProgress($tenant);
+        $this->assertSame(2, $progress['done']);
+        $this->assertSame('mid', $progress['headline_key']);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'price' => 1,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 't.jpg',
+            'property_type' => 'apartment',
+        ]);
+        WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'number' => '966500000099',
+            'name' => 'WA',
+            'status' => 'active',
+            'request_status' => 'active',
+        ]);
+
+        $progress = $service->getProgress($tenant->fresh());
+        $this->assertSame(4, $progress['done']);
+        $this->assertSame('almost', $progress['headline_key']);
+
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'done-' . uniqid('', true) . '.example.com',
+            'status' => 'active',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+
+        $progress = $service->getProgress($tenant->fresh());
+        $this->assertSame(5, $progress['done']);
+        $this->assertSame('done', $progress['headline_key']);
+        $this->assertSame(1.0, (float) $progress['progress']);
+    }
+
+    public function test_employee_sees_owner_progress(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($tenant);
+        $employee = $this->createEmployeeFor($tenant);
+
+        Sanctum::actingAs($employee);
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'site_identity'));
+        $this->assertTrue($this->stepStatus($json, 'contact_info'));
+        $this->assertSame(2, $json['done']);
+    }
+
+    public function test_post_first_property_writes_owner_properties_flag(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/steps/complete', ['step' => 'first_property']);
+
+        $response->assertOk()
+            ->assertJsonPath('message', 'Step marked as completed.')
+            ->assertJsonStructure(['progress', 'done', 'total', 'headline_key', 'dismissed', 'steps']);
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertProgressShape($response->json());
+    }
+
+    public function test_post_legacy_properties_maps_to_first_property_flag(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $this->postJson('/api/steps/complete', ['step' => 'properties'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+    }
+
+    public function test_post_contact_info_writes_contacts_social_info(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $this->postJson('/api/steps/complete', ['step' => 'contact_info'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('contacts_social_info')
+        );
+    }
+
+    public function test_post_noop_steps_do_not_write_user_steps_columns(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        foreach (['site_identity', 'integrated_link', 'connect_site'] as $step) {
+            $response = $this->postJson('/api/steps/complete', ['step' => $step]);
+            $response->assertOk();
+            $this->assertProgressShape($response->json());
+        }
+
+        $row = UserStep::where('user_id', $tenant->id)->first();
+        if ($row) {
+            $this->assertFalse((bool) $row->properties);
+            $this->assertFalse((bool) $row->contacts_social_info);
+        }
+    }
+
+    public function test_post_legacy_steps_return_422(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        foreach (['banner', 'footer', 'homepage_about_update', 'menu_builder', 'projects'] as $step) {
+            $this->postJson('/api/steps/complete', ['step' => $step])
+                ->assertStatus(422);
+        }
+    }
+
+    public function test_employee_post_writes_owner_user_steps_row(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $employee = $this->createEmployeeFor($tenant);
+        Sanctum::actingAs($employee);
+
+        $this->postJson('/api/steps/complete', ['step' => 'first_property'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertFalse(
+            UserStep::where('user_id', $employee->id)->where('properties', true)->exists()
+        );
+    }
+
+    public function test_property_create_syncs_owner_properties_flag_only(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $employee = $this->createEmployeeFor($tenant);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'created_by' => $employee->id,
+            'price' => 50000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'obs.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertFalse(
+            UserStep::where('user_id', $employee->id)->where('properties', true)->exists()
+        );
+
+        // Early-return path: already true should not throw.
+        app(SiteSetupProgressService::class)->syncPropertiesFlag($tenant);
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+    }
+
+    public function test_owner_null_employee_fails_closed_with_403(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $employee = User::factory()->employee()->create([
+            'tenant_id' => 0,
+            'email' => 'orphan-' . uniqid('', true) . '@example.com',
+            'username' => 'orphan' . substr(md5(uniqid('', true)), 0, 8),
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/steps/progress')->assertStatus(403);
+        $this->postJson('/api/steps/complete', ['step' => 'contact_info'])->assertStatus(403);
+    }
+
+    public function test_tenant_scoping_does_not_leak_other_owner_progress(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $ownerA = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($ownerA);
+        Property::create([
+            'user_id' => $ownerA->id,
+            'price' => 1,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'a.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $ownerB = $this->createTenant(['onboarding_completed' => false]);
+        Sanctum::actingAs($ownerB);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+        $this->assertFalse($this->stepStatus($json, 'first_property'));
+        $this->assertSame(0, $json['done']);
+    }
+
+    public function test_complete_onboarding_step_request_enums_match_openapi(): void
+    {
+        $request = new \App\Http\Requests\Api\Onboarding\CompleteOnboardingStepRequest();
+        $rule = $request->rules()['step'];
+        $this->assertIsString($rule);
+        $this->assertStringContainsString('site_identity', $rule);
+        $this->assertStringContainsString('contact_info', $rule);
+        $this->assertStringContainsString('first_property', $rule);
+        $this->assertStringContainsString('integrated_link', $rule);
+        $this->assertStringContainsString('connect_site', $rule);
+        $this->assertStringContainsString('properties', $rule);
+        $this->assertStringNotContainsString('banner', $rule);
+    }
+}


### PR DESCRIPTION
## Summary
- Add site setup progress handling and API responses for onboarding/steps progress.
- Target: `feat-mahmoud`.

## Merge order
1. **This PR first** (base of the stack)
2. then optional-project-id-property-requests
3. then property-excel-bulk-import-headers
4. then saudi-locations-nzl-sync
5. then customer-create-optional-type-id

## Test plan
- [ ] Hit steps/progress endpoints and confirm progress payload + error responses
- [ ] Smoke onboarding/site setup flow against feat-mahmoud