### PR TITLE
feat: optional project_id on property requests

### DIFF
--- a/app/Exports/PropertiesExport.php
+++ b/app/Exports/PropertiesExport.php
@@ -4,7 +4,9 @@ namespace App\Exports;
 
 use App\Models\User\RealestateManagement\Property;
 use App\Support\PropertyExcelMapping;
+use App\Support\PropertyFilterQuery;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithTitle;
@@ -14,7 +16,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 
-class PropertiesExport implements FromQuery, WithHeadings, WithMapping, WithTitle, WithEvents
+class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, WithMapping, WithTitle, WithEvents
 {
     protected $userId;
     protected $allowedUserIds;
@@ -52,128 +54,14 @@ class PropertiesExport implements FromQuery, WithHeadings, WithMapping, WithTitl
             ])
             ->whereIn('user_id', $this->allowedUserIds);
 
-        // Apply property IDs filter if provided (for selected properties export)
-        if (!empty($this->filters['ids']) && is_array($this->filters['ids']) && count($this->filters['ids']) > 0) {
-            $query->whereIn('id', $this->filters['ids']);
-        }
-
-        // Apply date range filter (optional if IDs are provided)
-        if (!empty($this->filters['date_from'])) {
-            $query->whereDate('created_at', '>=', $this->filters['date_from']);
-        }
-        if (!empty($this->filters['date_to'])) {
-            $query->whereDate('created_at', '<=', $this->filters['date_to']);
-        }
-
-        // Apply purpose filter
-        if (!empty($this->filters['purposes_filter'])) {
-            $query->where('purpose', $this->filters['purposes_filter']);
-        }
-        if (!empty($this->filters['purpose'])) {
-            $query->where('purpose', $this->filters['purpose']);
-        }
-
-        // Apply type filter
-        if (!empty($this->filters['type'])) {
-            $query->where('property_type', $this->filters['type']);
-        }
-
-        // Apply price filters
-        if (!empty($this->filters['price_from'])) {
-            $query->where('price', '>=', $this->filters['price_from']);
-        }
-        if (!empty($this->filters['price_to'])) {
-            $query->where('price', '<=', $this->filters['price_to']);
-        }
-
-        // Apply area filters
-        if (!empty($this->filters['area_from'])) {
-            $query->where('area', '>=', $this->filters['area_from']);
-        }
-        if (!empty($this->filters['area_to'])) {
-            $query->where('area', '<=', $this->filters['area_to']);
-        }
-
-        // Apply beds filter
-        if (!empty($this->filters['beds'])) {
-            $query->where('beds', $this->filters['beds']);
-        }
-
-        // Apply bath filter
-        if (!empty($this->filters['bath'])) {
-            $query->where('bath', $this->filters['bath']);
-        }
-
-        // Apply category filter
-        if (!empty($this->filters['category_id'])) {
-            $query->where('category_id', $this->filters['category_id']);
-        }
-
-        // Apply status filter
-        if (isset($this->filters['status']) && $this->filters['status'] !== '') {
-            $query->where('status', $this->filters['status']);
-        }
-
-        // Apply featured filter
-        if (isset($this->filters['featured']) && $this->filters['featured'] !== '') {
-            $query->where('featured', $this->filters['featured']);
-        }
-
-        // Apply city filter
-        if (!empty($this->filters['city_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('city_id', $this->filters['city_id']);
-            });
-        }
-
-        // Apply district filter
-        if (!empty($this->filters['district_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('state_id', $this->filters['district_id']);
-            });
-        }
-
-        // Apply search filter (title/address, plus numeric property ID)
-        if (!empty($this->filters['search'])) {
-            $search = trim((string) $this->filters['search']);
-            $numericId = $this->parsePositiveIntSearchId($search);
-            $query->where(function ($q) use ($search, $numericId) {
-                $q->whereHas('contents', function ($cq) use ($search) {
-                    $cq->where(function ($inner) use ($search) {
-                        $inner->where('title', 'like', "%{$search}%")
-                              ->orWhere('address', 'like', "%{$search}%");
-                    });
-                });
-                if ($numericId !== null) {
-                    $q->orWhere('id', $numericId);
-                }
-            });
-        }
-
-        // Apply features filter
-        if (!empty($this->filters['features'])) {
-            $featuresArray = explode(',', $this->filters['features']);
-            foreach ($featuresArray as $feature) {
-                $feature = trim($feature);
-                $query->whereJsonContains('features', $feature);
-            }
-        }
+        PropertyFilterQuery::apply($query, $this->filters);
 
         return $query->orderBy('created_at', 'desc');
     }
 
-    private function parsePositiveIntSearchId(?string $searchTerm): ?int
+    public function chunkSize(): int
     {
-        $searchTerm = trim((string) $searchTerm);
-        if ($searchTerm === ''
-            || !ctype_digit($searchTerm)
-            || strlen($searchTerm) > 18
-            || (int) $searchTerm <= 0
-        ) {
-            return null;
-        }
-
-        return (int) $searchTerm;
+        return 500;
     }
 
     public function headings(): array

--- a/app/Exports/PropertiesImportReadyExport.php
+++ b/app/Exports/PropertiesImportReadyExport.php
@@ -5,7 +5,9 @@ namespace App\Exports;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\UserDistrict;
 use App\Support\PropertyExcelMapping;
+use App\Support\PropertyFilterQuery;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
@@ -38,7 +40,7 @@ class PropertiesImportReadyExport implements WithMultipleSheets
     }
 }
 
-class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, WithMapping, WithTitle, WithEvents
+class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReading, WithHeadings, WithMapping, WithTitle, WithEvents
 {
     protected $userId;
     protected $allowedUserIds;
@@ -72,120 +74,14 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
             ])
             ->whereIn('user_id', $this->allowedUserIds);
 
-        // Apply property IDs filter if provided
-        if (!empty($this->filters['ids']) && is_array($this->filters['ids']) && count($this->filters['ids']) > 0) {
-            $query->whereIn('id', $this->filters['ids']);
-        }
-
-        // Apply date range filter
-        if (!empty($this->filters['date_from'])) {
-            $query->whereDate('created_at', '>=', $this->filters['date_from']);
-        }
-        if (!empty($this->filters['date_to'])) {
-            $query->whereDate('created_at', '<=', $this->filters['date_to']);
-        }
-
-        // Apply purpose filter
-        if (!empty($this->filters['purposes_filter'])) {
-            $query->where('purpose', $this->filters['purposes_filter']);
-        }
-        if (!empty($this->filters['purpose'])) {
-            $query->where('purpose', $this->filters['purpose']);
-        }
-
-        // Apply type filter
-        if (!empty($this->filters['type'])) {
-            $query->where('property_type', $this->filters['type']);
-        }
-
-        // Apply price filters
-        if (!empty($this->filters['price_from'])) {
-            $query->where('price', '>=', $this->filters['price_from']);
-        }
-        if (!empty($this->filters['price_to'])) {
-            $query->where('price', '<=', $this->filters['price_to']);
-        }
-
-        // Apply area filters
-        if (!empty($this->filters['area_from'])) {
-            $query->where('area', '>=', $this->filters['area_from']);
-        }
-        if (!empty($this->filters['area_to'])) {
-            $query->where('area', '<=', $this->filters['area_to']);
-        }
-
-        // Apply beds filter
-        if (!empty($this->filters['beds'])) {
-            $query->where('beds', $this->filters['beds']);
-        }
-
-        // Apply bath filter
-        if (!empty($this->filters['bath'])) {
-            $query->where('bath', $this->filters['bath']);
-        }
-
-        // Apply category filter
-        if (!empty($this->filters['category_id'])) {
-            $query->where('category_id', $this->filters['category_id']);
-        }
-
-        // Apply status filter
-        if (isset($this->filters['status']) && $this->filters['status'] !== '') {
-            $query->where('status', $this->filters['status']);
-        }
-
-        // Apply featured filter
-        if (isset($this->filters['featured']) && $this->filters['featured'] !== '') {
-            $query->where('featured', $this->filters['featured']);
-        }
-
-        // Apply city filter
-        if (!empty($this->filters['city_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('city_id', $this->filters['city_id']);
-            });
-        }
-
-        // Apply district filter
-        if (!empty($this->filters['district_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('state_id', $this->filters['district_id']);
-            });
-        }
-
-        // Apply search filter (title/description/address, plus numeric property ID)
-        if (!empty($this->filters['search'])) {
-            $search = trim((string) $this->filters['search']);
-            $numericId = $this->parsePositiveIntSearchId($search);
-            $query->where(function ($q) use ($search, $numericId) {
-                $q->whereHas('contents', function ($cq) use ($search) {
-                    $cq->where(function ($inner) use ($search) {
-                        $inner->where('title', 'like', "%{$search}%")
-                              ->orWhere('description', 'like', "%{$search}%")
-                              ->orWhere('address', 'like', "%{$search}%");
-                    });
-                });
-                if ($numericId !== null) {
-                    $q->orWhere('id', $numericId);
-                }
-            });
-        }
+        PropertyFilterQuery::apply($query, $this->filters);
 
         return $query->orderBy('id', 'desc');
     }
 
-    private function parsePositiveIntSearchId(?string $searchTerm): ?int
+    public function chunkSize(): int
     {
-        $searchTerm = trim((string) $searchTerm);
-        if ($searchTerm === ''
-            || !ctype_digit($searchTerm)
-            || strlen($searchTerm) > 18
-            || (int) $searchTerm <= 0
-        ) {
-            return null;
-        }
-
-        return (int) $searchTerm;
+        return 500;
     }
 
     public function headings(): array
@@ -351,8 +247,17 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
 
     public function registerEvents(): array
     {
+        $cityCount = (int) \App\Models\User\RealestateManagement\City::query()
+            ->distinct()
+            ->count('name_ar');
+        $districtCount = (int) UserDistrict::query()
+            ->distinct()
+            ->count('name_ar');
+        $cityEndRow = max(2, 1 + $cityCount);
+        $districtEndRow = max(2, 1 + $districtCount);
+
         return [
-            AfterSheet::class => function(AfterSheet $event) {
+            AfterSheet::class => function(AfterSheet $event) use ($cityEndRow, $districtEndRow) {
                 $sheet = $event->sheet;
                 $highestRow = $sheet->getHighestRow();
                 $rowCount = min($highestRow, 1000); // Apply validation to first 1000 rows
@@ -413,7 +318,7 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\$500");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\${$cityEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("K$i")->setDataValidation(clone $validation);
@@ -427,7 +332,7 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\$10000");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\${$districtEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("L$i")->setDataValidation(clone $validation);

--- a/app/Exports/PropertiesTemplateExport.php
+++ b/app/Exports/PropertiesTemplateExport.php
@@ -59,7 +59,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 'موقف دراجات,غرفة غسيل',
                 'A-101',
                 '5',
-                '2020',
+                '5',
                 'إطلالة مدينة',
                 'مفروش بالكامل',
                 '2',
@@ -101,7 +101,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 'سونا، جاكوزي',
                 '1',
                 '0',
-                '2018',
+                '8',
                 'إطلالة حديقة',
                 'مفروش جزئياً',
                 '3',
@@ -143,7 +143,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 'غرفة اجتماعات، استقبال',
                 '301',
                 '3',
-                '2019',
+                '12',
                 'إطلالة بحرية',
                 'غير مفروش',
                 '10',
@@ -238,6 +238,12 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
 
                 // Set header row height for better visibility
                 $sheet->getRowDimension(1)->setRowHeight(25);
+
+                // Unit number column (Y) — keep numeric-looking values as text for re-import
+                for ($i = 2; $i <= 4; $i++) {
+                    $cell = $sheet->getCell("Y{$i}");
+                    $cell->setValueExplicit((string) $cell->getValue(), \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                }
 
                 // Purpose Column (E) - "sale,rent"
                 $validation = $sheet->getCell('E2')->getDataValidation();

--- a/app/Exports/PropertiesTemplateExport.php
+++ b/app/Exports/PropertiesTemplateExport.php
@@ -12,6 +12,7 @@ use Maatwebsite\Excel\Concerns\WithTitle;
 
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 
 class PropertiesTemplateExport implements WithMultipleSheets
@@ -214,8 +215,22 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
 
     public function registerEvents(): array
     {
+        $unitNumberColIndex = array_search('رقم الوحدة', $this->headings(), true);
+        $unitNumberCol = $unitNumberColIndex !== false
+            ? Coordinate::stringFromColumnIndex($unitNumberColIndex + 1)
+            : null;
+
+        $cityCount = (int) \App\Models\User\RealestateManagement\City::query()
+            ->distinct()
+            ->count('name_ar');
+        $districtCount = (int) UserDistrict::query()
+            ->distinct()
+            ->count('name_ar');
+        $cityEndRow = max(2, 1 + $cityCount);
+        $districtEndRow = max(2, 1 + $districtCount);
+
         return [
-            AfterSheet::class => function(AfterSheet $event) {
+            AfterSheet::class => function(AfterSheet $event) use ($unitNumberCol, $cityEndRow, $districtEndRow) {
                 $sheet = $event->sheet;
                 $rowCount = 1000; // Apply validation to first 1000 rows
 
@@ -239,10 +254,12 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 // Set header row height for better visibility
                 $sheet->getRowDimension(1)->setRowHeight(25);
 
-                // Unit number column (Y) — keep numeric-looking values as text for re-import
-                for ($i = 2; $i <= 4; $i++) {
-                    $cell = $sheet->getCell("Y{$i}");
-                    $cell->setValueExplicit((string) $cell->getValue(), \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                // Unit number column — keep numeric-looking values as text for re-import
+                if ($unitNumberCol !== null) {
+                    for ($i = 2; $i <= 4; $i++) {
+                        $cell = $sheet->getCell("{$unitNumberCol}{$i}");
+                        $cell->setValueExplicit((string) $cell->getValue(), \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                    }
                 }
 
                 // Purpose Column (E) - "sale,rent"
@@ -281,7 +298,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\$500");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\${$cityEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("J$i")->setDataValidation(clone $validation);
@@ -295,7 +312,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\$10000");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\${$districtEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("K$i")->setDataValidation(clone $validation);

--- a/app/Http/Controllers/Api/AnalyticsDashboardController.php
+++ b/app/Http/Controllers/Api/AnalyticsDashboardController.php
@@ -1260,6 +1260,12 @@ class AnalyticsDashboardController extends Controller
     {
         $data = app(SiteSetupProgressService::class)->getProgress($request->user());
 
+        if ($data === null) {
+            return response()->json([
+                'message' => 'Unable to resolve tenant owner.',
+            ], 403);
+        }
+
         return response()->json($data);
     }
 

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -42,6 +42,7 @@ use App\Models\User\HomePageText;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Api\ApiMenuSetting;
 use App\Services\TempTokenService;
+use App\Services\SiteSetupProgressService;
 use Illuminate\Support\Facades\DB;
 use App\Models\User\UserPermission;
 use App\Services\OnboardingService;
@@ -1115,7 +1116,9 @@ class AuthController extends Controller
                 }
             }
 
-            DB::transaction(function () use ($user, $owner, $validated) {
+            $didCompanyUpdate = false;
+
+            DB::transaction(function () use ($user, $owner, $validated, &$didCompanyUpdate) {
                 $userFields = $this->extractPersonalProfileFields($validated);
 
                 if ($userFields !== []) {
@@ -1130,8 +1133,13 @@ class AuthController extends Controller
 
                 if ($this->hasCompanyFieldUpdates($validated)) {
                     $this->applyCompanyProfileUpdates($owner, $validated);
+                    $didCompanyUpdate = true;
                 }
             });
+
+            if ($didCompanyUpdate && $owner) {
+                app(SiteSetupProgressService::class)->syncContactsSocialInfo($owner);
+            }
 
             CacheInvalidationHelper::clearTenantProfileCachesAuto($ownerId);
 

--- a/app/Http/Controllers/Api/GeneratedApiPathsDoc.php
+++ b/app/Http/Controllers/Api/GeneratedApiPathsDoc.php
@@ -2363,8 +2363,23 @@ namespace App\Http\Controllers\Api;
  *         operationId="get_dashboard_setup_progress_0",
  *         tags={"Dashboard"},
  *         summary="Setup Progress", security={{"sanctum":{}}},
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site"}),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner")
  *     )
  *
  * )
@@ -4178,10 +4193,27 @@ namespace App\Http\Controllers\Api;
  *         tags={"Steps"},
  *         summary="Complete Step", security={{"sanctum":{}}},
  *         @OA\RequestBody(required=true, @OA\JsonContent(type="object", required={"step"},
- *             @OA\Property(property="step", type="string", enum={"banner","footer","homepage_about_update","menu_builder","projects","properties"}),
+ *             @OA\Property(property="step", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site","properties"}),
  *         )),
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="message", type="string", example="Step marked as completed."),
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string"),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner"),
+ *         @OA\Response(response=422, description="Validation error")
  *     )
  *
  * )
@@ -4194,8 +4226,23 @@ namespace App\Http\Controllers\Api;
  *         operationId="get_steps_progress_0",
  *         tags={"Steps"},
  *         summary="Get Steps", security={{"sanctum":{}}},
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site"}),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner")
  *     )
  *
  * )

--- a/app/Http/Controllers/Api/StepProgressController.php
+++ b/app/Http/Controllers/Api/StepProgressController.php
@@ -2,126 +2,54 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Models\UserStep;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\Onboarding\CompleteOnboardingStepRequest;
+use App\Services\SiteSetupProgressService;
+use Illuminate\Http\Request;
 
 class StepProgressController extends Controller
 {
-    /**
-     * Step map configuration - moved to class constant to avoid per-request allocation
-     */
-    private const STEP_MAP = [
-        'banner' => [
-            'path' => '/content/banner',
-            'text' => 'قم بتخصيص البانر الخاص بك',
-        ],
-        'footer' => [
-            'path' => '/content/footer',
-            'text' => 'قم بتخصيص التذييل الخاص بك',
-        ],
-        'homepage_about_update' => [
-            'path' => '/content/about',
-            'text' => 'قم بتحديث قسم من نحن',
-        ],
-        'menu_builder' => [
-            'path' => '/content/menu',
-            'text' => 'قم بإعداد قائمة الموقع',
-        ],
-        'projects' => [
-            'path' => '/projects/add',
-            'text' => 'أضف أول مشروع',
-        ],
-        'properties' => [
-            'path' => '/properties/add',
-            'text' => 'اضف اول عقار الآن',
-        ],
-    ];
+    public function __construct(
+        private readonly SiteSetupProgressService $progressService,
+    ) {}
 
     /**
-     * Display the progress of a specific step for a user.
+     * Display site setup progress for the authenticated user's tenant owner.
      *
-     * @param  Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function getSteps(Request $request)
     {
-        $user = $request->user();
-        
-        // Check if performance optimizations are enabled
-        $useOptimizations = config('performance.enable_api_performance_optimizations');
-        
-        if ($useOptimizations) {
-            // Select only the columns we use to avoid pulling large blobs
-            $stepKeys = array_keys(self::STEP_MAP);
-            $steps = UserStep::select(['user_id', ...$stepKeys])
-                ->firstOrCreate(['user_id' => $user->id], array_fill_keys($stepKeys, false));
-        } else {
-            $steps = UserStep::firstOrCreate(['user_id' => $user->id]);
+        $progress = $this->progressService->getProgress($request->user());
+
+        if ($progress === null) {
+            return response()->json([
+                'message' => 'Unable to resolve tenant owner.',
+            ], 403);
         }
 
-        $stepMap = self::STEP_MAP;
-        $rawData = $steps->only(array_keys($stepMap));
-
-    $stepsWithStatus = [];
-    foreach ($stepMap as $key => $info) {
-        $value = $rawData[$key] ?? null;
-        $stepsWithStatus[$key] = [
-            'status' => $value,
-            'text' => $info['text'],
-        ];
+        return response()->json($progress);
     }
 
-    $progress = collect($stepsWithStatus)->filter(fn($step) => $step['status'])->count();
-    $percentage = intval(($progress / count($stepMap)) * 100);
-
-    $continuePath = collect($stepMap)
-        ->filter(fn($_, $key) => empty($rawData[$key]))
-        ->pluck('path')
-        ->first();
-
-    return response()->json([
-        'steps' => $stepsWithStatus,
-        'progress' => $percentage,
-        'continue_path' => $continuePath,
-    ]);
-}
-
-
+    /**
+     * Mark a setup step complete (owner user_steps write) and return GET-shaped progress.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function completeStep(CompleteOnboardingStepRequest $request)
     {
         $validated = $request->validated();
-        $user = auth()->user();
-        $steps = UserStep::firstOrCreate(['user_id' => $user->id]);
+        $result = $this->progressService->completeStep($request->user(), $validated['step']);
 
-        $steps->{$validated['step']} = true;
-        // Optional: check if all steps are completed now
-        $stepKeys = ['banner', 'footer', 'homepage_about_update', 'menu_builder', 'projects', 'properties'];
-        $remaining = collect($steps->only($stepKeys))->filter(fn ($v) => ! $v);
-
-        if ($remaining->isEmpty() && ! $steps->completed_at) {
-            $steps->completed_at = now();
+        if (! $result['ok']) {
+            return response()->json([
+                'message' => $result['error'] ?? 'Unable to complete step.',
+            ], $result['status'] ?? 422);
         }
 
-        $steps->save();
-
-        $data = $steps->only($stepKeys);
-        $progress = collect($data)->filter(fn ($v) => $v)->count();
-        $percentage = intval(($progress / count($stepKeys)) * 100);
-
-        $continuePath = collect(self::STEP_MAP)
-            ->filter(fn ($_, $key) => empty($data[$key]))
-            ->pluck('path')
-            ->first();
-
-        return response()->json([
-            'message' => 'Step marked as completed.',
-            'steps' => $data,
-            'progress' => $percentage,
-            'continue_path' => $continuePath,
-        ]);
+        return response()->json(array_merge(
+            ['message' => 'Step marked as completed.'],
+            $result['progress']
+        ));
     }
-
-
 }

--- a/app/Http/Controllers/Api/property/ApiPropertyRequestController.php
+++ b/app/Http/Controllers/Api/property/ApiPropertyRequestController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use App\Models\Api\UserPropertyRequest;
 use App\Models\User\UserCity;
 use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\Project;
 use App\Http\Requests\Api\Property\StorePropertyRequestRequest;
 use App\Http\Requests\Api\Property\UpdatePropertyRequestRequest;
 use App\Http\Requests\Api\Property\UpdateStatusPropertyRequestRequest;
@@ -91,6 +92,26 @@ class ApiPropertyRequestController extends Controller
             }
 
             $propertyIds = $validIds;
+        }
+
+        // Ensure provided project_id belongs to the resolved tenant
+        if (array_key_exists('project_id', $data) && $data['project_id'] !== null) {
+            $projectId = (int) $data['project_id'];
+            $owned = Project::query()
+                ->where('user_id', $tenant->id)
+                ->where('id', $projectId)
+                ->exists();
+
+            if (! $owned) {
+                return response()->json([
+                    'message' => 'The selected project ID is invalid or does not belong to this tenant.',
+                    'errors' => [
+                        'project_id' => ['The selected project ID is invalid or unauthorized for this tenant.'],
+                    ],
+                ], 422);
+            }
+
+            $data['project_id'] = $projectId;
         }
 
         if (! empty($data['region'])) {
@@ -192,12 +213,17 @@ class ApiPropertyRequestController extends Controller
      */
     public function storeFromInterest(Request $request): JsonResponse
     {
+        if ($request->has('project_id') && $request->input('project_id') === '') {
+            $request->merge(['project_id' => null]);
+        }
+
         $validated = $request->validate([
             'tenant_username' => 'required|string|max:255',
             'property_id' => 'required|integer|exists:user_properties,id',
             'full_name' => 'required|string|max:255',
             'phone' => 'required|string|max:20',
             'notes' => 'nullable|string|max:1000',
+            'project_id' => 'nullable|integer|exists:user_projects,id',
         ]);
 
         try {
@@ -219,6 +245,30 @@ class ApiPropertyRequestController extends Controller
                 'message' => 'Property not found.',
                 'errors' => ['property_id' => ['Property does not exist or does not belong to this tenant.']],
             ], 404);
+        }
+
+        // Body project_id wins when key present; otherwise inherit from property when set.
+        $projectId = null;
+        if (array_key_exists('project_id', $validated)) {
+            $projectId = $validated['project_id'] !== null ? (int) $validated['project_id'] : null;
+        } elseif (! empty($property->project_id)) {
+            $projectId = (int) $property->project_id;
+        }
+
+        if ($projectId !== null) {
+            $owned = Project::query()
+                ->where('user_id', $tenant->id)
+                ->where('id', $projectId)
+                ->exists();
+
+            if (! $owned) {
+                return response()->json([
+                    'message' => 'The selected project ID is invalid or does not belong to this tenant.',
+                    'errors' => [
+                        'project_id' => ['The selected project ID is invalid or unauthorized for this tenant.'],
+                    ],
+                ], 422);
+            }
         }
 
         $content = $property->contents->first();
@@ -247,6 +297,7 @@ class ApiPropertyRequestController extends Controller
             'initial_property_id' => $property->id,
             'latitude' => $property->latitude,
             'longitude' => $property->longitude,
+            'project_id' => $projectId,
         ];
 
         $data = app(PropertyRequestLocationNormalizer::class)->normalize($data, 'property_interest');

--- a/app/Http/Controllers/Api/property/PropertyController.php
+++ b/app/Http/Controllers/Api/property/PropertyController.php
@@ -32,6 +32,7 @@ use App\Models\User\RealestateManagement\UserPropertyCharacteristic;
 use App\Models\User\RealestateManagement\ApiUserCategory as Category;
 use App\Models\Analytics\AnalyticsDailySummary;
 use App\Support\Audit;
+use App\Support\PropertyFilterQuery;
 use App\Support\SourceBrokerNormalizer;
 use App\Services\GoogleAnalyticsService;
 use App\Services\DatabaseVersionService;
@@ -159,9 +160,6 @@ class PropertyController extends Controller
                     ], 422);
                 }
 
-                // Smart Method: Calculate the exact number of rows with data
-                // This avoids reading thousands of empty rows
-                $filePath = $uploadedFile->getPathname();
                 $fileSize = $uploadedFile->getSize();
 
                 // Check file size (10MB = 10485760 bytes)
@@ -180,15 +178,8 @@ class PropertyController extends Controller
                     ], 422);
                 }
 
-                $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReaderForFile($filePath);
-                $reader->setReadDataOnly(true); // Optimization: Read only data, ignore formatting
-                $spreadsheet = $reader->load($filePath);
-                $worksheet = $spreadsheet->getActiveSheet();
-                $highestRow = $worksheet->getHighestDataRow(); // This gets the last row with actual data
-
-                // Pass the smart limit to the import class
-                // highestRow includes header, so we pass it as the limit
-                $import = new PropertiesImport($user->id, $highestRow);
+                // Fixed generous row limit — avoid a third PhpSpreadsheet pre-read just for getHighestDataRow()
+                $import = new PropertiesImport($user->id, 5000);
 
                 $collection = Excel::toCollection($import, $uploadedFile);
 
@@ -294,8 +285,7 @@ class PropertyController extends Controller
             }
 
             try {
-                // Use the same smart limit for the actual import
-                $import = new PropertiesImport($user->id, $highestRow);
+                $import = new PropertiesImport($user->id, 5000);
                 Excel::import($import, $uploadedFile);
 
                 $failures = $import->sheetImport->failures();
@@ -348,13 +338,18 @@ class PropertyController extends Controller
                     $row = null;
                     $field = null;
 
+                    if ($error instanceof \App\Imports\Exceptions\RowValidationException) {
+                        $field = $error->field;
+                        $row = $error->row;
+                    }
+
                     // Extract row number if present in exception message
-                    if (preg_match('/Row (\d+):/', $message, $matches)) {
+                    if ($row === null && preg_match('/Row (\d+):/', $message, $matches)) {
                         $row = (int)$matches[1];
                     }
 
                     // Try to extract field name from error message
-                    if (preg_match('/Invalid (\w+)/i', $message, $fieldMatches)) {
+                    if ($field === null && preg_match('/Invalid (\w+)/i', $message, $fieldMatches)) {
                         $field = strtolower($fieldMatches[1]);
                     }
 
@@ -596,7 +591,28 @@ class PropertyController extends Controller
 
     public function downloadTemplate()
     {
-        return Excel::download(new \App\Exports\PropertiesTemplateExport, 'properties_import_template.xlsx');
+        try {
+            return Excel::download(new \App\Exports\PropertiesTemplateExport, 'properties_import_template.xlsx');
+        } catch (\Exception $e) {
+            Log::error('Properties import template generation error', [
+                'user_id' => auth()->id(),
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status' => 'error',
+                'code' => 'TEMPLATE_GENERATION_FAILED',
+                'message' => 'Failed to generate import template',
+                'details' => [
+                    'user_id' => auth()->id(),
+                    'error' => config('app.debug')
+                        ? $e->getMessage()
+                        : 'An error occurred while generating the import template. Please try again.',
+                ],
+                'timestamp' => now()->toIso8601String(),
+            ], 500);
+        }
     }
 
 
@@ -3717,112 +3733,7 @@ class PropertyController extends Controller
                   ->orWhere('property_status', '!=', 'rented');
             });
 
-        // Apply property IDs filter if provided
-        if (!empty($filters['ids']) && is_array($filters['ids']) && count($filters['ids']) > 0) {
-            $query->whereIn('id', $filters['ids']);
-        }
-
-        // Apply date range filter
-        if (!empty($filters['date_from'])) {
-            $query->whereDate('created_at', '>=', $filters['date_from']);
-        }
-        if (!empty($filters['date_to'])) {
-            $query->whereDate('created_at', '<=', $filters['date_to']);
-        }
-
-        // Apply purpose filter
-        if (!empty($filters['purposes_filter'])) {
-            $query->where('purpose', $filters['purposes_filter']);
-        }
-        if (!empty($filters['purpose'])) {
-            $query->where('purpose', $filters['purpose']);
-        }
-
-        // Apply property_type filter
-        if (!empty($filters['property_type'])) {
-            $query->where('property_type', $filters['property_type']);
-        }
-
-        // Apply price filters
-        if (!empty($filters['price_from'])) {
-            $query->where('price', '>=', $filters['price_from']);
-        }
-        if (!empty($filters['price_to'])) {
-            $query->where('price', '<=', $filters['price_to']);
-        }
-
-        // Apply area filters
-        if (!empty($filters['area_from'])) {
-            $query->where('area', '>=', $filters['area_from']);
-        }
-        if (!empty($filters['area_to'])) {
-            $query->where('area', '<=', $filters['area_to']);
-        }
-
-        // Apply beds filter
-        if (!empty($filters['beds'])) {
-            $query->where('beds', $filters['beds']);
-        }
-
-        // Apply bath filter
-        if (!empty($filters['bath'])) {
-            $query->where('bath', $filters['bath']);
-        }
-
-        // Apply category filter
-        if (!empty($filters['category_id'])) {
-            $query->where('category_id', $filters['category_id']);
-        }
-
-        // Apply status filter
-        if (isset($filters['status']) && $filters['status'] !== '') {
-            $query->where('status', $filters['status']);
-        }
-
-        // Apply featured filter
-        if (isset($filters['featured']) && $filters['featured'] !== '') {
-            $query->where('featured', $filters['featured']);
-        }
-
-        // Apply city filter
-        if (!empty($filters['city_id'])) {
-            $query->whereHas('contents', function ($q) use ($filters) {
-                $q->where('city_id', $filters['city_id']);
-            });
-        }
-
-        // Apply district filter
-        if (!empty($filters['district_id'])) {
-            $query->whereHas('contents', function ($q) use ($filters) {
-                $q->where('state_id', $filters['district_id']);
-            });
-        }
-
-        // Apply search filter (title/address, plus numeric property ID)
-        if (!empty($filters['search'])) {
-            $search = trim((string) $filters['search']);
-            $numericId = $this->parsePositiveIntSearchId($search);
-            $query->where(function ($q) use ($search, $numericId) {
-                $q->whereHas('contents', function ($cq) use ($search) {
-                    $cq->where(function ($inner) use ($search) {
-                        $inner->where('title', 'like', "%{$search}%")
-                              ->orWhere('address', 'like', "%{$search}%");
-                    });
-                });
-                if ($numericId !== null) {
-                    $q->orWhere('id', $numericId);
-                }
-            });
-        }
-
-        // Apply features filter
-        if (!empty($filters['features'])) {
-            $featuresArray = explode(',', $filters['features']);
-            foreach ($featuresArray as $feature) {
-                $feature = trim($feature);
-                $query->whereJsonContains('features', $feature);
-            }
-        }
+        PropertyFilterQuery::apply($query, $filters);
 
         // Optionally filter out properties with active rentals
         if (method_exists(Property::class, 'rentals')) {

--- a/app/Http/Requests/Api/Onboarding/CompleteOnboardingStepRequest.php
+++ b/app/Http/Requests/Api/Onboarding/CompleteOnboardingStepRequest.php
@@ -14,7 +14,7 @@ class CompleteOnboardingStepRequest extends BaseApiFormRequest
     public function rules()
     {
         return [
-            'step' => 'required|in:banner,footer,homepage_about_update,menu_builder,projects,properties',
+            'step' => 'required|in:site_identity,contact_info,first_property,integrated_link,connect_site,properties',
         ];
     }
 }

--- a/app/Http/Requests/Api/Property/StorePropertyRequestRequest.php
+++ b/app/Http/Requests/Api/Property/StorePropertyRequestRequest.php
@@ -3,11 +3,14 @@
 namespace App\Http\Requests\Api\Property;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Http\Requests\Concerns\ValidatesTenantProjectId;
 use App\Rules\PropertyTypeRule;
 use Illuminate\Validation\Rule;
 
 class StorePropertyRequestRequest extends BaseApiFormRequest
 {
+    use ValidatesTenantProjectId;
+
     public function authorize()
     {
         return true;
@@ -15,6 +18,8 @@ class StorePropertyRequestRequest extends BaseApiFormRequest
 
     protected function prepareForValidation(): void
     {
+        $this->normalizeNullableProjectId();
+
         if ($this->has('property_type')) {
             $normalized = PropertyTypeRule::normalize(is_string($this->input('property_type')) ? $this->input('property_type') : null);
             if ($normalized !== null) {
@@ -31,6 +36,8 @@ class StorePropertyRequestRequest extends BaseApiFormRequest
             'phone' => 'required|string|max:20',
             'property_ids' => 'nullable|array',
             'property_ids.*' => 'integer|exists:user_properties,id',
+            // Ownership checked in controller after tenant resolve (public may have no auth).
+            'project_id' => 'nullable|integer|exists:user_projects,id',
             'source' => ['nullable', 'string', Rule::in([
                 'property_interest',
                 'public_form',

--- a/app/Http/Requests/Api/Property/UpdatePropertyRequestRequest.php
+++ b/app/Http/Requests/Api/Property/UpdatePropertyRequestRequest.php
@@ -3,11 +3,14 @@
 namespace App\Http\Requests\Api\Property;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Http\Requests\Concerns\ValidatesTenantProjectId;
 use App\Rules\PropertyTypeRule;
 use Illuminate\Validation\Rule;
 
 class UpdatePropertyRequestRequest extends BaseApiFormRequest
 {
+    use ValidatesTenantProjectId;
+
     public function authorize()
     {
         return true;
@@ -15,6 +18,8 @@ class UpdatePropertyRequestRequest extends BaseApiFormRequest
 
     protected function prepareForValidation(): void
     {
+        $this->normalizeNullableProjectId();
+
         if ($this->has('property_type')) {
             $normalized = PropertyTypeRule::normalize(is_string($this->input('property_type')) ? $this->input('property_type') : null);
             if ($normalized !== null) {
@@ -30,7 +35,7 @@ class UpdatePropertyRequestRequest extends BaseApiFormRequest
             ? (int) $user->tenantOwnerId()
             : (int) ($user->id ?? 0);
 
-        return [
+        return array_merge([
             'status_id' => ['nullable', 'integer', 'exists:property_request_statuses,id'],
             'full_name' => ['nullable', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20'],
@@ -94,6 +99,6 @@ class UpdatePropertyRequestRequest extends BaseApiFormRequest
             'referral_source' => ['nullable', 'string', 'max:255'],
             'detected_entities_json' => ['nullable', 'array'],
             'notes' => ['nullable', 'string', 'max:5000'],
-        ];
+        ], $this->tenantProjectIdRules(sometimes: true));
     }
 }

--- a/app/Http/Requests/Api/V2/CustomersHub/CompleteDataRequest.php
+++ b/app/Http/Requests/Api/V2/CustomersHub/CompleteDataRequest.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Requests\Api\V2\CustomersHub;
 
+use App\Http\Requests\Concerns\ValidatesTenantProjectId;
 use App\Rules\PropertyTypeRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CompleteDataRequest extends FormRequest
 {
+    use ValidatesTenantProjectId;
+
     public function authorize(): bool
     {
         return true;
@@ -14,6 +17,8 @@ class CompleteDataRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        $this->normalizeNullableProjectId();
+
         if ($this->has('property_type')) {
             $normalized = \App\Rules\PropertyTypeRule::normalize(is_string($this->input('property_type')) ? $this->input('property_type') : null);
             if ($normalized !== null) {
@@ -24,7 +29,7 @@ class CompleteDataRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
+        return array_merge([
             'property_type'  => ['sometimes', ...PropertyTypeRule::nullableRule()],
             'purpose'        => ['sometimes', 'nullable', 'string', 'in:rent,sale,buy,invest'],
             'city'           => ['sometimes', 'nullable', 'string', 'max:255'],
@@ -41,7 +46,7 @@ class CompleteDataRequest extends FormRequest
             'area_to'        => ['sometimes', 'nullable', 'integer', 'min:0'],
             'latitude'       => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
             'longitude'      => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
-        ];
+        ], $this->tenantProjectIdRules(sometimes: true));
     }
 
     /**

--- a/app/Imports/Exceptions/RowValidationException.php
+++ b/app/Imports/Exceptions/RowValidationException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Imports\Exceptions;
+
+class RowValidationException extends \Exception
+{
+    public function __construct(
+        string $message,
+        public readonly ?string $field = null,
+        public readonly ?int $row = null,
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -131,14 +131,48 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     }
 
     /**
-     * Normalize row keys: map Arabic headers to English, keep existing English keys.
+     * Arabic + Maatwebsite-slugified Arabic headers → English keys.
+     * With heading_row.formatter = slug, Maatwebsite uses Str::slug($header, '_'),
+     * so "عنوان الإعلان" arrives as "aanoan_alaaalan".
+     *
+     * @return array<string, string>
+     */
+    private static function headerKeyMap(): array
+    {
+        static $map = null;
+        if ($map !== null) {
+            return $map;
+        }
+
+        $map = [];
+        foreach (self::arabicHeaderToKey() as $arabic => $english) {
+            $map[$arabic] = $english;
+
+            $arabicSlug = Str::slug($arabic, '_');
+            if ($arabicSlug !== '') {
+                $map[$arabicSlug] = $english;
+            }
+
+            // English keys that contain Arabic (e.g. amenity_مصعد) are also slugified
+            $englishSlug = Str::slug($english, '_');
+            if ($englishSlug !== '' && $englishSlug !== $english) {
+                $map[$englishSlug] = $english;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Normalize row keys: map Arabic / slugified Arabic headers to English, keep existing English keys.
      */
     private function normalizeRowKeys(array $row): array
     {
-        $map = self::arabicHeaderToKey();
+        $map = self::headerKeyMap();
         $out = [];
         foreach ($row as $header => $value) {
-            $key = $map[$header] ?? $header;
+            $headerStr = is_string($header) ? $header : (string) $header;
+            $key = $map[$headerStr] ?? $headerStr;
             $out[$key] = $value;
         }
         return $out;
@@ -1042,14 +1076,14 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             'video_url'   => 'nullable|url|max:500',
             'virtual_tour' => 'nullable|url|max:500',
             'gallery_images' => 'nullable|string',
-            'amenity_مصعد' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_أمن' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_كاميرات_مراقبة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_تكييف_مركزي' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_تدفئة_مركزية' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_صيانة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_بواب' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_إنترنت' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
+            'amenity_مصعد' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_أمن' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_كاميرات_مراقبة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_تكييف_مركزي' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_تدفئة_مركزية' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_صيانة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_بواب' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_إنترنت' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
             'additional_amenities' => 'nullable|string|max:1000',
             'unit_number' => 'nullable|string|max:50',
             'floor_number' => 'nullable|integer|min:0|max:200',
@@ -1083,15 +1117,31 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     }
 
     /**
-     * Prepare data for validation - skip empty rows before validation runs
+     * Prepare data for validation - remap slug/Arabic headers and map purpose/type
+     * so WithValidation rules see English keys and DB enum values.
      */
     public function prepareForValidation($data, $index)
     {
+        $data = $this->normalizeRowKeys(is_array($data) ? $data : (array) $data);
+
+        if (array_key_exists('purpose', $data)) {
+            $mapped = PropertyExcelMapping::purposeToDb($data['purpose']);
+            if ($mapped !== null) {
+                $data['purpose'] = $mapped;
+            }
+        }
+        if (array_key_exists('type', $data)) {
+            $mapped = PropertyExcelMapping::typeToDb($data['type']);
+            if ($mapped !== null) {
+                $data['type'] = $mapped;
+            }
+        }
+
         // Check if row is completely empty (all values are null or empty)
-        $hasData = !empty(array_filter($data, function($value) {
+        $hasData = !empty(array_filter($data, function ($value) {
             return !is_null($value) && $value !== '';
         }));
-        
+
         // If row is completely empty, add a special marker to skip it
         if (!$hasData) {
             // Add required fields with dummy values to pass validation
@@ -1106,7 +1156,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             $data['type'] = 'residential';
             $data['area'] = 0;
         }
-        
+
         return $data;
     }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -2,6 +2,7 @@
 
 namespace App\Imports;
 
+use App\Imports\Exceptions\RowValidationException;
 use App\Models\User\RealestateManagement\Amenity;
 use App\Models\User\RealestateManagement\City;
 use App\Models\User\RealestateManagement\Property;
@@ -26,6 +27,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithValidation, SkipsOnFailure, SkipsOnError, WithLimit
 {
@@ -127,6 +129,13 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             'مميز' => 'featured',
             'مميزات' => 'features',
             'المعرّف' => 'id',
+            // Raw PropertiesExport-only headers (mapped so reject logic can detect them)
+            'معرّف المستخدم' => 'user_id',
+            'اسم المستخدم' => 'user_name',
+            'أنشئ بواسطة' => 'created_by',
+            'اسم المنشئ' => 'creator_name',
+            'تاريخ الإنشاء' => 'created_at',
+            'تاريخ التحديث' => 'updated_at',
         ];
     }
 
@@ -163,6 +172,26 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         return $map;
     }
 
+    /**
+     * Detect PropertiesExport (raw) rows that must not be imported.
+     *
+     * @param  array<string, mixed>  $row
+     */
+    private function isRawExportRow(array $row): bool
+    {
+        if (array_key_exists('id', $row) && array_key_exists('created_at', $row) && array_key_exists('user_id', $row)) {
+            return true;
+        }
+
+        $exportOnlyColumns = ['slug', 'user_id', 'user_name', 'created_by', 'creator_name', 'created_at', 'updated_at'];
+        foreach ($exportOnlyColumns as $col) {
+            if (array_key_exists($col, $row) && $this->valueProvided($row[$col])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
     /**
      * Normalize row keys: map Arabic / slugified Arabic headers to English, keep existing English keys.
      */
@@ -346,19 +375,27 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         // Validate featured image URL format
         if (!empty($row['featured_image'])) {
             if (!$this->validateImageUrl($row['featured_image'])) {
-                throw new \Exception("Row {$rowIndex}: Invalid featured_image URL format. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid featured_image URL format. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).",
+                    field: 'featured_image',
+                    row: $rowIndex
+                );
             }
         }
 
         // Validate gallery image URLs
         foreach ($galleryImages as $galleryUrl) {
             if (!$this->validateImageUrl($galleryUrl)) {
-                throw new \Exception("Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).",
+                    field: 'gallery_images',
+                    row: $rowIndex
+                );
             }
         }
 
         // Business rule validation (after determining if it's an update)
-        $this->validateBusinessRules($row, $rowIndex, $isUpdate);
+        $businessViolations = $this->validateBusinessRules($row, $rowIndex, $isUpdate);
 
         // Check for missing required fields (only for new properties, not updates)
         $missingFields = [];
@@ -366,6 +403,22 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         
         // Add location validation errors
         $validationErrors = array_merge($validationErrors, $locationValidationErrors);
+
+        // Soft-fail business rules for creates; hard-fail for updates
+        if ($isUpdate && !empty($businessViolations)) {
+            $first = $businessViolations[0];
+            throw new RowValidationException(
+                "Row {$rowIndex}: {$first['message']}",
+                field: $first['field'],
+                row: $rowIndex
+            );
+        }
+        if (!$isUpdate && !empty($businessViolations)) {
+            $validationErrors = array_merge(
+                $validationErrors,
+                array_column($businessViolations, 'message')
+            );
+        }
         
         if (!$isUpdate) {
             $requiredFields = [
@@ -473,45 +526,21 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 // Replace gallery images (delete existing, add new)
                 if (isset($row['gallery_images'])) {
                     PropertySliderImg::where('property_id', $property->id)->delete();
-                    if (is_array($galleryImages)) {
-                        foreach ($galleryImages as $galleryUrl) {
-                            try {
-                                PropertySliderImg::storeSliderImage($this->userId, $property->id, $galleryUrl);
-                            } catch (\Exception $e) {
-                                Log::error("Row {$rowIndex}: Failed to store gallery image", [
-                                    'url' => $galleryUrl,
-                                    'error' => $e->getMessage()
-                                ]);
-                                throw new \Exception("Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}");
-                            }
-                        }
+                    if (is_array($galleryImages) && !empty($galleryImages)) {
+                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
                     }
                 }
 
                 // Replace amenities (delete existing, add new)
                 PropertyAmenity::where('property_id', $property->id)->delete();
                 if (!empty($amenityIds)) {
-                    foreach ($amenityIds as $amenityId) {
-                        PropertyAmenity::sotreAmenity($this->userId, $property->id, $amenityId);
-                    }
+                    $this->bulkInsertAmenities($property->id, $amenityIds);
                 }
 
                 // Replace specifications (delete existing, add new)
                 PropertySpecification::where('property_id', $property->id)->delete();
                 if (is_array($specifications) && !empty($specifications)) {
-                    $specIndex = 0;
-                    foreach ($specifications as $spec) {
-                        if (!is_array($spec)) {
-                            continue; // Skip invalid entries
-                        }
-                        $specData = [
-                            'language_id' => $this->defaultLanguageId,
-                            'key' => $specIndex++,
-                            'label' => $spec['label'] ?? $spec['key'] ?? '',
-                            'value' => $spec['value'] ?? '',
-                        ];
-                        PropertySpecification::storeSpecification($this->userId, $property->id, $specData);
-                    }
+                    $this->bulkInsertSpecifications($property->id, $specifications);
                 }
 
                 // Update characteristics if provided
@@ -582,41 +611,18 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     }
 
                     // Process gallery images if provided
-                    if (is_array($galleryImages)) {
-                        foreach ($galleryImages as $galleryUrl) {
-                            try {
-                                PropertySliderImg::storeSliderImage($this->userId, $property->id, $galleryUrl);
-                            } catch (\Exception $e) {
-                                Log::warning("Row {$rowIndex}: Failed to store gallery image for incomplete property", [
-                                    'url' => $galleryUrl,
-                                    'error' => $e->getMessage()
-                                ]);
-                            }
-                        }
+                    if (is_array($galleryImages) && !empty($galleryImages)) {
+                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
                     }
 
                     // Process amenities if provided
                     if (!empty($amenityIds) && is_array($amenityIds)) {
-                        foreach ($amenityIds as $amenityId) {
-                            PropertyAmenity::sotreAmenity($this->userId, $property->id, $amenityId);
-                        }
+                        $this->bulkInsertAmenities($property->id, $amenityIds);
                     }
 
                     // Process specifications if provided
                     if (is_array($specifications) && !empty($specifications)) {
-                        $specIndex = 0;
-                        foreach ($specifications as $spec) {
-                            if (!is_array($spec)) {
-                                continue; // Skip invalid spec entries
-                            }
-                            $specData = [
-                                'language_id' => $this->defaultLanguageId,
-                                'key' => $specIndex++,
-                                'label' => $spec['label'] ?? $spec['key'] ?? '',
-                                'value' => $spec['value'] ?? '',
-                            ];
-                            PropertySpecification::storeSpecification($this->userId, $property->id, $specData);
-                        }
+                        $this->bulkInsertSpecifications($property->id, $specifications);
                     }
 
                     // Create characteristics if provided
@@ -680,42 +686,18 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
 
                     // Process gallery images
-                    if (is_array($galleryImages)) {
-                        foreach ($galleryImages as $galleryUrl) {
-                            try {
-                                PropertySliderImg::storeSliderImage($this->userId, $property->id, $galleryUrl);
-                            } catch (\Exception $e) {
-                                Log::error("Row {$rowIndex}: Failed to store gallery image", [
-                                    'url' => $galleryUrl,
-                                    'error' => $e->getMessage()
-                                ]);
-                                throw new \Exception("Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}");
-                            }
-                        }
+                    if (is_array($galleryImages) && !empty($galleryImages)) {
+                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
                     }
 
                     // Process amenities (no validation - same as API store method)
                     if (!empty($amenityIds) && is_array($amenityIds)) {
-                        foreach ($amenityIds as $amenityId) {
-                            PropertyAmenity::sotreAmenity($this->userId, $property->id, $amenityId);
-                        }
+                        $this->bulkInsertAmenities($property->id, $amenityIds);
                     }
 
                     // Process specifications (use integer keys matching API behavior)
                     if (is_array($specifications) && !empty($specifications)) {
-                        $specIndex = 0; // Counter for integer keys (matching API store method)
-                        foreach ($specifications as $spec) {
-                            if (!is_array($spec)) {
-                                continue; // Skip invalid entries
-                            }
-                            $specData = [
-                                'language_id' => $this->defaultLanguageId,
-                                'key' => $specIndex++, // Use integer counter instead of string key (matching API)
-                                'label' => $spec['label'] ?? $spec['key'] ?? '',
-                                'value' => $spec['value'] ?? '',
-                            ];
-                            PropertySpecification::storeSpecification($this->userId, $property->id, $specData);
-                        }
+                        $this->bulkInsertSpecifications($property->id, $specifications);
                     }
 
                     // Create characteristics if provided
@@ -1097,7 +1079,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         // Note: Fields are intentionally NOT required here to allow incomplete properties
         // Custom validation in onRow() determines completeness and creates incomplete properties if needed
         return [
-            'id'          => 'nullable|integer|exists:user_properties,id',
+            'id' => [
+                'nullable',
+                'integer',
+                Rule::exists('user_properties', 'id')->where('user_id', $this->userId),
+            ],
             'title'       => 'nullable|string|max:255',
             'price'       => 'nullable|numeric|min:0',
             'price_per_meter' => 'nullable|numeric|min:0',
@@ -1161,6 +1147,33 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
      * Prepare data for validation - remap slug/Arabic headers and map purpose/type
      * so WithValidation rules see English keys and DB enum values.
      */
+        public function customValidationMessages(): array
+    {
+        return [
+            '_raw_export.prohibited' => 'Invalid file format. It appears you are trying to import a raw Export file which is not supported. Please copy your data into the official Import Template.',
+        ];
+    }
+
+    /**
+     * @param  \Illuminate\Validation\Validator  $validator
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            foreach ($validator->getData() as $rowIndex => $row) {
+                if (!is_array($row)) {
+                    continue;
+                }
+                // Marker set in prepareForValidation for raw PropertiesExport rows
+                if (($row['_raw_export'] ?? null) === '1') {
+                    $validator->errors()->add(
+                        $rowIndex . '._raw_export',
+                        "Row {$rowIndex}: Invalid file format. It appears you are trying to import a raw Export file which is not supported. Please copy your data into the official Import Template."
+                    );
+                }
+            }
+        });
+    }
     public function prepareForValidation($data, $index)
     {
         $data = $this->normalizeRowKeys(is_array($data) ? $data : (array) $data);
@@ -1179,6 +1192,14 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         $data = $this->castStringFieldsForValidation($data);
+
+        // Raw-export files map id + export-only columns (user_id, created_at, …).
+        // WithValidation runs before onRow(), and OnEachRow does not swallow exceptions
+        // via SkipsOnError — so reject through validation (see withValidator) instead of throwing.
+        if ($this->isRawExportRow($data)) {
+            unset($data['id']);
+            $data['_raw_export'] = '1';
+        }
 
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {
@@ -1214,19 +1235,31 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if ($this->valueProvided($cityIdRaw)) {
             $cityId = $this->resolveCityId($cityIdRaw, $rowIndex);
             if (!$cityId) {
-                throw new \Exception("Row {$rowIndex}: Invalid city_id: {$cityIdRaw}. Please use a valid ID or leave it blank and fill city_name.");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid city_id: {$cityIdRaw}. Please use a valid ID or leave it blank and fill city_name.",
+                    field: 'city_id',
+                    row: $rowIndex
+                );
             }
 
             if ($this->valueProvided($cityNameRaw)) {
                 $cityNameId = $this->resolveCityId($cityNameRaw, $rowIndex);
                 if ($cityNameId && $cityNameId !== $cityId) {
-                    throw new \Exception("Row {$rowIndex}: city_id ({$cityIdRaw}) does not match city_name ({$cityNameRaw}).");
+                    throw new RowValidationException(
+                        "Row {$rowIndex}: city_id ({$cityIdRaw}) does not match city_name ({$cityNameRaw}).",
+                        field: 'city_id',
+                        row: $rowIndex
+                    );
                 }
             }
         } elseif ($this->valueProvided($cityNameRaw)) {
             $cityId = $this->resolveCityId($cityNameRaw, $rowIndex);
             if (!$cityId) {
-                throw new \Exception("Row {$rowIndex}: Unable to find a city named '{$cityNameRaw}'. Please copy a value from the reference sheet.");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Unable to find a city named '{$cityNameRaw}'. Please copy a value from the reference sheet.",
+                    field: 'city_id',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1236,13 +1269,21 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if ($this->valueProvided($stateIdRaw)) {
             $stateId = $this->resolveDistrictId($stateIdRaw, $cityId, $rowIndex);
             if (!$stateId) {
-                throw new \Exception("Row {$rowIndex}: Invalid state_id: {$stateIdRaw}. Please use a valid ID or leave it blank and fill district_name.");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid state_id: {$stateIdRaw}. Please use a valid ID or leave it blank and fill district_name.",
+                    field: 'state_id',
+                    row: $rowIndex
+                );
             }
 
             if ($this->valueProvided($districtNameRaw)) {
                 $districtNameId = $this->resolveDistrictId($districtNameRaw, $cityId, $rowIndex);
                 if ($districtNameId && $districtNameId !== $stateId) {
-                    throw new \Exception("Row {$rowIndex}: state_id ({$stateIdRaw}) does not match district_name ({$districtNameRaw}).");
+                    throw new RowValidationException(
+                        "Row {$rowIndex}: state_id ({$stateIdRaw}) does not match district_name ({$districtNameRaw}).",
+                        field: 'state_id',
+                        row: $rowIndex
+                    );
                 }
             }
         } elseif ($this->valueProvided($districtNameRaw)) {
@@ -1307,7 +1348,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-        throw new \Exception("{$prefix}Multiple cities share the name '{$value}'. Please use city_id to specify the correct city.");
+        throw new RowValidationException(
+            "{$prefix}Multiple cities share the name '{$value}'. Please use city_id to specify the correct city.",
+            field: 'city_id',
+            row: $rowIndex
+        );
     }
 
     protected function resolveDistrictId($value, ?int $cityId = null, ?int $rowIndex = null): ?int
@@ -1330,7 +1375,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 $districtCityId = $this->getDistrictCityMapping($id);
                 if ($districtCityId !== $cityId) {
                     $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-                    throw new \Exception("{$prefix}District ID {$id} does not belong to the specified city (city_id: {$cityId}). The district belongs to city_id: {$districtCityId}.");
+                    throw new RowValidationException(
+                        "{$prefix}District ID {$id} does not belong to the specified city (city_id: {$cityId}). The district belongs to city_id: {$districtCityId}.",
+                        field: 'state_id',
+                        row: $rowIndex
+                    );
                 }
             }
             
@@ -1373,7 +1422,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
 
             if (count($cityMatches) > 1) {
                 $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-                throw new \Exception("{$prefix}Multiple districts named '{$value}' exist within the selected city. Please use state_id to specify the correct district.");
+                throw new RowValidationException(
+                    "{$prefix}Multiple districts named '{$value}' exist within the selected city. Please use state_id to specify the correct district.",
+                    field: 'state_id',
+                    row: $rowIndex
+                );
             }
 
             // If city is specified but no district found in that city, return null
@@ -1412,7 +1465,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-        throw new \Exception("{$prefix}Multiple districts share the name '{$value}'. Please specify city_id/state_id for clarity.");
+        throw new RowValidationException(
+            "{$prefix}Multiple districts share the name '{$value}'. Please specify city_id/state_id for clarity.",
+            field: 'state_id',
+            row: $rowIndex
+        );
     }
 
     /**
@@ -1542,29 +1599,39 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     }
 
     /**
-     * Validate business rules for property data
-     * 
+     * Validate business rules for property data.
+     * Soft-fail fields return violation entries; hard-fail fields throw RowValidationException.
+     *
      * @param array $row Row data
      * @param int $rowIndex Row index
      * @param bool $isUpdate Whether this is an update operation
-     * @return void
-     * @throws \Exception If business rule validation fails
+     * @return array<int, array{field: string, message: string}>
+     * @throws RowValidationException
      */
-    protected function validateBusinessRules(array $row, int $rowIndex, bool $isUpdate): void
+    protected function validateBusinessRules(array $row, int $rowIndex, bool $isUpdate): array
     {
+        $violations = [];
+
         // Validate price (must be positive if provided)
         if (isset($row['price']) && $this->valueProvided($row['price'])) {
             $price = is_numeric($row['price']) ? (float)$row['price'] : null;
             if ($price === null || $price < 0) {
-                throw new \Exception("Row {$rowIndex}: The price must be a positive number. Provided: {$row['price']}");
+                $violations[] = [
+                    'field' => 'price',
+                    'message' => "The price must be a positive number. Provided: {$row['price']}",
+                ];
             }
         }
 
-        // Validate price_per_meter (must be positive if provided)
+        // Validate price_per_meter (must be positive if provided) — hard-fail
         if (isset($row['price_per_meter']) && $this->valueProvided($row['price_per_meter'])) {
             $pricePerMeter = is_numeric($row['price_per_meter']) ? (float)$row['price_per_meter'] : null;
             if ($pricePerMeter === null || $pricePerMeter < 0) {
-                throw new \Exception("Row {$rowIndex}: The price_per_meter must be a positive number. Provided: {$row['price_per_meter']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The price_per_meter must be a positive number. Provided: {$row['price_per_meter']}",
+                    field: 'price_per_meter',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1572,15 +1639,22 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['area']) && $this->valueProvided($row['area'])) {
             $area = is_numeric($row['area']) ? (float)$row['area'] : null;
             if ($area === null || $area <= 0) {
-                throw new \Exception("Row {$rowIndex}: The area must be a positive number greater than 0. Provided: {$row['area']}");
+                $violations[] = [
+                    'field' => 'area',
+                    'message' => "The area must be a positive number greater than 0. Provided: {$row['area']}",
+                ];
             }
         }
 
-        // Validate size (must be positive if provided)
+        // Validate size (must be positive if provided) — hard-fail
         if (isset($row['size']) && $this->valueProvided($row['size'])) {
             $size = is_numeric($row['size']) ? (float)$row['size'] : null;
             if ($size === null || $size < 0) {
-                throw new \Exception("Row {$rowIndex}: The size must be a positive number. Provided: {$row['size']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The size must be a positive number. Provided: {$row['size']}",
+                    field: 'size',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1588,7 +1662,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['beds']) && $this->valueProvided($row['beds'])) {
             $beds = is_numeric($row['beds']) ? (int)$row['beds'] : null;
             if ($beds === null || $beds < 0 || $beds > 50) {
-                throw new \Exception("Row {$rowIndex}: The beds must be a non-negative integer between 0 and 50. Provided: {$row['beds']}");
+                $violations[] = [
+                    'field' => 'beds',
+                    'message' => "The beds must be a non-negative integer between 0 and 50. Provided: {$row['beds']}",
+                ];
             }
         }
 
@@ -1596,23 +1673,34 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['bath']) && $this->valueProvided($row['bath'])) {
             $bath = is_numeric($row['bath']) ? (int)$row['bath'] : null;
             if ($bath === null || $bath < 0 || $bath > 50) {
-                throw new \Exception("Row {$rowIndex}: The bath must be a non-negative integer between 0 and 50. Provided: {$row['bath']}");
+                $violations[] = [
+                    'field' => 'bath',
+                    'message' => "The bath must be a non-negative integer between 0 and 50. Provided: {$row['bath']}",
+                ];
             }
         }
 
-        // Validate latitude if provided
+        // Validate latitude if provided — hard-fail
         if (isset($row['latitude']) && $this->valueProvided($row['latitude'])) {
             $latitude = is_numeric($row['latitude']) ? (float)$row['latitude'] : null;
             if ($latitude === null || $latitude < -90 || $latitude > 90) {
-                throw new \Exception("Row {$rowIndex}: The latitude must be a number between -90 and 90. Provided: {$row['latitude']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The latitude must be a number between -90 and 90. Provided: {$row['latitude']}",
+                    field: 'latitude',
+                    row: $rowIndex
+                );
             }
         }
 
-        // Validate longitude if provided
+        // Validate longitude if provided — hard-fail
         if (isset($row['longitude']) && $this->valueProvided($row['longitude'])) {
             $longitude = is_numeric($row['longitude']) ? (float)$row['longitude'] : null;
             if ($longitude === null || $longitude < -180 || $longitude > 180) {
-                throw new \Exception("Row {$rowIndex}: The longitude must be a number between -180 and 180. Provided: {$row['longitude']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The longitude must be a number between -180 and 180. Provided: {$row['longitude']}",
+                    field: 'longitude',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1620,10 +1708,15 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['title']) && $this->valueProvided($row['title'])) {
             $titleLength = mb_strlen(trim($row['title']));
             if ($titleLength < 3) {
-                throw new \Exception("Row {$rowIndex}: The title must be at least 3 characters long. Provided length: {$titleLength}");
-            }
-            if ($titleLength > 255) {
-                throw new \Exception("Row {$rowIndex}: The title must not exceed 255 characters. Provided length: {$titleLength}");
+                $violations[] = [
+                    'field' => 'title',
+                    'message' => "The title must be at least 3 characters long. Provided length: {$titleLength}",
+                ];
+            } elseif ($titleLength > 255) {
+                $violations[] = [
+                    'field' => 'title',
+                    'message' => "The title must not exceed 255 characters. Provided length: {$titleLength}",
+                ];
             }
         }
 
@@ -1631,7 +1724,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['description']) && $this->valueProvided($row['description'])) {
             $descriptionLength = mb_strlen(trim($row['description']));
             if ($descriptionLength < 10) {
-                throw new \Exception("Row {$rowIndex}: The description must be at least 10 characters long. Provided length: {$descriptionLength}");
+                $violations[] = [
+                    'field' => 'description',
+                    'message' => "The description must be at least 10 characters long. Provided length: {$descriptionLength}",
+                ];
             }
         }
 
@@ -1639,10 +1735,15 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['address']) && $this->valueProvided($row['address'])) {
             $addressLength = mb_strlen(trim($row['address']));
             if ($addressLength < 5) {
-                throw new \Exception("Row {$rowIndex}: The address must be at least 5 characters long. Provided length: {$addressLength}");
-            }
-            if ($addressLength > 500) {
-                throw new \Exception("Row {$rowIndex}: The address must not exceed 500 characters. Provided length: {$addressLength}");
+                $violations[] = [
+                    'field' => 'address',
+                    'message' => "The address must be at least 5 characters long. Provided length: {$addressLength}",
+                ];
+            } elseif ($addressLength > 500) {
+                $violations[] = [
+                    'field' => 'address',
+                    'message' => "The address must not exceed 500 characters. Provided length: {$addressLength}",
+                ];
             }
         }
 
@@ -1650,7 +1751,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['purpose']) && $this->valueProvided($row['purpose'])) {
             $purpose = strtolower(trim($row['purpose']));
             if (!in_array($purpose, ['sale', 'rent'])) {
-                throw new \Exception("Row {$rowIndex}: The purpose must be either 'sale' or 'rent'. Provided: {$row['purpose']}");
+                $violations[] = [
+                    'field' => 'purpose',
+                    'message' => "The purpose must be either 'sale' or 'rent'. Provided: {$row['purpose']}",
+                ];
             }
         }
 
@@ -1658,8 +1762,90 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['type']) && $this->valueProvided($row['type'])) {
             $type = strtolower(trim($row['type']));
             if (!in_array($type, ['residential', 'commercial'])) {
-                throw new \Exception("Row {$rowIndex}: The type must be either 'residential' or 'commercial'. Provided: {$row['type']}");
+                $violations[] = [
+                    'field' => 'type',
+                    'message' => "The type must be either 'residential' or 'commercial'. Provided: {$row['type']}",
+                ];
             }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Bulk-insert gallery slider images for a property (N+1 fix).
+     */
+    protected function bulkInsertGalleryImages(int $propertyId, array $galleryImages): void
+    {
+        $now = now();
+        $rows = [];
+        foreach ($galleryImages as $galleryUrl) {
+            if ($galleryUrl === null || $galleryUrl === '') {
+                continue;
+            }
+            $rows[] = [
+                'user_id' => $this->userId,
+                'property_id' => $propertyId,
+                'image' => $galleryUrl,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if (!empty($rows)) {
+            PropertySliderImg::insert($rows);
+        }
+    }
+
+    /**
+     * Bulk-insert amenity pivots for a property (N+1 fix).
+     * Inlined because PropertyAmenity::sotreAmenity only supports single create().
+     */
+    protected function bulkInsertAmenities(int $propertyId, array $amenityIds): void
+    {
+        $now = now();
+        $rows = [];
+        foreach ($amenityIds as $amenityId) {
+            if ($amenityId === null || $amenityId === '') {
+                continue;
+            }
+            $rows[] = [
+                'user_id' => $this->userId,
+                'property_id' => $propertyId,
+                'amenity_id' => $amenityId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if (!empty($rows)) {
+            PropertyAmenity::insert($rows);
+        }
+    }
+
+    /**
+     * Bulk-insert specifications for a property (N+1 fix).
+     */
+    protected function bulkInsertSpecifications(int $propertyId, array $specifications): void
+    {
+        $now = now();
+        $rows = [];
+        $specIndex = 0;
+        foreach ($specifications as $spec) {
+            if (!is_array($spec)) {
+                continue;
+            }
+            $rows[] = [
+                'user_id' => $this->userId,
+                'property_id' => $propertyId,
+                'language_id' => $this->defaultLanguageId,
+                'key' => $specIndex++,
+                'label' => $spec['label'] ?? $spec['key'] ?? '',
+                'value' => $spec['value'] ?? '',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if (!empty($rows)) {
+            PropertySpecification::insert($rows);
         }
     }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -505,6 +505,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 $property->updateProperty($propertyData);
 
                 // Update Property Content
+                // Capture the existing content BEFORE it's deleted below, so fields not
+                // present in this import row (e.g. meta_keyword/meta_description, which
+                // the import template never carries) are preserved instead of wiped.
+                $existingContent = PropertyContent::where('property_id', $property->id)->first();
+
                 $contentData = [];
                 if (isset($row['title'])) $contentData['title'] = $row['title'];
                 if (isset($row['address'])) $contentData['address'] = $row['address'];
@@ -520,6 +525,13 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 if (!empty($contentData) || $cityId || $stateId) {
                     $contentData['language_id'] = $this->defaultLanguageId;
                     $contentData['category_id'] = $property->category_id;
+                    $contentData['title'] ??= $existingContent->title ?? '';
+                    $contentData['address'] ??= $existingContent->address ?? '';
+                    $contentData['description'] ??= $existingContent->description ?? '';
+                    $contentData['meta_keyword'] ??= $existingContent->meta_keyword ?? null;
+                    $contentData['meta_description'] ??= $existingContent->meta_description ?? null;
+                    $contentData['city_id'] ??= $existingContent->city_id ?? null;
+                    $contentData['state_id'] ??= $existingContent->state_id ?? null;
                     PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
                 }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -1137,6 +1137,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             }
         }
 
+        if (array_key_exists('unit_number', $data) && $data['unit_number'] !== null && $data['unit_number'] !== '') {
+            $data['unit_number'] = (string) $data['unit_number'];
+        }
+
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {
             return !is_null($value) && $value !== '';

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -173,9 +173,50 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         foreach ($row as $header => $value) {
             $headerStr = is_string($header) ? $header : (string) $header;
             $key = $map[$headerStr] ?? $headerStr;
-            $out[$key] = $value;
+            if ($this->valueProvided($value)) {
+                $out[$key] = $value;
+            } elseif (!array_key_exists($key, $out)) {
+                $out[$key] = $value;
+            }
         }
         return $out;
+    }
+
+    /**
+     * Excel often stores 0/1 and numeric unit numbers as integers; Laravel string rules reject them.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function castStringFieldsForValidation(array $data): array
+    {
+        $stringFields = [
+            'amenity_مصعد',
+            'amenity_أمن',
+            'amenity_كاميرات_مراقبة',
+            'amenity_تكييف_مركزي',
+            'amenity_تدفئة_مركزية',
+            'amenity_صيانة',
+            'amenity_بواب',
+            'amenity_إنترنت',
+            'unit_number',
+            'view_type',
+            'furnished',
+            'balcony',
+            'maid_room',
+            'storage_room',
+            'swimming_pool',
+            'gym',
+            'featured',
+        ];
+
+        foreach ($stringFields as $field) {
+            if (array_key_exists($field, $data) && $data[$field] !== null && $data[$field] !== '') {
+                $data[$field] = (string) $data[$field];
+            }
+        }
+
+        return $data;
     }
 
     public function onRow(Row $row)
@@ -1137,9 +1178,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             }
         }
 
-        if (array_key_exists('unit_number', $data) && $data['unit_number'] !== null && $data['unit_number'] !== '') {
-            $data['unit_number'] = (string) $data['unit_number'];
-        }
+        $data = $this->castStringFieldsForValidation($data);
 
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {

--- a/app/Models/Api/UserPropertyRequest.php
+++ b/app/Models/Api/UserPropertyRequest.php
@@ -82,6 +82,7 @@ class UserPropertyRequest extends Model
         'customers_hub_stage_id',
         'property_ids',
         'initial_property_id',
+        'project_id',
         'responsible_employee_id',
         'inquiry_type',
         'currency',
@@ -158,6 +159,11 @@ class UserPropertyRequest extends Model
     public function initialProperty()
     {
         return $this->belongsTo(\App\Models\User\RealestateManagement\Property::class, 'initial_property_id');
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(\App\Models\User\RealestateManagement\Project::class, 'project_id');
     }
 
     /**

--- a/app/Models/User/RealestateManagement/City.php
+++ b/app/Models/User/RealestateManagement/City.php
@@ -13,7 +13,6 @@ class City extends Model
     public $table = "user_cities";
 
     protected $fillable = [
-        'user_id',
         'language_id',
         'country_id',
         'state_id',
@@ -30,32 +29,6 @@ class City extends Model
         return Attribute::make(
             set: fn($value) => make_slug($value),
         );
-    }
-
-    public static function storeCity($userId, $request, $image, $countryId = null, $stateId = null)
-    {
-        return self::create([
-            'user_id' => $userId,
-            'language_id' => $request['language'],
-            'country_id' => $countryId,
-            'state_id' => $stateId,
-            'name' => $request['name'],
-            'slug' => $request['name'],
-            'status' => $request['status'],
-            'image' => $image,
-            'serial_number' => $request['serial_number']
-        ]);
-    }
-
-    public function updateCity($request, $image)
-    {
-        return $this->update([
-            'name' => $request['name'],
-            'slug' => $request['name'],
-            'status' => $request['status'],
-            'image' => $image,
-            'serial_number' => $request['serial_number']
-        ]);
     }
 
     public function country()

--- a/app/Models/User/RealestateManagement/PropertyContent.php
+++ b/app/Models/User/RealestateManagement/PropertyContent.php
@@ -85,15 +85,15 @@ class PropertyContent extends Model
             'category_id' => $requestData['category_id'],
             'country_id' => $requestData['country_id'] ?? null,
             'state_id' => $requestData['state_id'] ?? null,
-            'city_id' => $requestData['city_id'],
+            'city_id' => $requestData['city_id'] ?? null,
 
-            'title' => $requestData['title'],
+            'title' => $requestData['title'] ?? '',
             // 'slug' => $requestData['slug'],
-            'slug' => self::generateUniqueSlug($requestData['title'], $propertyId),
-            'address' => $requestData['address'],
-            'description' => $requestData['description'],
-            'meta_keyword' => $requestData['meta_keyword'],
-            'meta_description' => $requestData['meta_description'],
+            'slug' => self::generateUniqueSlug($requestData['title'] ?? '', $propertyId),
+            'address' => $requestData['address'] ?? '',
+            'description' => $requestData['description'] ?? '',
+            'meta_keyword' => $requestData['meta_keyword'] ?? null,
+            'meta_description' => $requestData['meta_description'] ?? null,
         ]);
     }
 

--- a/app/Observers/PropertyObserver.php
+++ b/app/Observers/PropertyObserver.php
@@ -2,9 +2,11 @@
 
 namespace App\Observers;
 
+use App\Models\User;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\Logs\PropertyLog;
 use App\Services\Audit\EntityAuditLogger;
+use App\Services\SiteSetupProgressService;
 use App\Support\AuditContext;
 use App\Support\PropertyAuditFields;
 use App\Support\CacheInvalidationHelper;
@@ -90,6 +92,12 @@ class PropertyObserver
         
         // Clear property-related caches when new property is created
         $this->clearPropertyCachesForUser($m->user_id);
+
+        // Sync owner user_steps.properties for site setup progress (GET still derives from DB).
+        $propertyOwner = User::find($m->user_id);
+        if ($propertyOwner) {
+            app(SiteSetupProgressService::class)->syncPropertiesFlag($propertyOwner);
+        }
     }
     
     public function updated(Property $m): void {

--- a/app/Services/SiteSetupProgressService.php
+++ b/app/Services/SiteSetupProgressService.php
@@ -2,69 +2,279 @@
 
 namespace App\Services;
 
-use App\Domain\Domain\Models\CustomDomain;
+use App\Models\Api\ApiDomainSetting;
+use App\Models\Api\FooterSetting;
 use App\Models\Api\marketing\MarketingChannel;
 use App\Models\User;
+use App\Models\User\BasicSetting;
+use App\Models\User\RealestateManagement\Property;
 use App\Models\UserStep;
+use App\Models\WhatsappUser;
 
 class SiteSetupProgressService
 {
+    private const TOTAL_STEPS = 5;
+
+    private const PLACEHOLDER_PHONES = [
+        '+966 5XXXXXXXX',
+        '+9665XXXXXXXX',
+        '5XXXXXXXX',
+    ];
+
+    private const PLACEHOLDER_EMAILS = [
+        'info@example.com',
+    ];
+
     /**
-     * Site setup checklist for the dashboard widget (5 steps).
-     * Uses tenant owner id so employees see the same progress as the account owner.
+     * Canonical FE setup-progress payload (5 steps).
+     * Derives each status from tenant-owner data; employees share owner progress.
+     *
+     * @return array<string, mixed>|null Null when owner cannot be resolved (fail closed).
      */
-    public function getProgress(User $user): array
+    public function getProgress(User $user): ?array
     {
         $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return null;
+        }
 
-        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
-        $hasDomain = CustomDomain::where('user_id', $ownerId)->exists();
-        $hasWhatsApp = MarketingChannel::where('user_id', $ownerId)
-            ->where('type', MarketingChannel::TYPE_WHATSAPP)
-            ->where('is_connected', true)
-            ->exists();
+        $owner = User::find($ownerId);
+        if (! $owner) {
+            return null;
+        }
+
+        $statuses = [
+            'site_identity' => (bool) $owner->onboarding_completed,
+            'contact_info' => $this->isContactInfoComplete($owner),
+            'first_property' => Property::where('user_id', $ownerId)->exists(),
+            'integrated_link' => $this->hasIntegratedLink($ownerId),
+            'connect_site' => ApiDomainSetting::where('user_id', $ownerId)
+                ->where('status', 'active')
+                ->exists(),
+        ];
 
         $stepDefs = [
             [
-                'key' => 'site_identity',
-                'label' => 'هوية الموقع',
-                'completed' => (bool) ($steps->logo_uploaded && $steps->website_named),
-                'path' => '/basic-settings',
+                'id' => 'site_identity',
+                'label_ar' => 'هوية الموقع',
+                'order' => 1,
+                'href_incomplete' => null,
             ],
             [
-                'key' => 'contact_data',
-                'label' => 'بيانات التواصل',
-                'completed' => (bool) $steps->contacts_social_info,
-                'path' => '/contact-info',
+                'id' => 'contact_info',
+                'label_ar' => 'بيانات التواصل',
+                'order' => 2,
+                'href_incomplete' => '/dashboard/my-account/personal',
             ],
             [
-                'key' => 'first_property',
-                'label' => 'أول عقار',
-                'completed' => (bool) $steps->properties,
-                'path' => '/properties/add',
+                'id' => 'first_property',
+                'label_ar' => 'أول عقار',
+                'order' => 3,
+                'href_incomplete' => '/dashboard/properties/add',
             ],
             [
-                'key' => 'domain_link',
-                'label' => 'ربط الموقع',
-                'completed' => $hasDomain,
-                'path' => '/domain-settings',
+                'id' => 'integrated_link',
+                'label_ar' => 'الرابط المتكامل',
+                'order' => 4,
+                'href_incomplete' => '/dashboard/apps',
             ],
             [
-                'key' => 'integration',
-                'label' => 'الرابط المتكامل',
-                'completed' => $hasWhatsApp,
-                'path' => '/whatsapp',
+                'id' => 'connect_site',
+                'label_ar' => 'ربط الموقع',
+                'order' => 5,
+                'href_incomplete' => '/dashboard/my-account/domains',
             ],
         ];
 
-        $completedCount = collect($stepDefs)->filter(fn ($s) => $s['completed'])->count();
-        $total = count($stepDefs);
+        $steps = [];
+        $done = 0;
+
+        foreach ($stepDefs as $def) {
+            $complete = (bool) ($statuses[$def['id']] ?? false);
+            if ($complete) {
+                $done++;
+            }
+
+            $steps[] = [
+                'id' => $def['id'],
+                'label_ar' => $def['label_ar'],
+                'status' => $complete,
+                'href' => $complete ? null : $def['href_incomplete'],
+                'order' => $def['order'],
+                'locked' => false,
+            ];
+        }
+
+        $progress = self::TOTAL_STEPS > 0
+            ? round($done / self::TOTAL_STEPS, 4)
+            : 0.0;
 
         return [
-            'steps' => $stepDefs,
-            'completed_count' => $completedCount,
-            'total_steps' => $total,
-            'progress_percentage' => $total > 0 ? (int) (($completedCount / $total) * 100) : 0,
+            'progress' => $progress,
+            'done' => $done,
+            'total' => self::TOTAL_STEPS,
+            'headline_key' => $this->headlineKeyForDone($done),
+            'dismissed' => false,
+            'steps' => $steps,
         ];
+    }
+
+    /**
+     * Map POST /steps/complete to owner user_steps flags, then return GET-shaped progress.
+     *
+     * @return array{ok: bool, progress: ?array, error?: string, status?: int}
+     */
+    public function completeStep(User $user, string $step): array
+    {
+        $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return ['ok' => false, 'progress' => null, 'error' => 'Unable to resolve tenant owner.', 'status' => 403];
+        }
+
+        $canonical = $step === 'properties' ? 'first_property' : $step;
+
+        $noopSteps = ['site_identity', 'integrated_link', 'connect_site'];
+        $flagMap = [
+            'first_property' => 'properties',
+            'contact_info' => 'contacts_social_info',
+        ];
+
+        if (in_array($canonical, $noopSteps, true)) {
+            // no-op on user_steps; GET remains source of truth
+        } elseif (isset($flagMap[$canonical])) {
+            $column = $flagMap[$canonical];
+            $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+            $steps->{$column} = true;
+            $steps->save();
+        } else {
+            return [
+                'ok' => false,
+                'progress' => null,
+                'error' => 'The selected step is invalid.',
+                'status' => 422,
+            ];
+        }
+
+        $progress = $this->getProgress($user);
+        if ($progress === null) {
+            return ['ok' => false, 'progress' => null, 'error' => 'Unable to resolve tenant owner.', 'status' => 403];
+        }
+
+        return ['ok' => true, 'progress' => $progress];
+    }
+
+    /**
+     * Sync contacts_social_info on the owner row when contact_info derives true.
+     */
+    public function syncContactsSocialInfo(User $owner): void
+    {
+        $ownerId = (int) ($owner->id ?: 0);
+        if (! $ownerId) {
+            return;
+        }
+
+        if (! $this->isContactInfoComplete($owner)) {
+            return;
+        }
+
+        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+        if ($steps->contacts_social_info) {
+            return;
+        }
+
+        $steps->contacts_social_info = true;
+        $steps->save();
+    }
+
+    /**
+     * Sync properties flag on the owner row after a property is created.
+     * Early-returns if already true.
+     */
+    public function syncPropertiesFlag(User $user): void
+    {
+        $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return;
+        }
+
+        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+        if ($steps->properties) {
+            return;
+        }
+
+        $steps->properties = true;
+        $steps->save();
+    }
+
+    public function isContactInfoComplete(User $owner): bool
+    {
+        $footer = FooterSetting::where('user_id', $owner->id)->first();
+        $general = is_array($footer?->general) ? $footer->general : [];
+
+        $phone = trim((string) ($general['phone'] ?? ''));
+        if ($phone === '' || $this->isPlaceholderPhone($phone)) {
+            return false;
+        }
+
+        $basic = BasicSetting::where('user_id', $owner->id)->first();
+        $basicEmail = trim((string) ($basic?->email ?? ''));
+        $footerEmail = trim((string) ($general['email'] ?? ''));
+
+        $email = $basicEmail !== '' ? $basicEmail : $footerEmail;
+        if ($email === '' || $this->isPlaceholderEmail($email)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hasIntegratedLink(int $ownerId): bool
+    {
+        $whatsappActive = WhatsappUser::where('user_id', $ownerId)
+            ->where('status', 'active')
+            ->exists();
+
+        if ($whatsappActive) {
+            return true;
+        }
+
+        return MarketingChannel::where('user_id', $ownerId)
+            ->where('type', MarketingChannel::TYPE_WHATSAPP)
+            ->where('is_connected', true)
+            ->exists();
+    }
+
+    private function headlineKeyForDone(int $done): string
+    {
+        return match (true) {
+            $done <= 0 => 'start',
+            $done === 1 => 'early',
+            $done <= 3 => 'mid',
+            $done === 4 => 'almost',
+            default => 'done',
+        };
+    }
+
+    private function isPlaceholderPhone(string $phone): bool
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($phone)) ?? '';
+        $compact = preg_replace('/\s+/', '', $normalized) ?? '';
+
+        foreach (self::PLACEHOLDER_PHONES as $placeholder) {
+            $pNorm = preg_replace('/\s+/', ' ', $placeholder) ?? '';
+            $pCompact = preg_replace('/\s+/', '', $placeholder) ?? '';
+            if (strcasecmp($normalized, $pNorm) === 0 || strcasecmp($compact, $pCompact) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPlaceholderEmail(string $email): bool
+    {
+        $email = strtolower(trim($email));
+
+        return in_array($email, array_map('strtolower', self::PLACEHOLDER_EMAILS), true);
     }
 }

--- a/app/Support/PropertyFilterQuery.php
+++ b/app/Support/PropertyFilterQuery.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Shared property list/export filter chain.
+ * Accepts both `property_type` and `type` for the type filter (controller vs export key drift).
+ */
+class PropertyFilterQuery
+{
+    public static function apply(Builder $query, array $filters): Builder
+    {
+        // Apply property IDs filter if provided
+        if (!empty($filters['ids']) && is_array($filters['ids']) && count($filters['ids']) > 0) {
+            $query->whereIn('id', $filters['ids']);
+        }
+
+        // Apply date range filter
+        if (!empty($filters['date_from'])) {
+            $query->whereDate('created_at', '>=', $filters['date_from']);
+        }
+        if (!empty($filters['date_to'])) {
+            $query->whereDate('created_at', '<=', $filters['date_to']);
+        }
+
+        // Apply purpose filter
+        if (!empty($filters['purposes_filter'])) {
+            $query->where('purpose', $filters['purposes_filter']);
+        }
+        if (!empty($filters['purpose'])) {
+            $query->where('purpose', $filters['purpose']);
+        }
+
+        // Apply type filter (accept both property_type and type keys)
+        $propertyType = $filters['property_type'] ?? $filters['type'] ?? null;
+        if (!empty($propertyType)) {
+            $query->where('property_type', $propertyType);
+        }
+
+        // Apply price filters
+        if (!empty($filters['price_from'])) {
+            $query->where('price', '>=', $filters['price_from']);
+        }
+        if (!empty($filters['price_to'])) {
+            $query->where('price', '<=', $filters['price_to']);
+        }
+
+        // Apply area filters
+        if (!empty($filters['area_from'])) {
+            $query->where('area', '>=', $filters['area_from']);
+        }
+        if (!empty($filters['area_to'])) {
+            $query->where('area', '<=', $filters['area_to']);
+        }
+
+        // Apply beds filter
+        if (!empty($filters['beds'])) {
+            $query->where('beds', $filters['beds']);
+        }
+
+        // Apply bath filter
+        if (!empty($filters['bath'])) {
+            $query->where('bath', $filters['bath']);
+        }
+
+        // Apply category filter
+        if (!empty($filters['category_id'])) {
+            $query->where('category_id', $filters['category_id']);
+        }
+
+        // Apply status filter
+        if (isset($filters['status']) && $filters['status'] !== '') {
+            $query->where('status', $filters['status']);
+        }
+
+        // Apply featured filter
+        if (isset($filters['featured']) && $filters['featured'] !== '') {
+            $query->where('featured', $filters['featured']);
+        }
+
+        // Apply city filter
+        if (!empty($filters['city_id'])) {
+            $query->whereHas('contents', function ($q) use ($filters) {
+                $q->where('city_id', $filters['city_id']);
+            });
+        }
+
+        // Apply district filter
+        if (!empty($filters['district_id'])) {
+            $query->whereHas('contents', function ($q) use ($filters) {
+                $q->where('state_id', $filters['district_id']);
+            });
+        }
+
+        // Apply search filter (title/description/address, plus numeric property ID)
+        if (!empty($filters['search'])) {
+            $search = trim((string) $filters['search']);
+            $numericId = self::parsePositiveIntSearchId($search);
+            $query->where(function ($q) use ($search, $numericId) {
+                $q->whereHas('contents', function ($cq) use ($search) {
+                    $cq->where(function ($inner) use ($search) {
+                        $inner->where('title', 'like', "%{$search}%")
+                              ->orWhere('description', 'like', "%{$search}%")
+                              ->orWhere('address', 'like', "%{$search}%");
+                    });
+                });
+                if ($numericId !== null) {
+                    $q->orWhere('id', $numericId);
+                }
+            });
+        }
+
+        // Apply features filter
+        if (!empty($filters['features'])) {
+            $featuresArray = explode(',', $filters['features']);
+            foreach ($featuresArray as $feature) {
+                $feature = trim($feature);
+                $query->whereJsonContains('features', $feature);
+            }
+        }
+
+        return $query;
+    }
+
+    private static function parsePositiveIntSearchId(?string $searchTerm): ?int
+    {
+        $searchTerm = trim((string) $searchTerm);
+        if ($searchTerm === ''
+            || !ctype_digit($searchTerm)
+            || strlen($searchTerm) > 18
+            || (int) $searchTerm <= 0
+        ) {
+            return null;
+        }
+
+        return (int) $searchTerm;
+    }
+}

--- a/database/migrations/2026_08_07_000001_add_project_id_to_users_property_requests.php
+++ b/database/migrations/2026_08_07_000001_add_project_id_to_users_property_requests.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users_property_requests')) {
+            return;
+        }
+
+        Schema::table('users_property_requests', function (Blueprint $table) {
+            if (! Schema::hasColumn('users_property_requests', 'project_id')) {
+                $table->unsignedBigInteger('project_id')->nullable()->after('initial_property_id');
+                $table->index('project_id');
+                $table->foreign('project_id')
+                    ->references('id')
+                    ->on('user_projects')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('users_property_requests')) {
+            return;
+        }
+
+        Schema::table('users_property_requests', function (Blueprint $table) {
+            if (Schema::hasColumn('users_property_requests', 'project_id')) {
+                $table->dropForeign(['project_id']);
+                $table->dropIndex(['project_id']);
+                $table->dropColumn('project_id');
+            }
+        });
+    }
+};

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -309,6 +309,60 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $this->assertSame('commercial', $property->property_type);
     }
 
+    public function test_bulk_import_update_via_id_does_not_crash_and_preserves_meta_fields(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant] = $this->actingAsTenantWithCreate();
+
+        // Create an initial property via import (mirrors the create path)
+        $file = $this->makeExcelUpload(
+            ['عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة'],
+            [['شقة أصلية', 500000, 'حي الأصلي الرياض', 'وصف عقار أصلي للاختبار', 'بيع', 'سكني', 100]],
+        );
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], ['Accept' => 'application/json']);
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+
+        $property = Property::where('user_id', $tenant->id)->latest('id')->first();
+        $this->assertNotNull($property);
+
+        // The import template has no SEO meta fields; simulate a value set some other way
+        // (e.g. via the property edit UI) that a re-import must not silently wipe.
+        PropertyContent::where('property_id', $property->id)->update([
+            'meta_keyword' => 'شقة مميزة, عقار الرياض',
+            'meta_description' => 'وصف ميتا مخصص للسيو',
+        ]);
+
+        // Re-import an update row referencing this property's id, as export-for-import round-trips do
+        $updateFile = $this->makeExcelUpload(
+            ['المعرّف', 'عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة'],
+            [[$property->id, 'شقة محدثة', 600000, 'حي محدث الرياض', 'وصف عقار محدث للاختبار', 'بيع', 'سكني', 120]],
+        );
+
+        $updateResponse = $this->post('/api/properties/bulk-import', ['file' => $updateFile], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(
+            200,
+            $updateResponse->status(),
+            'Update-via-id import must not crash (e.g. undefined array key): ' . $updateResponse->getContent()
+        );
+        $this->assertSame(0, (int) ($updateResponse->json('failed_count') ?? 0), $updateResponse->getContent());
+        $this->assertGreaterThan(0, (int) ($updateResponse->json('updated_count') ?? 0), $updateResponse->getContent());
+
+        $property->refresh();
+        $this->assertEquals(600000, (float) $property->price);
+
+        $content = PropertyContent::where('property_id', $property->id)->first();
+        $this->assertNotNull($content);
+        $this->assertSame('شقة محدثة', $content->title);
+        // meta_keyword has no column in the import template at all — must be preserved, not wiped to null
+        $this->assertSame('شقة مميزة, عقار الرياض', $content->meta_keyword);
+        // meta_description is intentionally re-derived from the row's (changed) description
+        $this->assertNotNull($content->meta_description);
+        $this->assertStringContainsString('وصف عقار محدث للاختبار', $content->meta_description);
+    }
+
     public function test_raw_export_numeric_zero_cells_do_not_fail_string_validation(): void
     {
         $this->skipIfMissingSchema();

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -386,8 +386,22 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         ]);
 
         $errors = $response->json('errors') ?? [];
-        $stringErrors = array_filter($errors, function ($error) {
-            return str_contains((string) ($error['error'] ?? ''), 'must be a string');
+        $errorMessages = array_map(
+            static fn ($error) => (string) ($error['error'] ?? ''),
+            $errors
+        );
+        $combined = implode("\n", $errorMessages);
+
+        $this->assertNotEmpty($errors, 'Raw export fixture should be rejected with errors: ' . $response->getContent());
+        $this->assertTrue(
+            str_contains($combined, 'raw Export file')
+                || str_contains($combined, 'raw export file')
+                || str_contains($combined, 'not supported'),
+            'Expected raw-export rejection message, got: ' . json_encode($errorMessages, JSON_UNESCAPED_UNICODE)
+        );
+
+        $stringErrors = array_filter($errorMessages, static function (string $message) {
+            return str_contains($message, 'must be a string');
         });
 
         $this->assertEmpty(

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -308,4 +308,91 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $this->assertSame('rent', $property->purpose);
         $this->assertSame('commercial', $property->property_type);
     }
+
+    public function test_raw_export_numeric_zero_cells_do_not_fail_string_validation(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        $file = $this->makeExcelUpload(
+            [
+                'عنوان الإعلان',
+                'السعر',
+                'العنوان',
+                'الوصف',
+                'الغرض',
+                'النوع',
+                'المساحة',
+                'مميز',
+                'مصعد',
+                'بلكونة',
+                'غرفة خادمة',
+                'غرفة تخزين',
+                'مسبح',
+            ],
+            [
+                [
+                    'عقار من تصدير خام',
+                    100000,
+                    'شارع الاختبار',
+                    'وصف كافي للاستيراد التجريبي',
+                    'بيع',
+                    'سكني',
+                    120,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            ],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        foreach ($response->json('errors') ?? [] as $error) {
+            $this->assertStringNotContainsString(
+                'must be a string',
+                (string) ($error['error'] ?? ''),
+                'Unexpected string validation failure: ' . json_encode($error, JSON_UNESCAPED_UNICODE)
+            );
+        }
+    }
+
+    public function test_user_raw_export_fixture_has_no_string_validation_errors(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        $fixture = base_path('tests/fixtures/properties-export-2026-08-05.xlsx');
+        if (! is_file($fixture)) {
+            $this->markTestSkipped('Fixture tests/fixtures/properties-export-2026-08-05.xlsx not found.');
+        }
+
+        $file = new UploadedFile(
+            $fixture,
+            'properties-export-2026-08-05.xlsx',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            null,
+            true,
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $errors = $response->json('errors') ?? [];
+        $stringErrors = array_filter($errors, function ($error) {
+            return str_contains((string) ($error['error'] ?? ''), 'must be a string');
+        });
+
+        $this->assertEmpty(
+            $stringErrors,
+            'Raw export fixture should not fail string validation: ' . json_encode($stringErrors, JSON_UNESCAPED_UNICODE)
+        );
+    }
 }

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Membership;
+use App\Models\Package;
+use App\Models\User;
+use App\Models\User\Language;
+use App\Models\User\RealestateManagement\Amenity;
+use App\Models\User\RealestateManagement\City;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\PropertyContent;
+use App\Services\MembershipCacheService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\Concerns\EnsuresPropertyStatusColumns;
+use Tests\TestCase;
+
+class PropertiesBulkImportArabicHeadersTest extends TestCase
+{
+    use DatabaseTransactions;
+    use EnsuresPropertyStatusColumns;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensurePropertyStatusColumns();
+    }
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach ([
+            'users',
+            'user_properties',
+            'user_property_contents',
+            'memberships',
+            'packages',
+            'user_languages',
+            'api_permissions',
+            'api_model_has_permissions',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function grantPermissions(User $user, User $tenant, array $permissions): void
+    {
+        if (! Schema::hasTable('api_permissions')) {
+            $this->markTestSkipped('api_permissions table not available.');
+        }
+
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->setPermissionsTeamId((int) $tenant->id);
+        $registrar->forgetCachedPermissions();
+
+        foreach ($permissions as $permissionName) {
+            try {
+                $permission = Permission::findByName($permissionName, 'sanctum');
+            } catch (\Throwable $e) {
+                $permission = Permission::create([
+                    'name' => $permissionName,
+                    'guard_name' => 'sanctum',
+                    'team_id' => $tenant->id,
+                ]);
+            }
+
+            $user->givePermissionTo($permission);
+        }
+
+        $registrar->forgetCachedPermissions();
+    }
+
+    private function seedTenantContext(User $tenant, int $propertyLimit = 100): Language
+    {
+        $package = Package::firstOrCreate(
+            ['title' => 'Bulk Arabic Headers Test Package'],
+            [
+                'slug' => 'bulk-arabic-headers-test-package',
+                'price' => 0,
+                'term' => 'monthly',
+                'status' => 1,
+                'is_active' => 1,
+                'project_limit_number' => 100,
+                'real_estate_limit_number' => $propertyLimit,
+                'serial_number' => 994,
+            ]
+        );
+
+        $package->update(['real_estate_limit_number' => $propertyLimit]);
+
+        $membership = Membership::firstOrNew(['user_id' => $tenant->id]);
+        $membership->status = 1;
+        $membership->start_date = now()->subDay();
+        $membership->expire_date = now()->addMonth();
+        $membership->package_id = $package->id;
+        $membership->price = 0;
+        $membership->currency = 'USD';
+        $membership->currency_symbol = '$';
+        $membership->payment_method = 'test';
+        $membership->transaction_id = 'bulk-ar-headers-' . uniqid();
+        $membership->save();
+
+        MembershipCacheService::clearCache($tenant->id);
+
+        return Language::firstOrCreate(
+            ['user_id' => $tenant->id, 'is_default' => 1],
+            [
+                'name' => 'Arabic',
+                'code' => 'ar',
+                'rtl' => 1,
+            ]
+        );
+    }
+
+    private function actingAsTenantWithCreate(): array
+    {
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $language = $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, $tenant, ['properties.create']);
+        Sanctum::actingAs($tenant);
+
+        return [$tenant, $language];
+    }
+
+    /**
+     * @param  list<string>  $headers
+     * @param  list<list<mixed>>  $rows
+     */
+    private function makeExcelUpload(array $headers, array $rows): UploadedFile
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        foreach ($headers as $i => $header) {
+            $sheet->setCellValueByColumnAndRow($i + 1, 1, $header);
+        }
+
+        foreach ($rows as $rIndex => $row) {
+            foreach ($row as $cIndex => $value) {
+                $sheet->setCellValueByColumnAndRow($cIndex + 1, $rIndex + 2, $value);
+            }
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'xlsx');
+        (new Xlsx($spreadsheet))->save($path);
+
+        return new UploadedFile(
+            $path,
+            'arabic-template.xlsx',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            null,
+            true,
+        );
+    }
+
+    public function test_arabic_template_headers_and_values_import_via_bulk_import(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $cityName = null;
+        if (Schema::hasTable('user_cities')) {
+            try {
+                $city = City::create([
+                    'user_id' => $tenant->id,
+                    'language_id' => $language->id,
+                    'country_id' => null,
+                    'state_id' => null,
+                    'name' => 'الرياض',
+                    'slug' => 'riyadh-ar-import-' . uniqid(),
+                    'featured' => 0,
+                    'status' => 1,
+                    'serial_number' => 1,
+                ]);
+                $cityName = $city->name;
+            } catch (\Throwable $e) {
+                $cityName = null;
+            }
+        }
+
+        if (Schema::hasTable('user_amenities')) {
+            try {
+                Amenity::firstOrCreate(
+                    ['user_id' => $tenant->id, 'name' => 'مصعد'],
+                    [
+                        'language_id' => $language->id,
+                        'slug' => 'msaad-import-' . uniqid(),
+                        'icon' => 'elevator',
+                        'status' => 1,
+                        'serial_number' => 1,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                // Amenity seed is optional; header/value mapping is the assertion target.
+            }
+        }
+
+        $headers = [
+            'عنوان الإعلان',
+            'السعر',
+            'العنوان',
+            'الوصف',
+            'الغرض',
+            'النوع',
+            'المساحة',
+            'مصعد',
+            'أمن',
+        ];
+        $row = [
+            'شقة اختبار عربية',
+            750000,
+            'حي النرجس الرياض',
+            'وصف عقار كامل للاختبار العربي',
+            'بيع',
+            'سكني',
+            150,
+            'نعم',
+            'لا',
+        ];
+
+        if ($cityName !== null) {
+            $headers[] = 'المدينة';
+            $row[] = $cityName;
+        }
+
+        $file = $this->makeExcelUpload($headers, [$row]);
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertContains(
+            $response->status(),
+            [200, 422],
+            'Expected success or partial_success HTTP status, got: ' . $response->status() . ' ' . $response->getContent()
+        );
+
+        $failedCount = (int) ($response->json('failed_count') ?? 0);
+        $this->assertSame(0, $failedCount, 'Arabic purpose/type/amenities should not fail validation: ' . $response->getContent());
+
+        $imported = (int) ($response->json('imported_count') ?? 0);
+        $incomplete = (int) ($response->json('incomplete_count') ?? 0);
+        $this->assertGreaterThan(0, $imported + $incomplete, 'Expected at least one created property');
+
+        $property = Property::where('user_id', $tenant->id)
+            ->where('import_batch_id', '!=', null)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($property);
+        $this->assertSame('sale', $property->purpose);
+        $this->assertSame('residential', $property->property_type);
+        $this->assertEquals(750000, (float) $property->price);
+        $this->assertEquals(150, (float) $property->area);
+
+        $content = PropertyContent::where('property_id', $property->id)->first();
+        $this->assertNotNull($content);
+        $this->assertSame('شقة اختبار عربية', $content->title);
+
+        $missing = $property->missing_fields ?? [];
+        if (is_string($missing)) {
+            $missing = json_decode($missing, true) ?: [];
+        }
+        $this->assertNotContains('title', $missing);
+        $this->assertNotContains('purpose', $missing);
+        $this->assertNotContains('type', $missing);
+        $this->assertNotContains('price', $missing);
+    }
+
+    public function test_arabic_purpose_type_and_amenity_values_do_not_skip_row(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        $file = $this->makeExcelUpload(
+            ['عنوان الإعلان', 'الغرض', 'النوع', 'مصعد', 'السعر'],
+            [
+                ['وحدة إيجار', 'إيجار', 'تجاري', 'نعم', 12000],
+            ],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertContains($response->status(), [200, 422]);
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(
+            0,
+            (int) ($response->json('imported_count') ?? 0) + (int) ($response->json('incomplete_count') ?? 0)
+        );
+
+        $property = Property::query()->latest('id')->first();
+        $this->assertNotNull($property);
+        $this->assertSame('rent', $property->purpose);
+        $this->assertSame('commercial', $property->property_type);
+    }
+}

--- a/tests/Feature/Api/PropertyRequestMapTest.php
+++ b/tests/Feature/Api/PropertyRequestMapTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Api\UserPropertyRequest;
 use App\Models\User;
+use App\Models\User\RealestateManagement\Project;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
 use App\Models\User\UserCity;
@@ -34,6 +35,35 @@ class PropertyRequestMapTest extends TestCase
         if (! Schema::hasColumn('users_property_requests', 'initial_property_id')) {
             $this->markTestSkipped('initial_property_id column required. Run migration.');
         }
+    }
+
+    private function skipIfMissingProjectIdColumn(): void
+    {
+        $this->skipIfMissingSchema();
+
+        if (! Schema::hasTable('user_projects')) {
+            $this->markTestSkipped('user_projects table required.');
+        }
+
+        if (! Schema::hasColumn('users_property_requests', 'project_id')) {
+            $this->markTestSkipped('project_id column required on users_property_requests. Run migration.');
+        }
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
     }
 
     private function grantPermissions(User $tenant, array $permissions): void
@@ -279,6 +309,91 @@ class PropertyRequestMapTest extends TestCase
             'id' => $requestId,
             'initial_property_id' => $property->id,
             'source' => 'property_interest',
+        ]);
+    }
+
+    public function test_store_from_interest_inherits_project_id_from_property_when_omitted(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        $project = $this->createProject($tenant);
+        $property = $this->createProperty($tenant, ['project_id' => $project->id]);
+
+        $response = $this->postJson('/api/v1/property-requests/interest', [
+            'tenant_username' => $tenant->username,
+            'property_id' => $property->id,
+            'full_name' => 'Interest Inherit Project',
+            'phone' => '+966501112244',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.property_id', $property->id)
+            ->assertJsonMissingPath('data.project_id');
+
+        $requestId = (int) $response->json('data.request_id');
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'initial_property_id' => $property->id,
+            'project_id' => $project->id,
+            'source' => 'property_interest',
+        ]);
+    }
+
+    public function test_store_from_interest_body_project_id_overrides_property_project(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        $propertyProject = $this->createProject($tenant);
+        $overrideProject = $this->createProject($tenant);
+        $property = $this->createProperty($tenant, ['project_id' => $propertyProject->id]);
+
+        $response = $this->postJson('/api/v1/property-requests/interest', [
+            'tenant_username' => $tenant->username,
+            'property_id' => $property->id,
+            'full_name' => 'Interest Override Project',
+            'phone' => '+966501112255',
+            'project_id' => $overrideProject->id,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonMissingPath('data.project_id');
+
+        $requestId = (int) $response->json('data.request_id');
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => $overrideProject->id,
+            'source' => 'property_interest',
+        ]);
+    }
+
+    public function test_public_store_with_valid_project_id_persists(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        $city = UserCity::query()->first();
+        if (! $city) {
+            $this->markTestSkipped('user_cities must have at least one row.');
+        }
+        $project = $this->createProject($tenant);
+
+        $response = $this->postJson('/api/v1/property-requests/public', [
+            'tenant_username' => $tenant->username,
+            'full_name' => 'Public Project User',
+            'phone' => '+966502223355',
+            'region' => $city->id,
+            'project_id' => $project->id,
+        ]);
+
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $response->json('data.id'),
+            'user_id' => $tenant->id,
+            'project_id' => $project->id,
+            'source' => 'public_form',
         ]);
     }
 

--- a/tests/Feature/Api/StepsProgressApiTest.php
+++ b/tests/Feature/Api/StepsProgressApiTest.php
@@ -1,0 +1,589 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Api\ApiDomainSetting;
+use App\Models\Api\FooterSetting;
+use App\Models\Api\marketing\MarketingChannel;
+use App\Models\User;
+use App\Models\User\BasicSetting;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\UserStep;
+use App\Models\WhatsappUser;
+use App\Services\SiteSetupProgressService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class StepsProgressApiTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach ([
+            'users',
+            'user_steps',
+            'user_basic_settings',
+            'api_footer_settings',
+            'user_properties',
+            'whatsapp_users',
+            'marketing_channels',
+            'api_domains_settings',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    private function createTenant(array $overrides = []): User
+    {
+        return User::factory()->tenant()->create(array_merge([
+            'email' => 'steps-' . uniqid('', true) . '@example.com',
+            'username' => 'steps' . substr(md5(uniqid('', true)), 0, 10),
+            'onboarding_completed' => false,
+        ], $overrides));
+    }
+
+    private function createEmployeeFor(User $tenant, array $overrides = []): User
+    {
+        return User::factory()->employee()->create(array_merge([
+            'tenant_id' => $tenant->id,
+            'email' => 'emp-' . uniqid('', true) . '@example.com',
+            'username' => 'emp' . substr(md5(uniqid('', true)), 0, 10),
+        ], $overrides));
+    }
+
+    private function seedPlaceholderContact(User $owner): void
+    {
+        FooterSetting::create([
+            'user_id' => $owner->id,
+            'general' => [
+                'phone' => '+966 5XXXXXXXX',
+                'email' => 'info@example.com',
+            ],
+            'social' => [],
+            'columns' => [],
+            'newsletter' => [],
+            'style' => [],
+            'status' => true,
+        ]);
+
+        BasicSetting::create([
+            'user_id' => $owner->id,
+            'email' => 'info@example.com',
+        ]);
+    }
+
+    private function seedRealContact(User $owner): void
+    {
+        FooterSetting::updateOrCreate(
+            ['user_id' => $owner->id],
+            [
+                'general' => [
+                    'phone' => '+966 512345678',
+                    'email' => 'office@realestate.test',
+                ],
+                'social' => [],
+                'columns' => [],
+                'newsletter' => [],
+                'style' => [],
+                'status' => true,
+            ]
+        );
+
+        BasicSetting::updateOrCreate(
+            ['user_id' => $owner->id],
+            ['email' => 'office@realestate.test']
+        );
+    }
+
+    private function assertProgressShape(array $json): void
+    {
+        $this->assertArrayHasKey('progress', $json);
+        $this->assertArrayHasKey('done', $json);
+        $this->assertArrayHasKey('total', $json);
+        $this->assertArrayHasKey('headline_key', $json);
+        $this->assertArrayHasKey('dismissed', $json);
+        $this->assertArrayHasKey('steps', $json);
+        $this->assertFalse($json['dismissed']);
+        $this->assertSame(5, $json['total']);
+        $this->assertIsFloat((float) $json['progress']);
+        $this->assertSame(
+            (float) $json['done'] / 5,
+            (float) $json['progress']
+        );
+
+        $ids = array_column($json['steps'], 'id');
+        $this->assertSame(
+            ['site_identity', 'contact_info', 'first_property', 'integrated_link', 'connect_site'],
+            $ids
+        );
+
+        foreach ($json['steps'] as $index => $step) {
+            $this->assertArrayHasKey('locked', $step);
+            $this->assertFalse($step['locked']);
+            $this->assertArrayHasKey('href', $step);
+            $this->assertArrayHasKey('status', $step);
+            $this->assertArrayHasKey('label_ar', $step);
+            $this->assertSame($index + 1, $step['order']);
+
+            if ($step['status'] === true) {
+                $this->assertNull($step['href']);
+            } elseif ($step['id'] !== 'site_identity') {
+                $this->assertNotNull($step['href']);
+            }
+        }
+
+        $this->assertSame(4, $json['steps'][3]['order']);
+        $this->assertSame('integrated_link', $json['steps'][3]['id']);
+        $this->assertSame(5, $json['steps'][4]['order']);
+        $this->assertSame('connect_site', $json['steps'][4]['id']);
+    }
+
+    private function stepStatus(array $json, string $id): bool
+    {
+        foreach ($json['steps'] as $step) {
+            if ($step['id'] === $id) {
+                return (bool) $step['status'];
+            }
+        }
+
+        $this->fail("Step {$id} missing from response");
+    }
+
+    public function test_get_progress_returns_fe_shape_and_start_headline(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $response = $this->getJson('/api/steps/progress');
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertProgressShape($json);
+        $this->assertSame(0, $json['done']);
+        $this->assertSame('start', $json['headline_key']);
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+    }
+
+    public function test_placeholders_keep_contact_info_incomplete(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => false]);
+        $this->seedPlaceholderContact($tenant);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+    }
+
+    public function test_site_identity_from_onboarding_completed(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'site_identity'));
+        $this->assertSame(1, $json['done']);
+        $this->assertSame('early', $json['headline_key']);
+    }
+
+    public function test_contact_info_from_real_company_phone_and_email(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $this->seedRealContact($tenant);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'contact_info'));
+        $contact = collect($json['steps'])->firstWhere('id', 'contact_info');
+        $this->assertNull($contact['href']);
+    }
+
+    public function test_first_property_from_draft_property_count(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'price' => 100000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'test.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'first_property'));
+    }
+
+    public function test_integrated_link_from_whatsapp_users_active(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'number' => '966500000001',
+            'name' => 'WA',
+            'status' => 'active',
+            'request_status' => 'active',
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'integrated_link'));
+    }
+
+    public function test_integrated_link_from_marketing_channel_connected(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        MarketingChannel::create([
+            'user_id' => $tenant->id,
+            'name' => 'WhatsApp',
+            'type' => MarketingChannel::TYPE_WHATSAPP,
+            'number' => '966500000002',
+            'is_connected' => true,
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'integrated_link'));
+    }
+
+    public function test_connect_site_from_active_domain(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'active-' . uniqid('', true) . '.example.com',
+            'status' => 'active',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'pending-' . uniqid('', true) . '.example.com',
+            'status' => 'pending',
+            'primary' => false,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'connect_site'));
+    }
+
+    public function test_pending_domain_does_not_complete_connect_site(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'only-pending-' . uniqid('', true) . '.example.com',
+            'status' => 'pending',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'connect_site'));
+    }
+
+    public function test_headline_key_buckets(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $service = app(SiteSetupProgressService::class);
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($tenant);
+
+        $progress = $service->getProgress($tenant);
+        $this->assertSame(2, $progress['done']);
+        $this->assertSame('mid', $progress['headline_key']);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'price' => 1,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 't.jpg',
+            'property_type' => 'apartment',
+        ]);
+        WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'number' => '966500000099',
+            'name' => 'WA',
+            'status' => 'active',
+            'request_status' => 'active',
+        ]);
+
+        $progress = $service->getProgress($tenant->fresh());
+        $this->assertSame(4, $progress['done']);
+        $this->assertSame('almost', $progress['headline_key']);
+
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'done-' . uniqid('', true) . '.example.com',
+            'status' => 'active',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+
+        $progress = $service->getProgress($tenant->fresh());
+        $this->assertSame(5, $progress['done']);
+        $this->assertSame('done', $progress['headline_key']);
+        $this->assertSame(1.0, (float) $progress['progress']);
+    }
+
+    public function test_employee_sees_owner_progress(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($tenant);
+        $employee = $this->createEmployeeFor($tenant);
+
+        Sanctum::actingAs($employee);
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'site_identity'));
+        $this->assertTrue($this->stepStatus($json, 'contact_info'));
+        $this->assertSame(2, $json['done']);
+    }
+
+    public function test_post_first_property_writes_owner_properties_flag(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/steps/complete', ['step' => 'first_property']);
+
+        $response->assertOk()
+            ->assertJsonPath('message', 'Step marked as completed.')
+            ->assertJsonStructure(['progress', 'done', 'total', 'headline_key', 'dismissed', 'steps']);
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertProgressShape($response->json());
+    }
+
+    public function test_post_legacy_properties_maps_to_first_property_flag(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $this->postJson('/api/steps/complete', ['step' => 'properties'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+    }
+
+    public function test_post_contact_info_writes_contacts_social_info(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $this->postJson('/api/steps/complete', ['step' => 'contact_info'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('contacts_social_info')
+        );
+    }
+
+    public function test_post_noop_steps_do_not_write_user_steps_columns(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        foreach (['site_identity', 'integrated_link', 'connect_site'] as $step) {
+            $response = $this->postJson('/api/steps/complete', ['step' => $step]);
+            $response->assertOk();
+            $this->assertProgressShape($response->json());
+        }
+
+        $row = UserStep::where('user_id', $tenant->id)->first();
+        if ($row) {
+            $this->assertFalse((bool) $row->properties);
+            $this->assertFalse((bool) $row->contacts_social_info);
+        }
+    }
+
+    public function test_post_legacy_steps_return_422(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        foreach (['banner', 'footer', 'homepage_about_update', 'menu_builder', 'projects'] as $step) {
+            $this->postJson('/api/steps/complete', ['step' => $step])
+                ->assertStatus(422);
+        }
+    }
+
+    public function test_employee_post_writes_owner_user_steps_row(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $employee = $this->createEmployeeFor($tenant);
+        Sanctum::actingAs($employee);
+
+        $this->postJson('/api/steps/complete', ['step' => 'first_property'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertFalse(
+            UserStep::where('user_id', $employee->id)->where('properties', true)->exists()
+        );
+    }
+
+    public function test_property_create_syncs_owner_properties_flag_only(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $employee = $this->createEmployeeFor($tenant);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'created_by' => $employee->id,
+            'price' => 50000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'obs.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertFalse(
+            UserStep::where('user_id', $employee->id)->where('properties', true)->exists()
+        );
+
+        // Early-return path: already true should not throw.
+        app(SiteSetupProgressService::class)->syncPropertiesFlag($tenant);
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+    }
+
+    public function test_owner_null_employee_fails_closed_with_403(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $employee = User::factory()->employee()->create([
+            'tenant_id' => 0,
+            'email' => 'orphan-' . uniqid('', true) . '@example.com',
+            'username' => 'orphan' . substr(md5(uniqid('', true)), 0, 8),
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/steps/progress')->assertStatus(403);
+        $this->postJson('/api/steps/complete', ['step' => 'contact_info'])->assertStatus(403);
+    }
+
+    public function test_tenant_scoping_does_not_leak_other_owner_progress(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $ownerA = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($ownerA);
+        Property::create([
+            'user_id' => $ownerA->id,
+            'price' => 1,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'a.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $ownerB = $this->createTenant(['onboarding_completed' => false]);
+        Sanctum::actingAs($ownerB);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+        $this->assertFalse($this->stepStatus($json, 'first_property'));
+        $this->assertSame(0, $json['done']);
+    }
+
+    public function test_complete_onboarding_step_request_enums_match_openapi(): void
+    {
+        $request = new \App\Http\Requests\Api\Onboarding\CompleteOnboardingStepRequest();
+        $rule = $request->rules()['step'];
+        $this->assertIsString($rule);
+        $this->assertStringContainsString('site_identity', $rule);
+        $this->assertStringContainsString('contact_info', $rule);
+        $this->assertStringContainsString('first_property', $rule);
+        $this->assertStringContainsString('integrated_link', $rule);
+        $this->assertStringContainsString('connect_site', $rule);
+        $this->assertStringContainsString('properties', $rule);
+        $this->assertStringNotContainsString('banner', $rule);
+    }
+}

--- a/tests/Feature/E2E/PropertyRequestWithPropertyIdsTest.php
+++ b/tests/Feature/E2E/PropertyRequestWithPropertyIdsTest.php
@@ -6,10 +6,52 @@ namespace Tests\Feature\E2E;
 
 use App\Models\User;
 use App\Models\User\UserCity;
+use App\Models\User\RealestateManagement\Project;
 use App\Models\User\RealestateManagement\Property;
+use Illuminate\Support\Facades\Schema;
 
 class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
 {
+    private function skipIfMissingProjectIdColumn(): void
+    {
+        if (! Schema::hasColumn('users_property_requests', 'project_id')) {
+            $this->markTestSkipped('project_id column required on users_property_requests. Run migration.');
+        }
+        if (! Schema::hasTable('user_projects')) {
+            $this->markTestSkipped('user_projects table required.');
+        }
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
+    }
+
+    private function loginAs(User $tenant): string
+    {
+        $this->fakeRecaptcha();
+
+        $login = $this->postJson('/api/login', [
+            'recaptcha_token' => 'fake',
+            'email' => $tenant->email,
+            'password' => 'password',
+        ]);
+        $login->assertOk();
+
+        return (string) $login->json('token');
+    }
+
     /** @test */
     public function create_property_request_without_property_ids_still_works(): void
     {
@@ -23,13 +65,7 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
         $city = UserCity::first();
         $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
 
-        $login = $this->postJson('/api/login', [
-            'recaptcha_token' => 'fake',
-            'email' => $tenant->email,
-            'password' => 'password',
-        ]);
-        $login->assertOk();
-        $token = $login->json('token');
+        $token = $this->loginAs($tenant);
 
         $response = $this->withHeader('Authorization', 'Bearer ' . $token)
             ->postJson('/api/v1/property-requests', [
@@ -62,13 +98,7 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
             'user_id' => $tenant->id,
         ]);
 
-        $login = $this->postJson('/api/login', [
-            'recaptcha_token' => 'fake',
-            'email' => $tenant->email,
-            'password' => 'password',
-        ]);
-        $login->assertOk();
-        $token = $login->json('token');
+        $token = $this->loginAs($tenant);
 
         $response = $this->withHeader('Authorization', 'Bearer ' . $token)
             ->postJson('/api/v1/property-requests', [
@@ -105,13 +135,7 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
             'user_id' => $otherTenant->id,
         ]);
 
-        $login = $this->postJson('/api/login', [
-            'recaptcha_token' => 'fake',
-            'email' => $tenant->email,
-            'password' => 'password',
-        ]);
-        $login->assertOk();
-        $token = $login->json('token');
+        $token = $this->loginAs($tenant);
 
         $response = $this->withHeader('Authorization', 'Bearer ' . $token)
             ->postJson('/api/v1/property-requests', [
@@ -123,6 +147,171 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['property_ids']);
+    }
+
+    /** @test */
+    public function create_property_request_with_valid_project_id_persists(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-valid-project',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $project = $this->createProject($tenant);
+        $token = $this->loginAs($tenant);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'With Project ID',
+                'phone' => '+966500000011',
+                'region' => $city->id,
+                'project_id' => $project->id,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.project_id', $project->id);
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $response->json('data.id'),
+            'user_id' => $tenant->id,
+            'project_id' => $project->id,
+        ]);
+    }
+
+    /** @test */
+    public function create_property_request_with_foreign_project_id_fails(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-foreign-project',
+        ]);
+
+        $otherTenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-foreign-project-other',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $foreignProject = $this->createProject($otherTenant);
+        $token = $this->loginAs($tenant);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'Foreign Project ID',
+                'phone' => '+966500000012',
+                'region' => $city->id,
+                'project_id' => $foreignProject->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['project_id']);
+    }
+
+    /** @test */
+    public function create_property_request_normalizes_empty_string_project_id_to_null(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-empty-project',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $token = $this->loginAs($tenant);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'Empty Project ID',
+                'phone' => '+966500000013',
+                'region' => $city->id,
+                'project_id' => '',
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $response->json('data.id'),
+            'user_id' => $tenant->id,
+            'project_id' => null,
+        ]);
+    }
+
+    /** @test */
+    public function update_property_request_can_set_and_clear_project_id(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-update-project',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $project = $this->createProject($tenant);
+        $token = $this->loginAs($tenant);
+
+        $create = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'Update Project ID',
+                'phone' => '+966500000014',
+                'region' => $city->id,
+            ]);
+        $create->assertStatus(201);
+        $requestId = (int) $create->json('data.id');
+
+        $set = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => $project->id,
+            ]);
+        $set->assertOk()
+            ->assertJsonPath('data.project_id', $project->id);
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => $project->id,
+        ]);
+
+        $clear = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => null,
+            ]);
+        $clear->assertOk();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => null,
+        ]);
+
+        $emptyString = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => $project->id,
+            ]);
+        $emptyString->assertOk();
+
+        $normalize = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => '',
+            ]);
+        $normalize->assertOk();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => null,
+        ]);
     }
 }
 

--- a/tests/Feature/V2/CustomersHub/RequestCompleteDataTest.php
+++ b/tests/Feature/V2/CustomersHub/RequestCompleteDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V2\CustomersHub;
 
 use App\Models\User;
+use App\Models\User\RealestateManagement\Project;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -25,9 +26,37 @@ class RequestCompleteDataTest extends TestCase
         }
     }
 
+    private function requireProjectIdColumn(): void
+    {
+        $this->requireTables();
+
+        if (!Schema::hasTable('user_projects')) {
+            $this->markTestSkipped('user_projects table required.');
+        }
+        if (!Schema::hasColumn('users_property_requests', 'project_id')) {
+            $this->markTestSkipped('project_id column required on users_property_requests. Run migration.');
+        }
+    }
+
     private function createTenant(): User
     {
         return User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
     }
 
     private function createPropertyRequest(int $userId, array $overrides = []): int
@@ -191,6 +220,28 @@ class RequestCompleteDataTest extends TestCase
         $row = DB::table('users_property_requests')->where('id', $requestId)->first();
         $this->assertEquals('الرياض', $row->city);
         $this->assertEquals('حي النزهة', $row->district);
+    }
+
+    /** @test */
+    public function complete_data_can_set_project_id(): void
+    {
+        $this->requireProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $requestId = $this->createPropertyRequest($tenant->id);
+
+        $this->postJson("/api/v2/customers-hub/requests/property_request_{$requestId}/complete-data", [
+            'project_id' => $project->id,
+            'city' => 'الرياض',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => $project->id,
+        ]);
     }
 
     /** @test */

--- a/tests/PropertyImportTester.php
+++ b/tests/PropertyImportTester.php
@@ -2,15 +2,20 @@
 
 /**
  * Property Import Tester Script
- * 
+ *
  * This script tests the incomplete properties import feature by:
  * 1. Reading CSV test files
  * 2. Converting them to Excel format
  * 3. Calling the import API
  * 4. Validating responses
  * 5. Reporting errors
- * 
- * Usage: php PropertyImportTester.php
+ *
+ * Usage:
+ *   PROPERTY_IMPORT_TEST_TOKEN=your-token php PropertyImportTester.php [base_url]
+ *   php PropertyImportTester.php [base_url] [token]
+ *   php PropertyImportTester.php [base_url] [token] --debug
+ *
+ * Token is required via the second CLI argument or PROPERTY_IMPORT_TEST_TOKEN env var.
  */
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -26,10 +31,21 @@ class PropertyImportTester
     private $testFilesDir;
     private $results = [];
     
-    public function __construct($baseUrl = 'http://localhost', $token = '3047|uahD3zAkkIoIgCayvGoFcrqT6tPGGa1Yz3CGvK1f14a54d22')
+    public function __construct($baseUrl = 'http://localhost', $token = null)
     {
+        $resolvedToken = $token !== null && $token !== ''
+            ? (string) $token
+            : (string) (getenv('PROPERTY_IMPORT_TEST_TOKEN') ?: '');
+
+        if ($resolvedToken === '') {
+            throw new \InvalidArgumentException(
+                'Sanctum token required. Pass it as the second constructor/CLI argument '
+                . 'or set PROPERTY_IMPORT_TEST_TOKEN in the environment.'
+            );
+        }
+
         $this->baseUrl = rtrim($baseUrl, '/');
-        $this->token = $token;
+        $this->token = $resolvedToken;
         $this->testFilesDir = __DIR__ . '/../docs/test-files/';
     }
     
@@ -430,10 +446,15 @@ class PropertyImportTester
 
 // Run tests
 if (php_sapi_name() === 'cli') {
-    // Get base URL from command line or use default
     $baseUrl = $argv[1] ?? 'http://localhost';
-    $token = $argv[2] ?? '3047|uahD3zAkkIoIgCayvGoFcrqT6tPGGa1Yz3CGvK1f14a54d22';
-    
+    $tokenArg = $argv[2] ?? null;
+    if ($tokenArg === '--debug') {
+        $tokenArg = null;
+    }
+    $token = ($tokenArg !== null && $tokenArg !== '')
+        ? $tokenArg
+        : (getenv('PROPERTY_IMPORT_TEST_TOKEN') ?: null);
+
     // Check if vendor/autoload.php exists
     $autoloadPath = __DIR__ . '/../vendor/autoload.php';
     if (!file_exists($autoloadPath)) {
@@ -441,25 +462,35 @@ if (php_sapi_name() === 'cli') {
         echo "Please run 'composer install' first.\n";
         exit(1);
     }
-    
+
     // Check if test files directory exists
     $testFilesDir = __DIR__ . '/../docs/test-files/';
     if (!is_dir($testFilesDir)) {
         echo "ERROR: Test files directory not found: {$testFilesDir}\n";
         exit(1);
     }
-    
+
+    if ($token === null || $token === '') {
+        echo "ERROR: Sanctum token required.\n";
+        echo "Pass it as the second argument or set PROPERTY_IMPORT_TEST_TOKEN.\n";
+        echo "Usage: php PropertyImportTester.php [base_url] [token] [--debug]\n";
+        echo "Example: PROPERTY_IMPORT_TEST_TOKEN=your-token php PropertyImportTester.php http://localhost:8000\n";
+        echo "Example: php PropertyImportTester.php http://localhost:8000 \"your-token\" --debug\n";
+        exit(1);
+    }
+
     echo "Base URL: {$baseUrl}\n";
     echo "Test Files Directory: {$testFilesDir}\n";
     echo "\n";
-    
+
     try {
         $tester = new PropertyImportTester($baseUrl, $token);
         $tester->runAllTests();
     } catch (\Exception $e) {
         echo "\n❌ FATAL ERROR: " . $e->getMessage() . "\n";
         echo "File: " . $e->getFile() . ":" . $e->getLine() . "\n";
-        if (isset($argv[3]) && $argv[3] === '--debug') {
+        $debug = in_array('--debug', $argv, true);
+        if ($debug) {
             echo "\nStack Trace:\n" . $e->getTraceAsString() . "\n";
         }
         exit(1);
@@ -467,6 +498,6 @@ if (php_sapi_name() === 'cli') {
 } else {
     echo "This script must be run from command line.\n";
     echo "Usage: php PropertyImportTester.php [base_url] [token] [--debug]\n";
-    echo "Example: php PropertyImportTester.php http://localhost:8000\n";
+    echo "Example: PROPERTY_IMPORT_TEST_TOKEN=your-token php PropertyImportTester.php http://localhost:8000\n";
     echo "Example: php PropertyImportTester.php http://localhost:8000 \"your-token\" --debug\n";
 }

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -72,6 +72,18 @@ class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
         $this->assertArrayNotHasKey(Str::slug('عنوان الإعلان', '_'), $normalized);
     }
 
+    public function test_prepare_for_validation_casts_numeric_unit_number_to_string(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+
+        $data = $import->prepareForValidation([
+            Str::slug('رقم الوحدة', '_') => 301,
+        ], 3);
+
+        $this->assertSame('301', $data['unit_number']);
+        $this->assertIsString($data['unit_number']);
+    }
+
     public function test_prepare_for_validation_remaps_headers_and_purpose_type(): void
     {
         $import = $this->newImportWithoutConstructor();

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -84,6 +84,41 @@ class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
         $this->assertIsString($data['unit_number']);
     }
 
+    public function test_prepare_for_validation_casts_numeric_boolean_like_fields_from_raw_export(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+
+        $data = $import->prepareForValidation([
+            Str::slug('مصعد', '_') => 0,
+            'featured' => 0,
+            'balcony' => 0,
+            'maid_room' => 0,
+            'storage_room' => 0,
+            'swimming_pool' => 0,
+        ], 2);
+
+        $this->assertSame('0', $data['amenity_مصعد']);
+        $this->assertSame('0', $data['featured']);
+        $this->assertSame('0', $data['balcony']);
+        $this->assertSame('0', $data['maid_room']);
+        $this->assertSame('0', $data['storage_room']);
+        $this->assertSame('0', $data['swimming_pool']);
+    }
+
+    public function test_normalize_row_keys_keeps_first_non_empty_when_duplicate_headers_map_to_same_key(): void
+    {
+        $normalize = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('normalizeRowKeys');
+        $normalize->setAccessible(true);
+        $import = $this->newImportWithoutConstructor();
+
+        $normalized = $normalize->invoke($import, [
+            Str::slug('دورات المياه', '_') => 3,
+            'bath' => null,
+        ]);
+
+        $this->assertSame(3, $normalized['bath']);
+    }
+
     public function test_prepare_for_validation_remaps_headers_and_purpose_type(): void
     {
         $import = $this->newImportWithoutConstructor();

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Imports;
+
+use App\Imports\PropertiesSingleSheetImport;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use Tests\TestCase;
+
+class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
+{
+    /**
+     * @return array<string, string>
+     */
+    private function headerKeyMap(): array
+    {
+        $method = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('headerKeyMap');
+        $method->setAccessible(true);
+
+        return $method->invoke(null);
+    }
+
+    public function test_header_key_map_includes_exact_arabic_and_maatwebsite_slugs(): void
+    {
+        $map = $this->headerKeyMap();
+
+        $this->assertSame('title', $map['عنوان الإعلان']);
+        $this->assertSame('title', $map[Str::slug('عنوان الإعلان', '_')]);
+        $this->assertSame('aanoan_alaaalan', Str::slug('عنوان الإعلان', '_'));
+
+        $this->assertSame('purpose', $map['الغرض']);
+        $this->assertSame('purpose', $map[Str::slug('الغرض', '_')]);
+
+        $this->assertSame('type', $map['النوع']);
+        $this->assertSame('type', $map[Str::slug('النوع', '_')]);
+
+        $this->assertSame('price', $map['السعر']);
+        $this->assertSame('price', $map[Str::slug('السعر', '_')]);
+
+        $this->assertSame('amenity_مصعد', $map['مصعد']);
+        $this->assertSame('amenity_مصعد', $map[Str::slug('مصعد', '_')]);
+        $this->assertSame('amenity_مصعد', $map[Str::slug('amenity_مصعد', '_')]);
+    }
+
+    public function test_normalize_row_keys_maps_slugified_arabic_headers(): void
+    {
+        $normalize = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('normalizeRowKeys');
+        $normalize->setAccessible(true);
+
+        // Bypass constructor language requirement by allocating without __construct
+        $import = $this->newImportWithoutConstructor();
+
+        $row = [
+            Str::slug('عنوان الإعلان', '_') => 'شقة الرياض',
+            Str::slug('السعر', '_') => 500000,
+            Str::slug('الغرض', '_') => 'بيع',
+            Str::slug('النوع', '_') => 'سكني',
+            Str::slug('مصعد', '_') => 'نعم',
+            'title' => 'should-not-overwrite-if-absent',
+        ];
+        unset($row['title']);
+
+        $normalized = $normalize->invoke($import, $row);
+
+        $this->assertSame('شقة الرياض', $normalized['title']);
+        $this->assertSame(500000, $normalized['price']);
+        $this->assertSame('بيع', $normalized['purpose']);
+        $this->assertSame('سكني', $normalized['type']);
+        $this->assertSame('نعم', $normalized['amenity_مصعد']);
+        $this->assertArrayNotHasKey(Str::slug('عنوان الإعلان', '_'), $normalized);
+    }
+
+    public function test_prepare_for_validation_remaps_headers_and_purpose_type(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+
+        $data = $import->prepareForValidation([
+            Str::slug('عنوان الإعلان', '_') => 'وحدة تجريبية',
+            Str::slug('الغرض', '_') => 'إيجار',
+            Str::slug('النوع', '_') => 'تجاري',
+            Str::slug('مصعد', '_') => 'نعم',
+            Str::slug('أمن', '_') => 'لا',
+        ], 2);
+
+        $this->assertSame('وحدة تجريبية', $data['title']);
+        $this->assertSame('rent', $data['purpose']);
+        $this->assertSame('commercial', $data['type']);
+        $this->assertSame('نعم', $data['amenity_مصعد']);
+        $this->assertSame('لا', $data['amenity_أمن']);
+    }
+
+    public function test_amenity_validation_rules_accept_arabic_yes_no(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+        $rules = $import->rules();
+
+        foreach ([
+            'amenity_مصعد',
+            'amenity_أمن',
+            'amenity_كاميرات_مراقبة',
+            'amenity_تكييف_مركزي',
+            'amenity_تدفئة_مركزية',
+            'amenity_صيانة',
+            'amenity_بواب',
+            'amenity_إنترنت',
+        ] as $field) {
+            $this->assertArrayHasKey($field, $rules);
+            $this->assertStringContainsString('نعم', $rules[$field]);
+            $this->assertStringContainsString('لا', $rules[$field]);
+        }
+    }
+
+    private function newImportWithoutConstructor(): PropertiesSingleSheetImport
+    {
+        return (new ReflectionClass(PropertiesSingleSheetImport::class))
+            ->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
## Summary
- Make project ID optional/validated on property request flows.
- Includes related property request validation handling.

## Merge order
Merge **after** `feature/steps-progress-api` into `feat-mahmoud` (this branch is stacked on top of it).

## Test plan
- [ ] Create/update property requests with and without `project_id`
- [ ] Confirm validation errors for invalid project IDs
- [ ] Frontend handoff doc still matches API behavior