### PR TITLE
fix: optional type_id on customer create + CRM default seeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ my-skill/agents/openai.yaml
 _misc_files/db/*
 scripts/git-hooks/
 .cursor/
+scripts/copy-test-db.ps1

--- a/app/Console/Commands/BackfillTenantCrmDefaults.php
+++ b/app/Console/Commands/BackfillTenantCrmDefaults.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Api\UserApiCustomerPriority;
+use App\Models\Api\UserApiCustomerProcedure;
+use App\Models\Api\UserApiCustomerType;
+use App\Models\User;
+use App\Services\TenantCrmBootstrapService;
+use Illuminate\Console\Command;
+
+/**
+ * Backfills the CRM lookup rows (types, priorities, procedures) that used to be
+ * created only as a side effect of loading GET /api/crm. Tenants that never
+ * opened the CRM dashboard have none, which leaves customer creation with no
+ * type to default to.
+ *
+ * Deliberately does not touch property_request_auto_customer_settings, so a
+ * tenant that disabled auto-create keeps that choice.
+ */
+class BackfillTenantCrmDefaults extends Command
+{
+    protected $signature = 'crm:backfill-tenant-defaults
+                            {--tenant= : Only process a specific tenant ID}
+                            {--dry-run : Report what would be created without writing}
+                            {--chunk=200 : Tenants to load per batch}';
+
+    protected $description = 'Create missing default CRM types, priorities and procedures for existing tenants';
+
+    public function __construct(
+        private TenantCrmBootstrapService $bootstrap
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $tenantId = $this->option('tenant');
+        $dryRun = (bool) $this->option('dry-run');
+        $chunk = max(1, (int) $this->option('chunk'));
+
+        if ($dryRun) {
+            $this->warn('DRY RUN - no changes will be written.');
+            $this->newLine();
+        }
+
+        $query = User::query()->where('account_type', 'tenant');
+
+        if ($tenantId) {
+            $query->where('id', (int) $tenantId);
+        }
+
+        $total = (clone $query)->count();
+
+        if ($total === 0) {
+            $this->warn('No tenants matched.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Processing {$total} tenant(s)...");
+
+        $touched = 0;
+        $createdTypes = 0;
+        $createdPriorities = 0;
+        $createdProcedures = 0;
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $query->orderBy('id')->chunkById($chunk, function ($tenants) use (
+            $dryRun,
+            $bar,
+            &$touched,
+            &$createdTypes,
+            &$createdPriorities,
+            &$createdProcedures
+        ) {
+            foreach ($tenants as $tenant) {
+                $id = (int) $tenant->id;
+
+                $missingTypes = $this->missingTypes($id);
+                $missingPriorities = $this->missingPriorities($id);
+                $missingProcedures = $this->missingProcedures($id);
+                $missingTotal = $missingTypes + $missingPriorities + $missingProcedures;
+
+                if ($missingTotal > 0) {
+                    $touched++;
+                    $createdTypes += $missingTypes;
+                    $createdPriorities += $missingPriorities;
+                    $createdProcedures += $missingProcedures;
+
+                    if (! $dryRun) {
+                        $this->bootstrap->ensureDefaultTypes($id);
+                        $this->bootstrap->ensureDefaultPriorities($id);
+                        $this->bootstrap->ensureDefaultProcedures($id);
+                    }
+                }
+
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine(2);
+
+        $verb = $dryRun ? 'Would create' : 'Created';
+
+        $this->table(
+            ['Metric', 'Count'],
+            [
+                ['Tenants scanned', $total],
+                ['Tenants needing rows', $touched],
+                ["{$verb} types", $createdTypes],
+                ["{$verb} priorities", $createdPriorities],
+                ["{$verb} procedures", $createdProcedures],
+            ]
+        );
+
+        if ($dryRun) {
+            $this->newLine();
+            $this->warn('Dry run only. Re-run without --dry-run to apply.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function missingTypes(int $tenantId): int
+    {
+        $existing = UserApiCustomerType::where('user_id', $tenantId)->pluck('value')->all();
+
+        return $this->countMissing(array_column(TenantCrmBootstrapService::defaultTypes(), 'value'), $existing);
+    }
+
+    private function missingPriorities(int $tenantId): int
+    {
+        $existing = UserApiCustomerPriority::where('user_id', $tenantId)->pluck('value')->all();
+
+        return $this->countMissing(array_column(TenantCrmBootstrapService::defaultPriorities(), 'value'), $existing);
+    }
+
+    private function missingProcedures(int $tenantId): int
+    {
+        $existing = UserApiCustomerProcedure::where('user_id', $tenantId)->pluck('procedure_name')->all();
+
+        return $this->countMissing(array_column(TenantCrmBootstrapService::defaultProcedures(), 'procedure_name'), $existing);
+    }
+
+    /**
+     * @param  list<string|int>  $expected
+     * @param  list<string|int|null>  $existing
+     */
+    private function countMissing(array $expected, array $existing): int
+    {
+        $existing = array_map(static fn ($v) => (string) $v, $existing);
+
+        $missing = 0;
+        foreach ($expected as $value) {
+            if (! in_array((string) $value, $existing, true)) {
+                $missing++;
+            }
+        }
+
+        return $missing;
+    }
+}

--- a/app/Console/Commands/CheckUserPropertiesCompletion.php
+++ b/app/Console/Commands/CheckUserPropertiesCompletion.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\User\Language;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
+use App\Support\PropertyCompletionRequirements;
 use Illuminate\Console\Command;
 
 /**
@@ -21,15 +22,13 @@ class CheckUserPropertiesCompletion extends Command
 
     protected $description = 'Verify complete properties for a user have no missing required fields (user_properties + user_property_contents)';
 
-    protected array $requiredFields = ['title', 'price', 'address', 'description', 'purpose', 'property_type', 'area'];
-
     public function handle(): int
     {
         $userId = (int) $this->argument('user_id');
 
         $query = Property::where('user_id', $userId)
             ->where('completion_status', 'complete')
-            ->select(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'completion_status']);
+            ->select(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'featured_image', 'completion_status']);
 
         $properties = $query->get();
 
@@ -66,7 +65,7 @@ class CheckUserPropertiesCompletion extends Command
         }
         $this->table(['Property ID', 'Missing fields'], $rows);
         $this->newLine();
-        $this->info('Required: title, price, address, description, purpose, property_type, area.');
+        $this->info('Required: ' . implode(', ', PropertyCompletionRequirements::fields()) . '.');
         $this->info('Content fields come from user_property_contents for the owner default language.');
 
         return self::FAILURE;
@@ -79,7 +78,7 @@ class CheckUserPropertiesCompletion extends Command
             ->first();
 
         if (!$defaultLanguage) {
-            return $this->requiredFields;
+            return PropertyCompletionRequirements::fields();
         }
 
         $content = PropertyContent::where('property_id', $property->id)
@@ -88,22 +87,12 @@ class CheckUserPropertiesCompletion extends Command
 
         $currentData = [
             'title' => $content?->title,
-            'price' => $property->price,
             'address' => $content?->address,
             'description' => $content?->description,
-            'purpose' => $property->purpose,
             'property_type' => $property->property_type,
-            'area' => $property->area,
+            'featured_image' => $property->featured_image,
         ];
 
-        $missing = [];
-        foreach ($this->requiredFields as $field) {
-            $value = $currentData[$field] ?? null;
-            if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
-                $missing[] = $field;
-            }
-        }
-
-        return $missing;
+        return PropertyCompletionRequirements::missingFrom($currentData);
     }
 }

--- a/app/Console/Commands/FixLegacyIncompleteProperties.php
+++ b/app/Console/Commands/FixLegacyIncompleteProperties.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
 use App\Models\User\Language;
+use App\Support\PropertyCompletionRequirements;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -29,11 +30,6 @@ class FixLegacyIncompleteProperties extends Command
      * @var string
      */
     protected $description = 'Fix legacy properties that are marked as complete but are missing required fields';
-
-    /**
-     * Required fields for a complete property
-     */
-    protected $requiredFields = ['title', 'price', 'address', 'description', 'purpose', 'type', 'area'];
 
     /**
      * Execute the console command.
@@ -78,7 +74,7 @@ class FixLegacyIncompleteProperties extends Command
             ->with(['contents' => function($q) {
                 $q->select('id', 'property_id', 'language_id', 'title', 'address', 'description');
             }])
-            ->get(['id', 'user_id', 'price', 'purpose', 'type', 'area', 'completion_status']);
+            ->get(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'featured_image', 'completion_status']);
 
         $incompleteProperties = [];
         $sampleData = [];
@@ -202,7 +198,7 @@ class FixLegacyIncompleteProperties extends Command
         // Process in chunks to avoid memory issues
         // Select only fields we need to avoid loading large JSON features that might trigger features_text virtual column issues
         $query = $baseQuery()
-            ->select(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'completion_status']);
+            ->select(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'featured_image', 'completion_status']);
 
         $totalToProcess = $query->count();
         $this->output->progressStart($totalToProcess);
@@ -366,7 +362,7 @@ class FixLegacyIncompleteProperties extends Command
 
         if (!$defaultLanguage) {
             // If no default language, mark as incomplete with all fields missing
-            return $this->requiredFields;
+            return PropertyCompletionRequirements::fields();
         }
 
         // Get property content for default language
@@ -377,23 +373,13 @@ class FixLegacyIncompleteProperties extends Command
         // Check current data
         $currentData = [
             'title' => $propertyContent?->title,
-            'price' => $property->price,
             'address' => $propertyContent?->address,
             'description' => $propertyContent?->description,
-            'purpose' => $property->purpose,
             'property_type' => $property->property_type,
-            'area' => $property->area,
+            'featured_image' => $property->featured_image,
         ];
 
-        // Identify missing fields
-        $missingFields = [];
-        foreach ($this->requiredFields as $field) {
-            $value = $currentData[$field] ?? null;
-            if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
-                $missingFields[] = $field;
-            }
-        }
-
-        return $missingFields;
+        // Use the helper to get missing fields
+        return PropertyCompletionRequirements::missingFrom($currentData);
     }
 }

--- a/app/Console/Commands/ImportCitiesAndDistricts.php
+++ b/app/Console/Commands/ImportCitiesAndDistricts.php
@@ -5,71 +5,323 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use App\Models\User\UserCity;
 use App\Models\User\UserDistrict;
+use App\Support\LocationLookupCache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\DB;
 
-
-
+/**
+ * One-time (re-runnable) sync of Saudi cities and districts from nzl-backend.
+ *
+ * nzl ids are preserved verbatim on both tables: taearif records created before
+ * this sync already reference them, so a generated id would orphan live data.
+ * Locally created locations get ids from a reserved range instead -- see
+ * database/migrations/2026_08_09_000001_prepare_user_locations_for_nzl_sync.php.
+ */
 class ImportCitiesAndDistricts extends Command
 {
-    protected $signature = 'import:cities-districts';
-    protected $description = 'Import cities and districts from external API';
+    protected $signature = 'import:cities-districts {--dry-run : Report what would change without writing}';
+    protected $description = 'Import Saudi cities and districts from nzl-backend, preserving their ids';
+
+    const CITIES_URL = 'https://nzl-backend.com/api/cities?country_id=1';
+    const DISTRICTS_URL = 'https://nzl-backend.com/api/districts';
+    const SAUDI_COUNTRY_ID = 1;
 
     public function handle()
     {
-        $this->importCities();
-        $this->importDistricts();
-    }
+        $dryRun = (bool) $this->option('dry-run');
 
-    private function importCities()
-    {
-        $response = Http::get('https://nzl-backend.com/api/cities?country_id=1');
-
-        if ($response->successful()) {
-            foreach ($response['data'] as $cityData) {
-                UserCity::updateOrCreate(
-                    ['id' => $cityData['id']],
-                    [
-                        'name_ar' => $cityData['name_ar'],
-                        'name_en' => $cityData['name_en'],
-                        'country_id' => $cityData['country_id'],
-                        'region_id' => $cityData['region_id'],
-                        'latitude' => $cityData['latitude'],
-                        'longitude' => $cityData['longitude'],
-                    ]
-                );
-            }
-
-            $this->info("Cities imported successfully.");
-        } else {
-            $this->error("Failed to fetch cities.");
+        if ($dryRun) {
+            $this->warn('DRY RUN - no writes will be performed.');
         }
+
+        $cities = $this->fetch(self::CITIES_URL, 120, 'cities');
+        if ($cities === null) {
+            return 1;
+        }
+
+        $districts = $this->fetch(self::DISTRICTS_URL, 180, 'districts');
+        if ($districts === null) {
+            return 1;
+        }
+
+        $districts = $this->saudiOnly($districts);
+
+        $cityIds = $this->importCities($cities, $dryRun);
+        $projectedCities = $this->importDistricts($districts, $dryRun);
+        $this->backfillCitiesFromDistricts($projectedCities, $cityIds, $dryRun);
+
+        if (! $dryRun) {
+            LocationLookupCache::flush();
+            $this->info('Cleared cached /api/cities and /api/districts payloads.');
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '%s -> cities: %d, districts: %d',
+            $dryRun ? 'Totals before this dry run' : 'Totals',
+            UserCity::count(),
+            UserDistrict::count()
+        ));
+
+        return 0;
     }
 
-    private function importDistricts()
+    /**
+     * @return array|null  null signals a failed request (caller aborts).
+     */
+    private function fetch(string $url, int $timeout, string $label)
     {
-        foreach (range(1, 6) as $cityId) {
-            $response = Http::get("https://nzl-backend.com/api/districts?city_id={$cityId}");
+        $this->info("Fetching {$label}...");
 
-            if ($response->successful()) {
-                foreach ($response['data'] as $districtData) {
-                    UserDistrict::updateOrCreate(
-                        ['id' => $districtData['id']],
+        try {
+            $response = Http::timeout($timeout)->get($url);
+        } catch (\Throwable $e) {
+            $this->error("Failed to fetch {$label}: " . $e->getMessage());
+
+            return null;
+        }
+
+        if (! $response->successful()) {
+            $this->error("Failed to fetch {$label}. HTTP status: " . $response->status());
+
+            return null;
+        }
+
+        $rows = $response->json('data');
+
+        if (! is_array($rows) || empty($rows)) {
+            $this->error("Fetched {$label} but the payload was empty or malformed.");
+
+            return null;
+        }
+
+        return $rows;
+    }
+
+    private function saudiOnly(array $districts): array
+    {
+        return array_values(array_filter($districts, function ($row) {
+            $en = isset($row['country_name_en']) ? $row['country_name_en'] : '';
+            $ar = isset($row['country_name_ar']) ? $row['country_name_ar'] : '';
+
+            return $en === 'Saudi Arabia' || $ar === 'السعودية';
+        }));
+    }
+
+    /**
+     * @return array  ids of every city the table will hold once this step commits,
+     *                as a lookup map. Returned rather than re-queried so --dry-run
+     *                does not re-report cities this step would already have created.
+     */
+    private function importCities(array $cities, bool $dryRun): array
+    {
+        $existingIds = UserCity::pluck('id')->all();
+        $existingIds = array_flip(array_map('intval', $existingIds));
+
+        $toCreate = [];
+        $toUpdate = [];
+
+        foreach ($cities as $row) {
+            if (isset($existingIds[(int) $row['id']])) {
+                $toUpdate[] = $row;
+            } else {
+                $toCreate[] = $row;
+            }
+        }
+
+        if (! $dryRun) {
+            DB::transaction(function () use ($cities) {
+                foreach ($cities as $row) {
+                    UserCity::updateOrCreate(
+                        ['id' => $row['id']],
                         [
-                            'name_ar' => $districtData['name_ar'],
-                            'name_en' => $districtData['name_en'],
-                            'city_id' => $districtData['city_id'],
-                            'city_name_ar' => $districtData['city_name_ar'],
-                            'city_name_en' => $districtData['city_name_en'],
-                            'country_name_ar' => $districtData['country_name_ar'],
-                            'country_name_en' => $districtData['country_name_en'],
+                            'name_ar' => $row['name_ar'],
+                            'name_en' => $row['name_en'],
+                            'country_id' => $row['country_id'],
+                            'region_id' => isset($row['region_id']) ? $row['region_id'] : null,
+                            'latitude' => isset($row['latitude']) ? $row['latitude'] : null,
+                            'longitude' => isset($row['longitude']) ? $row['longitude'] : null,
                         ]
                     );
                 }
+            });
+        }
 
-                $this->info("Districts for city_id {$cityId} imported.");
-            } else {
-                $this->error("Failed to fetch districts for city_id {$cityId}.");
+        $this->info(sprintf(
+            'Cities: %d fetched, %d created, %d updated',
+            count($cities),
+            count($toCreate),
+            count($toUpdate)
+        ));
+
+        foreach ($cities as $row) {
+            $existingIds[(int) $row['id']] = true;
+        }
+
+        return $existingIds;
+    }
+
+    /**
+     * Applies three rules per incoming district:
+     *   (a) unknown id            -> create with the nzl id verbatim
+     *   (b) known id, same city   -> refresh display names only
+     *   (c) known id, other city  -> skip entirely and report
+     *
+     * (c) is not hypothetical: nzl reused id 11302270959 for a district in a
+     * different city. Re-parenting an existing row would silently relocate every
+     * property/request/customer pointing at it, so city_id is never rewritten.
+     *
+     * @return array  cityId => ['name_ar' => ..., 'name_en' => ...] for every city the
+     *                districts table will reference once this run commits. Built in
+     *                memory rather than re-queried so --dry-run projects accurately.
+     */
+    private function importDistricts(array $districts, bool $dryRun): array
+    {
+        $existing = UserDistrict::select('id', 'city_id', 'name_ar', 'name_en', 'city_name_ar', 'city_name_en')
+            ->get()
+            ->keyBy('id');
+
+        $create = [];
+        $update = [];
+        $conflicts = [];
+        $projectedCities = [];
+
+        foreach ($districts as $row) {
+            $id = (int) $row['id'];
+            $incomingCityId = (int) $row['city_id'];
+            $local = $existing->get($id);
+
+            if ($local === null) {
+                $create[] = $row;
+                $projectedCities[$incomingCityId] = [
+                    'name_ar' => $row['city_name_ar'],
+                    'name_en' => $row['city_name_en'],
+                ];
+                continue;
             }
+
+            if ((int) $local->city_id !== $incomingCityId) {
+                $conflicts[] = [
+                    $id,
+                    $local->name_ar,
+                    (int) $local->city_id,
+                    $row['name_ar'],
+                    $incomingCityId,
+                ];
+                continue;
+            }
+
+            if ($local->name_ar !== $row['name_ar'] || $local->name_en !== $row['name_en']) {
+                $update[] = $row;
+            }
+        }
+
+        // Rows already present keep their existing city, including skipped conflicts.
+        // These overwrite payload-derived names so stored values win on disagreement.
+        foreach ($existing as $local) {
+            $projectedCities[(int) $local->city_id] = [
+                'name_ar' => $local->city_name_ar,
+                'name_en' => $local->city_name_en,
+            ];
+        }
+
+        if (! $dryRun) {
+            DB::transaction(function () use ($create, $update) {
+                foreach (array_chunk($create, 500) as $chunk) {
+                    $now = now();
+                    $rows = [];
+                    foreach ($chunk as $row) {
+                        $rows[] = [
+                            'id' => $row['id'],
+                            'name_ar' => $row['name_ar'],
+                            'name_en' => $row['name_en'],
+                            'city_id' => $row['city_id'],
+                            'city_name_ar' => $row['city_name_ar'],
+                            'city_name_en' => $row['city_name_en'],
+                            'country_name_ar' => $row['country_name_ar'],
+                            'country_name_en' => $row['country_name_en'],
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+                    }
+                    UserDistrict::insert($rows);
+                }
+
+                foreach ($update as $row) {
+                    UserDistrict::where('id', $row['id'])->update([
+                        'name_ar' => $row['name_ar'],
+                        'name_en' => $row['name_en'],
+                    ]);
+                }
+            });
+        }
+
+        $this->info(sprintf(
+            'Districts: %d fetched (Saudi only), %d created, %d renamed, %d skipped',
+            count($districts),
+            count($create),
+            count($update),
+            count($conflicts)
+        ));
+
+        if (! empty($conflicts)) {
+            $this->newLine();
+            $this->warn('Skipped - id exists locally under a different city. Review manually; city_id is never rewritten:');
+            $this->table(
+                ['District ID', 'Local name', 'Local city', 'Incoming name', 'Incoming city'],
+                $conflicts
+            );
+        }
+
+        return $projectedCities;
+    }
+
+    /**
+     * Some cities are reachable only through the districts payload (as the
+     * denormalized city_name_* columns) and never appear in nzl's /cities list.
+     * region_id stays null: the region code embedded in a district id agrees with
+     * nzl's own region_id for just 37 of 397 known cities, so it is not derivable.
+     */
+    private function backfillCitiesFromDistricts(array $projectedCities, array $existingIds, bool $dryRun): void
+    {
+        $rows = [];
+        $unnamed = [];
+
+        foreach ($projectedCities as $cityId => $name) {
+            if (isset($existingIds[$cityId])) {
+                continue;
+            }
+
+            if (empty($name['name_ar'])) {
+                $unnamed[] = $cityId;
+                continue;
+            }
+
+            $rows[] = [
+                'id' => $cityId,
+                'name_ar' => $name['name_ar'],
+                'name_en' => $name['name_en'],
+                'country_id' => self::SAUDI_COUNTRY_ID,
+                'region_id' => null,
+                'latitude' => null,
+                'longitude' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        }
+
+        if (! $dryRun && ! empty($rows)) {
+            DB::transaction(function () use ($rows) {
+                foreach (array_chunk($rows, 500) as $chunk) {
+                    UserCity::insert($chunk);
+                }
+            });
+        }
+
+        $this->info('Cities backfilled from districts: ' . count($rows));
+
+        if (! empty($unnamed)) {
+            $this->warn('Skipped backfill (no usable city name on any district row): ' . implode(', ', $unnamed));
         }
     }
 }

--- a/app/Exports/PropertiesExport.php
+++ b/app/Exports/PropertiesExport.php
@@ -4,7 +4,9 @@ namespace App\Exports;
 
 use App\Models\User\RealestateManagement\Property;
 use App\Support\PropertyExcelMapping;
+use App\Support\PropertyFilterQuery;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithTitle;
@@ -14,7 +16,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 
-class PropertiesExport implements FromQuery, WithHeadings, WithMapping, WithTitle, WithEvents
+class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, WithMapping, WithTitle, WithEvents
 {
     protected $userId;
     protected $allowedUserIds;
@@ -52,128 +54,14 @@ class PropertiesExport implements FromQuery, WithHeadings, WithMapping, WithTitl
             ])
             ->whereIn('user_id', $this->allowedUserIds);
 
-        // Apply property IDs filter if provided (for selected properties export)
-        if (!empty($this->filters['ids']) && is_array($this->filters['ids']) && count($this->filters['ids']) > 0) {
-            $query->whereIn('id', $this->filters['ids']);
-        }
-
-        // Apply date range filter (optional if IDs are provided)
-        if (!empty($this->filters['date_from'])) {
-            $query->whereDate('created_at', '>=', $this->filters['date_from']);
-        }
-        if (!empty($this->filters['date_to'])) {
-            $query->whereDate('created_at', '<=', $this->filters['date_to']);
-        }
-
-        // Apply purpose filter
-        if (!empty($this->filters['purposes_filter'])) {
-            $query->where('purpose', $this->filters['purposes_filter']);
-        }
-        if (!empty($this->filters['purpose'])) {
-            $query->where('purpose', $this->filters['purpose']);
-        }
-
-        // Apply type filter
-        if (!empty($this->filters['type'])) {
-            $query->where('property_type', $this->filters['type']);
-        }
-
-        // Apply price filters
-        if (!empty($this->filters['price_from'])) {
-            $query->where('price', '>=', $this->filters['price_from']);
-        }
-        if (!empty($this->filters['price_to'])) {
-            $query->where('price', '<=', $this->filters['price_to']);
-        }
-
-        // Apply area filters
-        if (!empty($this->filters['area_from'])) {
-            $query->where('area', '>=', $this->filters['area_from']);
-        }
-        if (!empty($this->filters['area_to'])) {
-            $query->where('area', '<=', $this->filters['area_to']);
-        }
-
-        // Apply beds filter
-        if (!empty($this->filters['beds'])) {
-            $query->where('beds', $this->filters['beds']);
-        }
-
-        // Apply bath filter
-        if (!empty($this->filters['bath'])) {
-            $query->where('bath', $this->filters['bath']);
-        }
-
-        // Apply category filter
-        if (!empty($this->filters['category_id'])) {
-            $query->where('category_id', $this->filters['category_id']);
-        }
-
-        // Apply status filter
-        if (isset($this->filters['status']) && $this->filters['status'] !== '') {
-            $query->where('status', $this->filters['status']);
-        }
-
-        // Apply featured filter
-        if (isset($this->filters['featured']) && $this->filters['featured'] !== '') {
-            $query->where('featured', $this->filters['featured']);
-        }
-
-        // Apply city filter
-        if (!empty($this->filters['city_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('city_id', $this->filters['city_id']);
-            });
-        }
-
-        // Apply district filter
-        if (!empty($this->filters['district_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('state_id', $this->filters['district_id']);
-            });
-        }
-
-        // Apply search filter (title/address, plus numeric property ID)
-        if (!empty($this->filters['search'])) {
-            $search = trim((string) $this->filters['search']);
-            $numericId = $this->parsePositiveIntSearchId($search);
-            $query->where(function ($q) use ($search, $numericId) {
-                $q->whereHas('contents', function ($cq) use ($search) {
-                    $cq->where(function ($inner) use ($search) {
-                        $inner->where('title', 'like', "%{$search}%")
-                              ->orWhere('address', 'like', "%{$search}%");
-                    });
-                });
-                if ($numericId !== null) {
-                    $q->orWhere('id', $numericId);
-                }
-            });
-        }
-
-        // Apply features filter
-        if (!empty($this->filters['features'])) {
-            $featuresArray = explode(',', $this->filters['features']);
-            foreach ($featuresArray as $feature) {
-                $feature = trim($feature);
-                $query->whereJsonContains('features', $feature);
-            }
-        }
+        PropertyFilterQuery::apply($query, $this->filters);
 
         return $query->orderBy('created_at', 'desc');
     }
 
-    private function parsePositiveIntSearchId(?string $searchTerm): ?int
+    public function chunkSize(): int
     {
-        $searchTerm = trim((string) $searchTerm);
-        if ($searchTerm === ''
-            || !ctype_digit($searchTerm)
-            || strlen($searchTerm) > 18
-            || (int) $searchTerm <= 0
-        ) {
-            return null;
-        }
-
-        return (int) $searchTerm;
+        return 500;
     }
 
     public function headings(): array

--- a/app/Exports/PropertiesExport.php
+++ b/app/Exports/PropertiesExport.php
@@ -3,54 +3,74 @@
 namespace App\Exports;
 
 use App\Models\User\RealestateManagement\Property;
+use App\Models\User\UserDistrict;
 use App\Support\PropertyExcelMapping;
 use App\Support\PropertyFilterQuery;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
-use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 
-class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, WithMapping, WithTitle, WithEvents
+/**
+ * Regular properties export — same 40-column import-safe layout as
+ * PropertiesTemplateExport / PropertiesImportReadyExport (no id, no export-only metadata).
+ */
+class PropertiesExport implements WithMultipleSheets
 {
     protected $userId;
     protected $allowedUserIds;
     protected $filters;
-    protected $isTemplate;
 
-    public function __construct($userId, array $allowedUserIds, array $filters = [], $isTemplate = false)
+    public function __construct($userId, array $allowedUserIds, array $filters = [])
     {
         $this->userId = $userId;
         $this->allowedUserIds = $allowedUserIds;
         $this->filters = $filters;
-        $this->isTemplate = $isTemplate;
+    }
+
+    public function sheets(): array
+    {
+        return [
+            new PropertiesExportMainSheet($this->userId, $this->allowedUserIds, $this->filters),
+            new PropertiesTemplateLookupSheetExport(),
+        ];
+    }
+}
+
+class PropertiesExportMainSheet implements FromQuery, WithChunkReading, WithHeadings, WithMapping, WithTitle, WithEvents
+{
+    protected $userId;
+    protected $allowedUserIds;
+    protected $filters;
+
+    public function __construct($userId, array $allowedUserIds, array $filters = [])
+    {
+        $this->userId = $userId;
+        $this->allowedUserIds = $allowedUserIds;
+        $this->filters = $filters;
     }
 
     public function query()
     {
         $query = Property::query()
             ->with([
-                'category:id,name',
-                'user:id,username,first_name,last_name',
                 'contents' => function ($q) {
                     $q->with([
                         'city:id,name_ar,name_en',
                         'state:id,name',
-                        'country:id,name',
                     ]);
                 },
                 'galleryImages:id,property_id,image',
                 'proertyAmenities.amenity:id,name',
                 'UserPropertyCharacteristics',
                 'specifications:id,property_id,label,value',
-                'project.contents:id,project_id,title',
-                'building:id,name',
-                'creator:id,first_name,last_name,username',
             ])
             ->whereIn('user_id', $this->allowedUserIds);
 
@@ -66,52 +86,22 @@ class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, Wit
 
     public function headings(): array
     {
-        if ($this->isTemplate) {
-            return [
-                'عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة',
-                'غرف النوم', 'دورات المياه', 'المدينة', 'الحي', 'الصورة الرئيسية', 'رابط الفيديو',
-                'الحالة', 'السعر للمتر', 'معرض الصور',
-                'مصعد', 'أمن', 'كاميرات مراقبة', 'تكييف مركزي',
-                'تدفئة مركزية', 'صيانة', 'بواب', 'إنترنت',
-                'مرافق إضافية', 'رقم الوحدة', 'رقم الطابق', 'عمر المبنى',
-                'نوع الإطلالة', 'مفروش', 'مواقف السيارات', 'بلكونة', 'غرفة خادمة',
-                'غرفة تخزين', 'مسبح', 'صالة رياضية', 'مساحة الحديقة', 'المواصفات',
-                'طريقة الدفع', 'مميز', 'مميزات'
-            ];
-        }
-
         return [
-            'المعرّف',
             'عنوان الإعلان',
-            'الوصف',
-            'العنوان',
-            'المدينة',
-            'الحي',
-            'المنطقة',
-            'الدولة',
             'السعر',
-            'السعر للمتر',
+            'العنوان',
+            'الوصف',
             'الغرض',
             'النوع',
             'المساحة',
-            'الحجم',
             'غرف النوم',
             'دورات المياه',
-            'الحالة',
-            'مميز',
-            'حالة العقار',
-            'التصنيف',
-            'خط العرض',
-            'خط الطول',
-            'اسم المشروع',
-            'اسم المبنى',
+            'المدينة',
+            'الحي',
             'الصورة الرئيسية',
-            'معرض الصور',
             'رابط الفيديو',
-            'الجولة الافتراضية',
-            'صور التخطيط',
-            'المرافق',
-            // Individual amenity columns (for import compatibility)
+            'الحالة',
+            'معرض الصور',
             'مصعد',
             'أمن',
             'كاميرات مراقبة',
@@ -121,94 +111,40 @@ class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, Wit
             'بواب',
             'إنترنت',
             'مرافق إضافية',
-            'مميزات',
-            'الأسئلة الشائعة',
-            'المواصفات',
-            // Individual specification columns (for import compatibility)
             'رقم الوحدة',
+            'رقم الطابق',
+            'عمر المبنى',
             'نوع الإطلالة',
             'مفروش',
             'مواقف السيارات',
+            'بلكونة',
+            'غرفة خادمة',
+            'غرفة تخزين',
+            'مسبح',
             'صالة رياضية',
             'مساحة الحديقة',
+            'المواصفات',
             'طريقة الدفع',
-            'رقم عداد المياه',
-            'رقم عداد الكهرباء',
-            'رقم الصك',
-            'إظهار الحجوزات',
-            'ترتيب',
-            'ترتيب المميز',
-            // UserPropertyCharacteristics fields
-            'معرّف الواجهة',
-            'الطول',
-            'العرض',
-            'عرض الشارع شمال',
-            'عرض الشارع جنوب',
-            'عرض الشارع شرق',
-            'عرض الشارع غرب',
-            'عمر المبنى',
-            'الغرف',
-            'دورات المياه',
-            'الطوابق',
-            'رقم الطابق',
-            'غرفة سائق',
-            'غرفة خادمة',
-            'غرفة طعام',
-            'غرفة معيشة',
-            'مجلس',
-            'غرفة تخزين',
-            'قبو',
-            'مسبح',
-            'مطبخ',
-            'بلكونة',
-            'حديقة',
-            'ملحق',
-            'مصعد',
-            'موقف خاص',
-            'مساحة الخصائص',
-            // User information
-            'معرّف المستخدم',
-            'اسم المستخدم',
-            'أنشئ بواسطة',
-            'اسم المنشئ',
-            'تاريخ الإنشاء',
-            'تاريخ التحديث',
+            'مميز',
+            'مميزات',
         ];
     }
 
     public function map($property): array
     {
         $content = $property->contents->first();
-        $characteristics = $property->UserPropertyCharacteristics;
-        
-        // Get location names
+
         $cityName = $content?->city?->name_ar ?? $content?->city?->name_en ?? '';
         $districtName = $content?->state?->name ?? '';
-        $stateName = '';
-        $countryName = $content?->country?->name ?? '';
 
-        // Get gallery images as comma-separated URLs
         $galleryImages = $property->galleryImages->map(function ($img) {
             return asset($img->image);
         })->implode(', ');
 
-        // Get floor planning images as comma-separated URLs
-        $floorPlanningImages = '';
-        if (is_array($property->floor_planning_image)) {
-            $floorPlanningImages = collect($property->floor_planning_image)
-                ->map(fn($img) => asset($img))
-                ->filter()
-                ->implode(', ');
-        }
-
-        // Get amenities as comma-separated names
         $amenityNames = $property->proertyAmenities->map(function ($amenity) {
             return $amenity->amenity?->name ?? '';
         })->filter()->values();
-        
-        $amenities = $amenityNames->implode(', ');
 
-        // Map individual amenity columns (for import compatibility)
         $amenityMapping = [
             'amenity_مصعد' => 'مصعد',
             'amenity_أمن' => 'أمن',
@@ -219,217 +155,79 @@ class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, Wit
             'amenity_بواب' => 'بواب',
             'amenity_إنترنت' => 'إنترنت',
         ];
-        
+
         $amenityColumns = [];
         foreach ($amenityMapping as $column => $arabicName) {
             $hasAmenity = $amenityNames->contains($arabicName);
-            $amenityColumns[$column] = $hasAmenity ? PropertyExcelMapping::booleanToExcel(true) : '';
+            $amenityColumns[$column] = $hasAmenity
+                ? PropertyExcelMapping::booleanToExcel(true)
+                : PropertyExcelMapping::booleanToExcel(false);
         }
-        
-        // Get additional amenities (amenities not in the standard list)
+
         $standardAmenities = array_values($amenityMapping);
         $additionalAmenities = $amenityNames->reject(function ($name) use ($standardAmenities) {
             return in_array($name, $standardAmenities);
         })->implode(', ');
 
-        // Get features as comma-separated string
-        $features = is_array($property->features) 
+        $features = is_array($property->features)
             ? implode(', ', array_filter($property->features))
             : '';
 
-        // Get FAQs as formatted string
-        $faqs = '';
-        if (is_array($property->faqs) && !empty($property->faqs)) {
-            $faqStrings = collect($property->faqs)->map(function ($faq) {
-                if (is_array($faq) && isset($faq['question']) && isset($faq['answer'])) {
-                    return ($faq['question'] ?? '') . ': ' . ($faq['answer'] ?? '');
-                }
-                return '';
-            })->filter()->implode(' | ');
-            $faqs = $faqStrings;
-        }
-
-        // Get specifications as formatted string
         $specifications = $property->specifications->map(function ($spec) {
             return ($spec->label ?? '') . ': ' . ($spec->value ?? '');
         })->implode(' | ');
-        
-        // Get individual specification values (for import compatibility)
-        // Check both specifications table and characteristics
+
         $specValues = [];
         foreach ($property->specifications as $spec) {
             $key = strtolower(str_replace(' ', '_', $spec->label ?? ''));
             $specValues[$key] = $spec->value ?? '';
         }
-        
-        // Get individual specification values (for import compatibility)
-        // These come from the specifications table, not characteristics
-        $unitNumber = $specValues['unit_number'] ?? '';
-        $viewType = $specValues['view_type'] ?? '';
-        $furnished = $specValues['furnished'] ?? '';
-        $parkingSpaces = $specValues['parking_spaces'] ?? ($characteristics?->private_parking ? '1' : '');
-        $gym = $specValues['gym'] ?? '';
-        $gardenSize = $specValues['garden_size'] ?? '';
 
-        // Get featured image URL
+        $characteristics = $property->UserPropertyCharacteristics;
+
         $featuredImage = $property->featured_image ? asset($property->featured_image) : '';
 
-        // Get user names
-        $userName = '';
-        if ($property->user) {
-            $userName = trim(($property->user->first_name ?? '') . ' ' . ($property->user->last_name ?? ''));
-            if (empty($userName)) {
-                $userName = $property->user->username ?? '';
-            }
-        }
-
-        $creatorName = '';
-        if ($property->creator) {
-            $creatorName = trim(($property->creator->first_name ?? '') . ' ' . ($property->creator->last_name ?? ''));
-            if (empty($creatorName)) {
-                $creatorName = $property->creator->username ?? '';
-            }
-        }
-
-        if ($this->isTemplate) {
-            return [
-                $content?->title ?? '',
-                $property->price ?? '',
-                $content?->address ?? '',
-                $content?->description ?? '',
-                $property->purpose ?? '',
-                $property->property_type ?? '',
-                $property->area ?? '',
-                $property->beds ?? '',
-                $property->bath ?? '',
-                $cityName,
-                $districtName,
-                $featuredImage,
-                $property->video_url ?? '',
-                $property->status ? '1' : '0',
-                $property->pricePerMeter ?? '',
-                $galleryImages,
-                $amenityColumns['amenity_مصعد'] ?? '',
-                $amenityColumns['amenity_أمن'] ?? '',
-                $amenityColumns['amenity_كاميرات_مراقبة'] ?? '',
-                $amenityColumns['amenity_تكييف_مركزي'] ?? '',
-                $amenityColumns['amenity_تدفئة_مركزية'] ?? '',
-                $amenityColumns['amenity_صيانة'] ?? '',
-                $amenityColumns['amenity_بواب'] ?? '',
-                $amenityColumns['amenity_إنترنت'] ?? '',
-                $additionalAmenities,
-                $unitNumber,
-                $characteristics?->floor_number ?? '',
-                $characteristics?->building_age ?? '',
-                $viewType,
-                $furnished,
-                $parkingSpaces,
-                $characteristics?->balcony ? '1' : '0',
-                $characteristics?->maid_room ? '1' : '0',
-                $characteristics?->storage_room ? '1' : '0',
-                $characteristics?->swimming_pool ? '1' : '0',
-                $gym,
-                $gardenSize,
-                $specifications,
-                PropertyExcelMapping::paymentMethodToExcel($property->payment_method ?? null),
-                $property->featured ? '1' : '0',
-                $features
-            ];
-        }
-
         return [
-            $property->id,
             $content?->title ?? '',
-            $content?->description ?? '',
-            $content?->address ?? '',
-            $cityName,
-            $districtName,
-            $stateName,
-            $countryName,
             $property->price ?? '',
-            $property->pricePerMeter ?? '',
+            $content?->address ?? '',
+            $content?->description ?? '',
             PropertyExcelMapping::purposeToExcel($property->purpose ?? null),
             PropertyExcelMapping::typeToExcel($property->property_type ?? null),
             $property->area ?? '',
-            $property->size ?? '',
             $property->beds ?? '',
             $property->bath ?? '',
-            $property->status ? '1' : '0',
-            $property->featured ? '1' : '0',
-            PropertyExcelMapping::propertyStatusToExcel($property->property_status ?? null),
-            $property->category?->name ?? '',
-            $property->latitude ?? '',
-            $property->longitude ?? '',
-            $property->project?->contents->first()?->title ?? '',
-            $property->building?->name ?? '',
+            $cityName,
+            $districtName,
             $featuredImage,
-            $galleryImages,
             $property->video_url ?? '',
-            $property->virtual_tour ?? '',
-            $floorPlanningImages,
-            $amenities,
-            // Individual amenity columns
-            $amenityColumns['amenity_مصعد'] ?? '',
-            $amenityColumns['amenity_أمن'] ?? '',
-            $amenityColumns['amenity_كاميرات_مراقبة'] ?? '',
-            $amenityColumns['amenity_تكييف_مركزي'] ?? '',
-            $amenityColumns['amenity_تدفئة_مركزية'] ?? '',
-            $amenityColumns['amenity_صيانة'] ?? '',
-            $amenityColumns['amenity_بواب'] ?? '',
-            $amenityColumns['amenity_إنترنت'] ?? '',
+            $property->status ? '1' : '0',
+            $galleryImages,
+            $amenityColumns['amenity_مصعد'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_أمن'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_كاميرات_مراقبة'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_تكييف_مركزي'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_تدفئة_مركزية'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_صيانة'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_بواب'] ?? PropertyExcelMapping::booleanToExcel(false),
+            $amenityColumns['amenity_إنترنت'] ?? PropertyExcelMapping::booleanToExcel(false),
             $additionalAmenities,
-            $features,
-            $faqs,
+            $specValues['unit_number'] ?? '',
+            $specValues['floor_number'] ?? ($characteristics?->floor_number ?? ''),
+            $specValues['building_age'] ?? ($characteristics?->building_age ?? ''),
+            $specValues['view_type'] ?? '',
+            $specValues['furnished'] ?? '',
+            $specValues['parking_spaces'] ?? ($characteristics?->private_parking ? '1' : ''),
+            $specValues['balcony'] ?? ($characteristics?->balcony ? PropertyExcelMapping::booleanToExcel(true) : PropertyExcelMapping::booleanToExcel(false)),
+            $specValues['maid_room'] ?? ($characteristics?->maid_room ? PropertyExcelMapping::booleanToExcel(true) : PropertyExcelMapping::booleanToExcel(false)),
+            $specValues['storage_room'] ?? ($characteristics?->storage_room ? PropertyExcelMapping::booleanToExcel(true) : PropertyExcelMapping::booleanToExcel(false)),
+            $specValues['swimming_pool'] ?? ($characteristics?->swimming_pool ? PropertyExcelMapping::booleanToExcel(true) : PropertyExcelMapping::booleanToExcel(false)),
+            $specValues['gym'] ?? '',
+            $specValues['garden_size'] ?? '',
             $specifications,
-            // Individual specification columns
-            $unitNumber,
-            $viewType,
-            $furnished,
-            $parkingSpaces,
-            $gym,
-            $gardenSize,
             PropertyExcelMapping::paymentMethodToExcel($property->payment_method ?? null),
-            $property->water_meter_number ?? '',
-            $property->electricity_meter_number ?? '',
-            $property->deed_number ?? '',
-            $property->show_reservations ? '1' : '0',
-            $property->reorder ?? '',
-            $property->reorder_featured ?? '',
-            // UserPropertyCharacteristics fields
-            $characteristics?->facade_id ?? '',
-            $characteristics?->length ?? '',
-            $characteristics?->width ?? '',
-            $characteristics?->street_width_north ?? '',
-            $characteristics?->street_width_south ?? '',
-            $characteristics?->street_width_east ?? '',
-            $characteristics?->street_width_west ?? '',
-            $characteristics?->building_age ?? '',
-            $characteristics?->rooms ?? '',
-            $characteristics?->bathrooms ?? '',
-            $characteristics?->floors ?? '',
-            $characteristics?->floor_number ?? '',
-            $characteristics?->driver_room ? '1' : '0',
-            $characteristics?->maid_room ? '1' : '0',
-            $characteristics?->dining_room ? '1' : '0',
-            $characteristics?->living_room ? '1' : '0',
-            $characteristics?->majlis ? '1' : '0',
-            $characteristics?->storage_room ? '1' : '0',
-            $characteristics?->basement ? '1' : '0',
-            $characteristics?->swimming_pool ? '1' : '0',
-            $characteristics?->kitchen ? '1' : '0',
-            $characteristics?->balcony ? '1' : '0',
-            $characteristics?->garden ? '1' : '0',
-            $characteristics?->annex ? '1' : '0',
-            $characteristics?->elevator ? '1' : '0',
-            $characteristics?->private_parking ? '1' : '0',
-            $characteristics?->size ?? '',
-            // User information
-            $property->user_id ?? '',
-            $userName,
-            $property->created_by ?? '',
-            $creatorName,
-            $property->created_at?->format('Y-m-d H:i:s') ?? '',
-            $property->updated_at?->format('Y-m-d H:i:s') ?? '',
+            PropertyExcelMapping::booleanToExcel((bool) $property->featured),
+            $features,
         ];
     }
 
@@ -440,11 +238,21 @@ class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, Wit
 
     public function registerEvents(): array
     {
-        return [
-            AfterSheet::class => function (AfterSheet $event) {
-                $sheet = $event->sheet;
+        $cityCount = (int) \App\Models\User\RealestateManagement\City::query()
+            ->distinct()
+            ->count('name_ar');
+        $districtCount = (int) UserDistrict::query()
+            ->distinct()
+            ->count('name_ar');
+        $cityEndRow = max(2, 1 + $cityCount);
+        $districtEndRow = max(2, 1 + $districtCount);
 
-                // Style the header row
+        return [
+            AfterSheet::class => function (AfterSheet $event) use ($cityEndRow, $districtEndRow) {
+                $sheet = $event->sheet;
+                $highestRow = $sheet->getHighestRow();
+                $rowCount = min(max($highestRow, 2), 1000);
+
                 $sheet->getStyle('1:1')->applyFromArray([
                     'font' => [
                         'bold' => true,
@@ -463,16 +271,88 @@ class PropertiesExport implements FromQuery, WithChunkReading, WithHeadings, Wit
 
                 $sheet->getRowDimension(1)->setRowHeight(25);
 
-                // Auto-size columns (adjust range based on number of columns)
-                $lastColumn = $sheet->getHighestColumn();
-                $lastColumnIndex = Coordinate::columnIndexFromString($lastColumn);
-                
-                // Limit to reasonable number of columns (safety check)
-                $maxColumns = min($lastColumnIndex, 100);
-                
-                for ($colIndex = 1; $colIndex <= $maxColumns; $colIndex++) {
-                    $colLetter = Coordinate::stringFromColumnIndex($colIndex);
-                    $sheet->getColumnDimension($colLetter)->setAutoSize(true);
+                // Purpose Column (E)
+                $validation = $sheet->getCell('E2')->getDataValidation();
+                $validation->setType(DataValidation::TYPE_LIST);
+                $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                $validation->setAllowBlank(true);
+                $validation->setShowInputMessage(true);
+                $validation->setShowErrorMessage(true);
+                $validation->setShowDropDown(true);
+                $validation->setFormula1('"' . PropertyExcelMapping::purposeExcelOptions() . '"');
+
+                for ($i = 3; $i <= $rowCount; $i++) {
+                    $sheet->getCell("E$i")->setDataValidation(clone $validation);
+                }
+
+                // Type Column (F)
+                $validation = $sheet->getCell('F2')->getDataValidation();
+                $validation->setType(DataValidation::TYPE_LIST);
+                $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                $validation->setAllowBlank(false);
+                $validation->setShowInputMessage(true);
+                $validation->setShowErrorMessage(true);
+                $validation->setShowDropDown(true);
+                $validation->setFormula1('"' . PropertyExcelMapping::typeExcelOptions() . '"');
+
+                for ($i = 3; $i <= $rowCount; $i++) {
+                    $sheet->getCell("F$i")->setDataValidation(clone $validation);
+                }
+
+                // City Name Column (J) — lookup sheet
+                $validation = $sheet->getCell('J2')->getDataValidation();
+                $validation->setType(DataValidation::TYPE_LIST);
+                $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                $validation->setAllowBlank(true);
+                $validation->setShowInputMessage(true);
+                $validation->setShowErrorMessage(true);
+                $validation->setShowDropDown(true);
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\${$cityEndRow}");
+
+                for ($i = 3; $i <= $rowCount; $i++) {
+                    $sheet->getCell("J$i")->setDataValidation(clone $validation);
+                }
+
+                // District Name Column (K) — lookup sheet
+                $validation = $sheet->getCell('K2')->getDataValidation();
+                $validation->setType(DataValidation::TYPE_LIST);
+                $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                $validation->setAllowBlank(true);
+                $validation->setShowInputMessage(true);
+                $validation->setShowErrorMessage(true);
+                $validation->setShowDropDown(true);
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\${$districtEndRow}");
+
+                for ($i = 3; $i <= $rowCount; $i++) {
+                    $sheet->getCell("K$i")->setDataValidation(clone $validation);
+                }
+
+                // Payment Method Column (AL)
+                $validation = $sheet->getCell('AL2')->getDataValidation();
+                $validation->setType(DataValidation::TYPE_LIST);
+                $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                $validation->setAllowBlank(true);
+                $validation->setShowInputMessage(true);
+                $validation->setShowErrorMessage(true);
+                $validation->setShowDropDown(true);
+                $validation->setFormula1('"' . PropertyExcelMapping::paymentMethodExcelOptions() . '"');
+
+                for ($i = 3; $i <= $rowCount; $i++) {
+                    $sheet->getCell("AL$i")->setDataValidation(clone $validation);
+                }
+
+                // Featured Column (AM) — Arabic نعم/لا to match booleanToExcel
+                $validation = $sheet->getCell('AM2')->getDataValidation();
+                $validation->setType(DataValidation::TYPE_LIST);
+                $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                $validation->setAllowBlank(true);
+                $validation->setShowInputMessage(true);
+                $validation->setShowErrorMessage(true);
+                $validation->setShowDropDown(true);
+                $validation->setFormula1('"نعم,لا"');
+
+                for ($i = 3; $i <= $rowCount; $i++) {
+                    $sheet->getCell("AM$i")->setDataValidation(clone $validation);
                 }
             },
         ];

--- a/app/Exports/PropertiesImportReadyExport.php
+++ b/app/Exports/PropertiesImportReadyExport.php
@@ -5,7 +5,9 @@ namespace App\Exports;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\UserDistrict;
 use App\Support\PropertyExcelMapping;
+use App\Support\PropertyFilterQuery;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
@@ -38,7 +40,7 @@ class PropertiesImportReadyExport implements WithMultipleSheets
     }
 }
 
-class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, WithMapping, WithTitle, WithEvents
+class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReading, WithHeadings, WithMapping, WithTitle, WithEvents
 {
     protected $userId;
     protected $allowedUserIds;
@@ -72,120 +74,14 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
             ])
             ->whereIn('user_id', $this->allowedUserIds);
 
-        // Apply property IDs filter if provided
-        if (!empty($this->filters['ids']) && is_array($this->filters['ids']) && count($this->filters['ids']) > 0) {
-            $query->whereIn('id', $this->filters['ids']);
-        }
-
-        // Apply date range filter
-        if (!empty($this->filters['date_from'])) {
-            $query->whereDate('created_at', '>=', $this->filters['date_from']);
-        }
-        if (!empty($this->filters['date_to'])) {
-            $query->whereDate('created_at', '<=', $this->filters['date_to']);
-        }
-
-        // Apply purpose filter
-        if (!empty($this->filters['purposes_filter'])) {
-            $query->where('purpose', $this->filters['purposes_filter']);
-        }
-        if (!empty($this->filters['purpose'])) {
-            $query->where('purpose', $this->filters['purpose']);
-        }
-
-        // Apply type filter
-        if (!empty($this->filters['type'])) {
-            $query->where('property_type', $this->filters['type']);
-        }
-
-        // Apply price filters
-        if (!empty($this->filters['price_from'])) {
-            $query->where('price', '>=', $this->filters['price_from']);
-        }
-        if (!empty($this->filters['price_to'])) {
-            $query->where('price', '<=', $this->filters['price_to']);
-        }
-
-        // Apply area filters
-        if (!empty($this->filters['area_from'])) {
-            $query->where('area', '>=', $this->filters['area_from']);
-        }
-        if (!empty($this->filters['area_to'])) {
-            $query->where('area', '<=', $this->filters['area_to']);
-        }
-
-        // Apply beds filter
-        if (!empty($this->filters['beds'])) {
-            $query->where('beds', $this->filters['beds']);
-        }
-
-        // Apply bath filter
-        if (!empty($this->filters['bath'])) {
-            $query->where('bath', $this->filters['bath']);
-        }
-
-        // Apply category filter
-        if (!empty($this->filters['category_id'])) {
-            $query->where('category_id', $this->filters['category_id']);
-        }
-
-        // Apply status filter
-        if (isset($this->filters['status']) && $this->filters['status'] !== '') {
-            $query->where('status', $this->filters['status']);
-        }
-
-        // Apply featured filter
-        if (isset($this->filters['featured']) && $this->filters['featured'] !== '') {
-            $query->where('featured', $this->filters['featured']);
-        }
-
-        // Apply city filter
-        if (!empty($this->filters['city_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('city_id', $this->filters['city_id']);
-            });
-        }
-
-        // Apply district filter
-        if (!empty($this->filters['district_id'])) {
-            $query->whereHas('contents', function ($q) {
-                $q->where('state_id', $this->filters['district_id']);
-            });
-        }
-
-        // Apply search filter (title/description/address, plus numeric property ID)
-        if (!empty($this->filters['search'])) {
-            $search = trim((string) $this->filters['search']);
-            $numericId = $this->parsePositiveIntSearchId($search);
-            $query->where(function ($q) use ($search, $numericId) {
-                $q->whereHas('contents', function ($cq) use ($search) {
-                    $cq->where(function ($inner) use ($search) {
-                        $inner->where('title', 'like', "%{$search}%")
-                              ->orWhere('description', 'like', "%{$search}%")
-                              ->orWhere('address', 'like', "%{$search}%");
-                    });
-                });
-                if ($numericId !== null) {
-                    $q->orWhere('id', $numericId);
-                }
-            });
-        }
+        PropertyFilterQuery::apply($query, $this->filters);
 
         return $query->orderBy('id', 'desc');
     }
 
-    private function parsePositiveIntSearchId(?string $searchTerm): ?int
+    public function chunkSize(): int
     {
-        $searchTerm = trim((string) $searchTerm);
-        if ($searchTerm === ''
-            || !ctype_digit($searchTerm)
-            || strlen($searchTerm) > 18
-            || (int) $searchTerm <= 0
-        ) {
-            return null;
-        }
-
-        return (int) $searchTerm;
+        return 500;
     }
 
     public function headings(): array
@@ -351,8 +247,17 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
 
     public function registerEvents(): array
     {
+        $cityCount = (int) \App\Models\User\RealestateManagement\City::query()
+            ->distinct()
+            ->count('name_ar');
+        $districtCount = (int) UserDistrict::query()
+            ->distinct()
+            ->count('name_ar');
+        $cityEndRow = max(2, 1 + $cityCount);
+        $districtEndRow = max(2, 1 + $districtCount);
+
         return [
-            AfterSheet::class => function(AfterSheet $event) {
+            AfterSheet::class => function(AfterSheet $event) use ($cityEndRow, $districtEndRow) {
                 $sheet = $event->sheet;
                 $highestRow = $sheet->getHighestRow();
                 $rowCount = min($highestRow, 1000); // Apply validation to first 1000 rows
@@ -413,7 +318,7 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\$500");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\${$cityEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("K$i")->setDataValidation(clone $validation);
@@ -427,7 +332,7 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithHeadings, W
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\$10000");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\${$districtEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("L$i")->setDataValidation(clone $validation);

--- a/app/Exports/PropertiesImportReadyExport.php
+++ b/app/Exports/PropertiesImportReadyExport.php
@@ -87,7 +87,6 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
     public function headings(): array
     {
         return [
-            'المعرّف',
             'عنوان الإعلان',
             'السعر',
             'العنوان',
@@ -196,7 +195,6 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
         $featuredImage = $property->featured_image ? asset($property->featured_image) : '';
 
         return [
-            $property->id,
             $content?->title ?? '',
             $property->price ?? '',
             $content?->address ?? '',
@@ -282,22 +280,22 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
                 // Set header row height
                 $sheet->getRowDimension(1)->setRowHeight(25);
 
-                // Purpose Column (F) - "sale,rent"
-                $validation = $sheet->getCell('F2')->getDataValidation();
+                // Purpose Column (E) — matches PropertiesTemplateExport (no id)
+                $validation = $sheet->getCell('E2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
-                $validation->setAllowBlank(false);
+                $validation->setAllowBlank(true);
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
                 $validation->setFormula1('"' . PropertyExcelMapping::purposeExcelOptions() . '"');
                 
                 for ($i = 3; $i <= $rowCount; $i++) {
-                    $sheet->getCell("F$i")->setDataValidation(clone $validation);
+                    $sheet->getCell("E$i")->setDataValidation(clone $validation);
                 }
 
-                // Type Column (G) - Arabic options
-                $validation = $sheet->getCell('G2')->getDataValidation();
+                // Type Column (F) - Arabic options
+                $validation = $sheet->getCell('F2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
                 $validation->setAllowBlank(false);
@@ -307,11 +305,11 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
                 $validation->setFormula1('"' . PropertyExcelMapping::typeExcelOptions() . '"');
 
                 for ($i = 3; $i <= $rowCount; $i++) {
-                    $sheet->getCell("G$i")->setDataValidation(clone $validation);
+                    $sheet->getCell("F$i")->setDataValidation(clone $validation);
                 }
 
-                // City Name Column (K) - Reference Lookup Sheet
-                $validation = $sheet->getCell('K2')->getDataValidation();
+                // City Name Column (J) - Reference Lookup Sheet
+                $validation = $sheet->getCell('J2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
                 $validation->setAllowBlank(true);
@@ -321,11 +319,11 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
                 $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\${$cityEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
-                    $sheet->getCell("K$i")->setDataValidation(clone $validation);
+                    $sheet->getCell("J$i")->setDataValidation(clone $validation);
                 }
 
-                // District Name Column (L) - Reference Lookup Sheet
-                $validation = $sheet->getCell('L2')->getDataValidation();
+                // District Name Column (K) - Reference Lookup Sheet
+                $validation = $sheet->getCell('K2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
                 $validation->setAllowBlank(true);
@@ -335,11 +333,11 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
                 $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\${$districtEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
-                    $sheet->getCell("L$i")->setDataValidation(clone $validation);
+                    $sheet->getCell("K$i")->setDataValidation(clone $validation);
                 }
 
-                // Payment Method Column (AJ) - Arabic options
-                $validation = $sheet->getCell('AJ2')->getDataValidation();
+                // Payment Method Column (AL) - Arabic options
+                $validation = $sheet->getCell('AL2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
                 $validation->setAllowBlank(true);
@@ -349,11 +347,11 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
                 $validation->setFormula1('"شهري,ربع سنوي,نصف سنوي,سنوي"');
 
                 for ($i = 3; $i <= $rowCount; $i++) {
-                    $sheet->getCell("AJ$i")->setDataValidation(clone $validation);
+                    $sheet->getCell("AL$i")->setDataValidation(clone $validation);
                 }
 
-                // Featured Column (AK) - "Yes,No"
-                $validation = $sheet->getCell('AK2')->getDataValidation();
+                // Featured Column (AM) - "Yes,No"
+                $validation = $sheet->getCell('AM2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
                 $validation->setAllowBlank(true);
@@ -363,7 +361,7 @@ class PropertiesImportReadyMainSheetExport implements FromQuery, WithChunkReadin
                 $validation->setFormula1('"Yes,No"');
 
                 for ($i = 3; $i <= $rowCount; $i++) {
-                    $sheet->getCell("AK$i")->setDataValidation(clone $validation);
+                    $sheet->getCell("AM$i")->setDataValidation(clone $validation);
                 }
             },
         ];

--- a/app/Exports/PropertiesTemplateExport.php
+++ b/app/Exports/PropertiesTemplateExport.php
@@ -5,7 +5,6 @@ namespace App\Exports;
 use App\Models\User\UserDistrict;
 use App\Support\PropertyExcelMapping;
 use Maatwebsite\Excel\Concerns\FromArray;
-use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithTitle;
@@ -299,63 +298,5 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 }
             },
         ];
-    }
-}
-
-class PropertiesTemplateLookupSheetExport implements FromCollection, WithHeadings, WithTitle
-{
-    public function collection()
-    {
-        // Get unique cities (Arabic)
-        $cities = \App\Models\User\RealestateManagement\City::query()
-            ->select('name_ar')
-            ->distinct()
-            ->orderBy('name_ar')
-            ->pluck('name_ar');
-
-        // Get all districts (Arabic)
-        $districts = UserDistrict::query()
-            ->select('name_ar')
-            ->distinct()
-            ->orderBy('name_ar')
-            ->pluck('name_ar');
-
-        // Get full mapping for reference
-        $fullMapping = UserDistrict::query()
-            ->join('user_cities', 'user_districts.city_id', '=', 'user_cities.id')
-            ->select('user_districts.name_ar as district', 'user_cities.name_ar as city')
-            ->orderBy('user_cities.name_ar')
-            ->orderBy('user_districts.name_ar')
-            ->get();
-
-        // Merge into a collection of rows
-        $maxCount = max($cities->count(), $districts->count(), $fullMapping->count());
-        $data = [];
-
-        for ($i = 0; $i < $maxCount; $i++) {
-            $data[] = [
-                'city_name_unique' => $cities[$i] ?? '',
-                'district_name_unique' => $districts[$i] ?? '',
-                'district_ref' => $fullMapping[$i]->district ?? '',
-                'city_ref' => $fullMapping[$i]->city ?? '',
-            ];
-        }
-
-        return collect($data);
-    }
-
-    public function headings(): array
-    {
-        return [
-            'المدينة (مصدر القائمة)',
-            'الحي (مصدر القائمة)',
-            'اسم الحي (مرجع)',
-            'تابع للمدينة (مرجع)',
-        ];
-    }
-
-    public function title(): string
-    {
-        return PropertyExcelMapping::LOOKUP_SHEET_TITLE;
     }
 }

--- a/app/Exports/PropertiesTemplateExport.php
+++ b/app/Exports/PropertiesTemplateExport.php
@@ -59,7 +59,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 'موقف دراجات,غرفة غسيل',
                 'A-101',
                 '5',
-                '2020',
+                '5',
                 'إطلالة مدينة',
                 'مفروش بالكامل',
                 '2',
@@ -101,7 +101,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 'سونا، جاكوزي',
                 '1',
                 '0',
-                '2018',
+                '8',
                 'إطلالة حديقة',
                 'مفروش جزئياً',
                 '3',
@@ -143,7 +143,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 'غرفة اجتماعات، استقبال',
                 '301',
                 '3',
-                '2019',
+                '12',
                 'إطلالة بحرية',
                 'غير مفروش',
                 '10',
@@ -238,6 +238,12 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
 
                 // Set header row height for better visibility
                 $sheet->getRowDimension(1)->setRowHeight(25);
+
+                // Unit number column (Y) — keep numeric-looking values as text for re-import
+                for ($i = 2; $i <= 4; $i++) {
+                    $cell = $sheet->getCell("Y{$i}");
+                    $cell->setValueExplicit((string) $cell->getValue(), \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                }
 
                 // Purpose Column (E) - "sale,rent"
                 $validation = $sheet->getCell('E2')->getDataValidation();

--- a/app/Exports/PropertiesTemplateExport.php
+++ b/app/Exports/PropertiesTemplateExport.php
@@ -30,153 +30,69 @@ class PropertiesTemplateExport implements WithMultipleSheets
 
 class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, WithTitle, WithEvents
 {
+    /**
+     * Required-for-complete columns (Excel ` *` is UX only; server soft-incomplete still applies).
+     * Indices match headings() below.
+     */
+    private const REQUIRED_HEADER_INDICES = [0, 2, 3, 5, 11]; // A, C, D, F, L
+
     public function array(): array
     {
+        // Sparse samples: values only in the five required columns.
+        // Delete these rows before a real import (they create live properties).
+        $empty = array_fill(0, 40, '');
+
+        $row = static function (string $title, string $address, string $description, string $type, string $image) use ($empty): array {
+            $r = $empty;
+            $r[0] = $title;
+            $r[2] = $address;
+            $r[3] = $description;
+            $r[5] = $type;
+            $r[11] = $image;
+
+            return $r;
+        };
+
         return [
-            [
+            $row(
                 'شقة فاخرة في القلب التجاري',
-                '750000',
                 'شارع الملك فهد، حي العليا',
                 'شقة ثلاث غرف نوم بإطلالة مدينة ومصعد وأمن على مدار الساعة',
-                'بيع',
                 'سكني',
-                '180',
-                '3',
-                '2',
-                'الرياض',
-                'حي العليا',
-                'https://example.com/img1.jpg',
-                'https://example.com/video1.mp4',
-                '1',
-                'https://example.com/g1.jpg,https://example.com/g2.jpg',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'لا',
-                'نعم',
-                'نعم',
-                'نعم',
-                'موقف دراجات,غرفة غسيل',
-                'A-101',
-                '5',
-                '5',
-                'إطلالة مدينة',
-                'مفروش بالكامل',
-                '2',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                '0',
-                'ارتفاع السقف: 3.5 م، نوع المطبخ: مطبخ مفتوح، أرضيات: رخام',
-                'شهري',
-                'نعم',
-                'منزل ذكي، ألواح شمسية',
-            ],
-            [
+                'https://example.com/img1.jpg'
+            ),
+            $row(
                 'فيلا للإيجار بحديقة ومسبح',
-                '120000',
                 'حي النخيل، طريق الأمير محمد',
                 'فيلا أربع غرف نوم مع حديقة خاصة ومسبح وصالة رياضية',
-                'إيجار',
                 'سكني',
-                '350',
-                '4',
-                '4',
-                'جدة',
-                'حي النخيل',
-                'https://example.com/img2.jpg',
-                '',
-                '1',
-                'https://example.com/g1.jpg',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'سونا، جاكوزي',
-                '1',
-                '0',
-                '8',
-                'إطلالة حديقة',
-                'مفروش جزئياً',
-                '3',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                '120',
-                'مساحة مبنية: 350 م²، التكييف: مركزي',
-                'سنوي',
-                'نعم',
-                'مدخل مستقل، مواقف زوار',
-            ],
-            [
+                'https://example.com/img2.jpg'
+            ),
+            $row(
                 'مكتب تجاري للبيع بموقع مميز',
-                '1200000',
                 'شارع العليا العام، برج الأعمال',
                 'مكتب بإطلالة بحرية ومناسب للشركات، مواقف تحت الأرض',
-                'بيع',
                 'تجاري',
-                '220',
-                '0',
-                '2',
-                'الدمام',
-                'حي الفيصلية',
-                'https://example.com/img3.jpg',
-                '',
-                '1',
-                '',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'نعم',
-                'غرفة اجتماعات، استقبال',
-                '301',
-                '3',
-                '12',
-                'إطلالة بحرية',
-                'غير مفروش',
-                '10',
-                'نعم',
-                'لا',
-                'نعم',
-                'نعم',
-                'لا',
-                '0',
-                'نظام إطفاء حريق، إنذار، كاميرات',
-                'ربع سنوي',
-                'لا',
-                'مدخل فاخر، مصعد خاص بالمكتب',
-            ],
+                'https://example.com/img3.jpg'
+            ),
         ];
     }
 
     public function headings(): array
     {
         return [
-            'عنوان الإعلان',
+            'عنوان الإعلان *',
             'السعر',
-            'العنوان',
-            'الوصف',
+            'العنوان *',
+            'الوصف *',
             'الغرض',
-            'النوع',
+            'النوع *',
             'المساحة',
             'غرف النوم',
             'دورات المياه',
             'المدينة',
             'الحي',
-            'الصورة الرئيسية',
+            'الصورة الرئيسية *',
             'رابط الفيديو',
             'الحالة',
             'معرض الصور',
@@ -251,6 +167,21 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                     ],
                 ]);
 
+                // Emphasize the five required header cells (A, C, D, F, L)
+                foreach (self::REQUIRED_HEADER_INDICES as $index) {
+                    $col = Coordinate::stringFromColumnIndex($index + 1);
+                    $sheet->getStyle("{$col}1")->applyFromArray([
+                        'font' => [
+                            'bold' => true,
+                            'color' => ['rgb' => 'FFFFFF'],
+                        ],
+                        'fill' => [
+                            'fillType' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID,
+                            'startColor' => ['rgb' => '2F5496'],
+                        ],
+                    ]);
+                }
+
                 // Set header row height for better visibility
                 $sheet->getRowDimension(1)->setRowHeight(25);
 
@@ -262,21 +193,42 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                     }
                 }
 
-                // Purpose Column (E) - "sale,rent"
+                // Text-length "required" UX on title / address / description / featured_image.
+                // Excel only warns on cell entry; untouched blanks never fire — ` *` is the real signal.
+                foreach (['A', 'C', 'D', 'L'] as $col) {
+                    $validation = $sheet->getCell("{$col}2")->getDataValidation();
+                    $validation->setType(DataValidation::TYPE_TEXTLENGTH);
+                    $validation->setOperator(DataValidation::OPERATOR_GREATERTHAN);
+                    $validation->setFormula1('0');
+                    $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+                    $validation->setAllowBlank(false);
+                    $validation->setShowInputMessage(true);
+                    $validation->setShowErrorMessage(true);
+                    $validation->setPromptTitle('حقل مطلوب');
+                    $validation->setPrompt('هذا الحقل مطلوب لاكتمال العقار');
+                    $validation->setErrorTitle('حقل مطلوب');
+                    $validation->setError('يرجى إدخال قيمة في هذا الحقل');
+
+                    for ($i = 3; $i <= $rowCount; $i++) {
+                        $sheet->getCell("{$col}{$i}")->setDataValidation(clone $validation);
+                    }
+                }
+
+                // Purpose Column (E) — optional for complete
                 $validation = $sheet->getCell('E2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);
-                $validation->setAllowBlank(false);
+                $validation->setAllowBlank(true);
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
                 $validation->setFormula1('"' . PropertyExcelMapping::purposeExcelOptions() . '"');
-                
+
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("E$i")->setDataValidation(clone $validation);
                 }
 
-                // Type Column (F) - "residential,commercial"
+                // Type Column (F) — required; four types
                 $validation = $sheet->getCell('F2')->getDataValidation();
                 $validation->setType(DataValidation::TYPE_LIST);
                 $validation->setErrorStyle(DataValidation::STYLE_INFORMATION);

--- a/app/Exports/PropertiesTemplateExport.php
+++ b/app/Exports/PropertiesTemplateExport.php
@@ -12,6 +12,7 @@ use Maatwebsite\Excel\Concerns\WithTitle;
 
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 
 class PropertiesTemplateExport implements WithMultipleSheets
@@ -214,8 +215,22 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
 
     public function registerEvents(): array
     {
+        $unitNumberColIndex = array_search('رقم الوحدة', $this->headings(), true);
+        $unitNumberCol = $unitNumberColIndex !== false
+            ? Coordinate::stringFromColumnIndex($unitNumberColIndex + 1)
+            : null;
+
+        $cityCount = (int) \App\Models\User\RealestateManagement\City::query()
+            ->distinct()
+            ->count('name_ar');
+        $districtCount = (int) UserDistrict::query()
+            ->distinct()
+            ->count('name_ar');
+        $cityEndRow = max(2, 1 + $cityCount);
+        $districtEndRow = max(2, 1 + $districtCount);
+
         return [
-            AfterSheet::class => function(AfterSheet $event) {
+            AfterSheet::class => function(AfterSheet $event) use ($unitNumberCol, $cityEndRow, $districtEndRow) {
                 $sheet = $event->sheet;
                 $rowCount = 1000; // Apply validation to first 1000 rows
 
@@ -239,10 +254,12 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 // Set header row height for better visibility
                 $sheet->getRowDimension(1)->setRowHeight(25);
 
-                // Unit number column (Y) — keep numeric-looking values as text for re-import
-                for ($i = 2; $i <= 4; $i++) {
-                    $cell = $sheet->getCell("Y{$i}");
-                    $cell->setValueExplicit((string) $cell->getValue(), \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                // Unit number column — keep numeric-looking values as text for re-import
+                if ($unitNumberCol !== null) {
+                    for ($i = 2; $i <= 4; $i++) {
+                        $cell = $sheet->getCell("{$unitNumberCol}{$i}");
+                        $cell->setValueExplicit((string) $cell->getValue(), \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+                    }
                 }
 
                 // Purpose Column (E) - "sale,rent"
@@ -281,7 +298,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\$500");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$A\$2:\$A\${$cityEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("J$i")->setDataValidation(clone $validation);
@@ -295,7 +312,7 @@ class PropertiesTemplateMainSheetExport implements FromArray, WithHeadings, With
                 $validation->setShowInputMessage(true);
                 $validation->setShowErrorMessage(true);
                 $validation->setShowDropDown(true);
-                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\$10000");
+                $validation->setFormula1("'" . PropertyExcelMapping::LOOKUP_SHEET_TITLE . "'!\$B\$2:\$B\${$districtEndRow}");
 
                 for ($i = 3; $i <= $rowCount; $i++) {
                     $sheet->getCell("K$i")->setDataValidation(clone $validation);

--- a/app/Exports/PropertiesTemplateLookupSheetExport.php
+++ b/app/Exports/PropertiesTemplateLookupSheetExport.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\User\UserDistrict;
+use App\Support\PropertyExcelMapping;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+
+class PropertiesTemplateLookupSheetExport implements FromCollection, WithHeadings, WithTitle
+{
+    public function collection()
+    {
+        // Get unique cities (Arabic)
+        $cities = \App\Models\User\RealestateManagement\City::query()
+            ->select('name_ar')
+            ->distinct()
+            ->orderBy('name_ar')
+            ->pluck('name_ar');
+
+        // Get all districts (Arabic)
+        $districts = UserDistrict::query()
+            ->select('name_ar')
+            ->distinct()
+            ->orderBy('name_ar')
+            ->pluck('name_ar');
+
+        // Get full mapping for reference
+        $fullMapping = UserDistrict::query()
+            ->join('user_cities', 'user_districts.city_id', '=', 'user_cities.id')
+            ->select('user_districts.name_ar as district', 'user_cities.name_ar as city')
+            ->orderBy('user_cities.name_ar')
+            ->orderBy('user_districts.name_ar')
+            ->get();
+
+        // Merge into a collection of rows
+        $maxCount = max($cities->count(), $districts->count(), $fullMapping->count());
+        $data = [];
+
+        for ($i = 0; $i < $maxCount; $i++) {
+            $data[] = [
+                'city_name_unique' => $cities[$i] ?? '',
+                'district_name_unique' => $districts[$i] ?? '',
+                'district_ref' => $fullMapping[$i]->district ?? '',
+                'city_ref' => $fullMapping[$i]->city ?? '',
+            ];
+        }
+
+        return collect($data);
+    }
+
+    public function headings(): array
+    {
+        return [
+            'المدينة (مصدر القائمة)',
+            'الحي (مصدر القائمة)',
+            'اسم الحي (مرجع)',
+            'تابع للمدينة (مرجع)',
+        ];
+    }
+
+    public function title(): string
+    {
+        return PropertyExcelMapping::LOOKUP_SHEET_TITLE;
+    }
+}

--- a/app/Http/Controllers/Api/AnalyticsDashboardController.php
+++ b/app/Http/Controllers/Api/AnalyticsDashboardController.php
@@ -1260,6 +1260,12 @@ class AnalyticsDashboardController extends Controller
     {
         $data = app(SiteSetupProgressService::class)->getProgress($request->user());
 
+        if ($data === null) {
+            return response()->json([
+                'message' => 'Unable to resolve tenant owner.',
+            ], 403);
+        }
+
         return response()->json($data);
     }
 

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -42,6 +42,7 @@ use App\Models\User\HomePageText;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\Api\ApiMenuSetting;
 use App\Services\TempTokenService;
+use App\Services\SiteSetupProgressService;
 use Illuminate\Support\Facades\DB;
 use App\Models\User\UserPermission;
 use App\Services\OnboardingService;
@@ -1115,7 +1116,9 @@ class AuthController extends Controller
                 }
             }
 
-            DB::transaction(function () use ($user, $owner, $validated) {
+            $didCompanyUpdate = false;
+
+            DB::transaction(function () use ($user, $owner, $validated, &$didCompanyUpdate) {
                 $userFields = $this->extractPersonalProfileFields($validated);
 
                 if ($userFields !== []) {
@@ -1130,8 +1133,13 @@ class AuthController extends Controller
 
                 if ($this->hasCompanyFieldUpdates($validated)) {
                     $this->applyCompanyProfileUpdates($owner, $validated);
+                    $didCompanyUpdate = true;
                 }
             });
+
+            if ($didCompanyUpdate && $owner) {
+                app(SiteSetupProgressService::class)->syncContactsSocialInfo($owner);
+            }
 
             CacheInvalidationHelper::clearTenantProfileCachesAuto($ownerId);
 

--- a/app/Http/Controllers/Api/CRMController.php
+++ b/app/Http/Controllers/Api/CRMController.php
@@ -33,45 +33,16 @@ class CRMController extends Controller
         $user = $request->user();
         $tenantId = $request->user()->tenantOwnerId();
 
-        // ===== Bootstrap defaults (unchanged) =====
-        app(TenantCrmBootstrapService::class)->ensureDefaultStages((int) $tenantId);
-
-        $defaultProcedures = [
-            ['procedure_name' => 'meeting', 'order' => 1, 'icon' => 'users', 'color' => '#2196f3'],
-            ['procedure_name' => 'visit',   'order' => 2, 'icon' => 'map',   'color' => '#ff9800'],
-        ];
-        foreach ($defaultProcedures as $p) {
-            UserApiCustomerProcedure::firstOrCreate(
-                ['user_id' => $tenantId, 'procedure_name' => $p['procedure_name']],
-                ['order' => $p['order'], 'icon' => $p['icon'], 'color' => $p['color'], 'is_active' => true]
-            );
-        }
-
-        $priorityDefaults = [
-            ['name'=>'Low',    'value'=>1, 'order'=>1, 'color'=>'#4caf50','icon'=>'arrow-down'],
-            ['name'=>'Medium', 'value'=>2, 'order'=>2, 'color'=>'#ff9800','icon'=>'minus'],
-            ['name'=>'High',   'value'=>3, 'order'=>3, 'color'=>'#f44336','icon'=>'arrow-up'],
-        ];
-        foreach ($priorityDefaults as $p) {
-            UserApiCustomerPriority::firstOrCreate(
-                ['user_id'=>$tenantId, 'value'=>$p['value']],
-                ['name'=>$p['name'], 'order'=>$p['order'], 'color'=>$p['color'], 'icon'=>$p['icon'], 'is_active'=>true]
-            );
-        }
-
-        $defaultTypes = [
-            ['name' => 'Rent',   'value' => 'Rent',   'order' => 1, 'icon' => 'home',      'color' => '#2196f3'],
-            ['name' => 'Sale',   'value' => 'Sale',   'order' => 2, 'icon' => 'dollar',    'color' => '#4caf50'],
-            ['name' => 'Rented', 'value' => 'Rented', 'order' => 3, 'icon' => 'check',     'color' => '#9e9e9e'],
-            ['name' => 'Sold',   'value' => 'Sold',   'order' => 4, 'icon' => 'check-all', 'color' => '#9e9e9e'],
-            ['name' => 'Both',   'value' => 'Both',   'order' => 5, 'icon' => 'arrows',    'color' => '#ff9800'],
-        ];
-        foreach ($defaultTypes as $t) {
-            UserApiCustomerType::firstOrCreate(
-                ['user_id' => $tenantId, 'value' => $t['value']],
-                ['name' => $t['name'], 'order' => $t['order'], 'icon' => $t['icon'], 'color' => $t['color'], 'is_active' => true]
-            );
-        }
+        // ===== Bootstrap defaults =====
+        // Kept here so the CRM board self-heals for tenants created before these
+        // rows were seeded at tenant creation; the definitions themselves live in
+        // TenantCrmBootstrapService. Deliberately not ensureForTenant(), which also
+        // rewrites auto-customer settings.
+        $bootstrap = app(TenantCrmBootstrapService::class);
+        $bootstrap->ensureDefaultStages((int) $tenantId);
+        $bootstrap->ensureDefaultProcedures((int) $tenantId);
+        $bootstrap->ensureDefaultPriorities((int) $tenantId);
+        $bootstrap->ensureDefaultTypes((int) $tenantId);
 
         $totalCustomers = ApiCustomer::where('user_id', $tenantId)->count();
 

--- a/app/Http/Controllers/Api/CityController.php
+++ b/app/Http/Controllers/Api/CityController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\User\UserDistrict;
+use App\Models\User\UserCity;
+use App\Support\LocationLookupCache;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class CityController extends Controller
 {
@@ -13,7 +15,7 @@ class CityController extends Controller
      * GET /api/cities
      * GET /api/cities?country_id=1
      *
-     * Returns distinct cities from user_districts. country_id is optional.
+     * Returns cities from user_cities. country_id is optional.
      */
     public function index(Request $request): JsonResponse
     {
@@ -21,18 +23,22 @@ class CityController extends Controller
             'country_id' => ['sometimes', 'nullable', 'integer', 'exists:user_cities,country_id'],
         ]);
 
-        $cities = UserDistrict::query()
-            ->whereNotNull('city_id')
-            ->whereNotNull('city_name_ar')
-            ->when($request->filled('country_id'), function ($query) use ($request) {
-                $query->whereHas('city', function ($q) use ($request) {
-                    $q->where('country_id', (int) $request->input('country_id'));
-                });
-            })
-            ->select('city_id as id', 'city_name_ar as name_ar', 'city_name_en as name_en')
-            ->distinct()
-            ->orderBy('city_name_ar')
-            ->get();
+        $countryId = $request->filled('country_id') ? (int) $request->input('country_id') : null;
+
+        $cities = Cache::remember(
+            LocationLookupCache::key('cities', $countryId),
+            LocationLookupCache::TTL_SECONDS,
+            function () use ($countryId) {
+                return UserCity::query()
+                    ->when($countryId !== null, function ($query) use ($countryId) {
+                        $query->where('country_id', $countryId);
+                    })
+                    ->select('id', 'name_ar', 'name_en')
+                    ->orderBy('name_ar')
+                    ->get()
+                    ->toArray();
+            }
+        );
 
         return response()->json(['data' => $cities]);
     }

--- a/app/Http/Controllers/Api/DistrictController.php
+++ b/app/Http/Controllers/Api/DistrictController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\User\UserDistrict;
+use App\Support\LocationLookupCache;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class DistrictController extends Controller
 {
@@ -18,15 +20,24 @@ class DistrictController extends Controller
     public function index(Request $request): JsonResponse
     {
         $request->validate([
-            'city_id' => ['sometimes', 'nullable', 'integer', 'exists:user_districts,city_id'],
+            'city_id' => ['sometimes', 'nullable', 'integer'],
         ]);
 
-        $districts = UserDistrict::query()
-            ->when($request->filled('city_id'), function ($query) use ($request) {
-                $query->where('city_id', (int) $request->input('city_id'));
-            })
-            ->orderBy('name_ar')
-            ->get();
+        $cityId = $request->filled('city_id') ? (int) $request->input('city_id') : null;
+
+        $districts = Cache::remember(
+            LocationLookupCache::key('districts', $cityId),
+            LocationLookupCache::TTL_SECONDS,
+            function () use ($cityId) {
+                return UserDistrict::query()
+                    ->when($cityId !== null, function ($query) use ($cityId) {
+                        $query->where('city_id', $cityId);
+                    })
+                    ->orderBy('name_ar')
+                    ->get()
+                    ->toArray();
+            }
+        );
 
         return response()->json(['data' => $districts]);
     }

--- a/app/Http/Controllers/Api/GeneratedApiPathsDoc.php
+++ b/app/Http/Controllers/Api/GeneratedApiPathsDoc.php
@@ -2363,8 +2363,23 @@ namespace App\Http\Controllers\Api;
  *         operationId="get_dashboard_setup_progress_0",
  *         tags={"Dashboard"},
  *         summary="Setup Progress", security={{"sanctum":{}}},
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site"}),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner")
  *     )
  *
  * )
@@ -4178,10 +4193,27 @@ namespace App\Http\Controllers\Api;
  *         tags={"Steps"},
  *         summary="Complete Step", security={{"sanctum":{}}},
  *         @OA\RequestBody(required=true, @OA\JsonContent(type="object", required={"step"},
- *             @OA\Property(property="step", type="string", enum={"banner","footer","homepage_about_update","menu_builder","projects","properties"}),
+ *             @OA\Property(property="step", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site","properties"}),
  *         )),
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="message", type="string", example="Step marked as completed."),
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string"),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner"),
+ *         @OA\Response(response=422, description="Validation error")
  *     )
  *
  * )
@@ -4194,8 +4226,23 @@ namespace App\Http\Controllers\Api;
  *         operationId="get_steps_progress_0",
  *         tags={"Steps"},
  *         summary="Get Steps", security={{"sanctum":{}}},
- *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object", @OA\Property(property="status", type="string", example="success"), @OA\Property(property="data", type="object"), @OA\Property(property="message", type="string", nullable=true))),
- *         @OA\Response(response=401, description="Unauthenticated")
+ *         @OA\Response(response=200, description="OK", @OA\JsonContent(type="object",
+ *             @OA\Property(property="progress", type="number", format="float", example=0.4),
+ *             @OA\Property(property="done", type="integer", example=2),
+ *             @OA\Property(property="total", type="integer", example=5),
+ *             @OA\Property(property="headline_key", type="string", enum={"start","early","mid","almost","done"}),
+ *             @OA\Property(property="dismissed", type="boolean", example=false),
+ *             @OA\Property(property="steps", type="array", @OA\Items(type="object",
+ *                 @OA\Property(property="id", type="string", enum={"site_identity","contact_info","first_property","integrated_link","connect_site"}),
+ *                 @OA\Property(property="label_ar", type="string"),
+ *                 @OA\Property(property="status", type="boolean"),
+ *                 @OA\Property(property="href", type="string", nullable=true),
+ *                 @OA\Property(property="order", type="integer"),
+ *                 @OA\Property(property="locked", type="boolean", example=false)
+ *             ))
+ *         )),
+ *         @OA\Response(response=401, description="Unauthenticated"),
+ *         @OA\Response(response=403, description="Unable to resolve tenant owner")
  *     )
  *
  * )

--- a/app/Http/Controllers/Api/StepProgressController.php
+++ b/app/Http/Controllers/Api/StepProgressController.php
@@ -2,126 +2,54 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Models\UserStep;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\Onboarding\CompleteOnboardingStepRequest;
+use App\Services\SiteSetupProgressService;
+use Illuminate\Http\Request;
 
 class StepProgressController extends Controller
 {
-    /**
-     * Step map configuration - moved to class constant to avoid per-request allocation
-     */
-    private const STEP_MAP = [
-        'banner' => [
-            'path' => '/content/banner',
-            'text' => 'قم بتخصيص البانر الخاص بك',
-        ],
-        'footer' => [
-            'path' => '/content/footer',
-            'text' => 'قم بتخصيص التذييل الخاص بك',
-        ],
-        'homepage_about_update' => [
-            'path' => '/content/about',
-            'text' => 'قم بتحديث قسم من نحن',
-        ],
-        'menu_builder' => [
-            'path' => '/content/menu',
-            'text' => 'قم بإعداد قائمة الموقع',
-        ],
-        'projects' => [
-            'path' => '/projects/add',
-            'text' => 'أضف أول مشروع',
-        ],
-        'properties' => [
-            'path' => '/properties/add',
-            'text' => 'اضف اول عقار الآن',
-        ],
-    ];
+    public function __construct(
+        private readonly SiteSetupProgressService $progressService,
+    ) {}
 
     /**
-     * Display the progress of a specific step for a user.
+     * Display site setup progress for the authenticated user's tenant owner.
      *
-     * @param  Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function getSteps(Request $request)
     {
-        $user = $request->user();
-        
-        // Check if performance optimizations are enabled
-        $useOptimizations = config('performance.enable_api_performance_optimizations');
-        
-        if ($useOptimizations) {
-            // Select only the columns we use to avoid pulling large blobs
-            $stepKeys = array_keys(self::STEP_MAP);
-            $steps = UserStep::select(['user_id', ...$stepKeys])
-                ->firstOrCreate(['user_id' => $user->id], array_fill_keys($stepKeys, false));
-        } else {
-            $steps = UserStep::firstOrCreate(['user_id' => $user->id]);
+        $progress = $this->progressService->getProgress($request->user());
+
+        if ($progress === null) {
+            return response()->json([
+                'message' => 'Unable to resolve tenant owner.',
+            ], 403);
         }
 
-        $stepMap = self::STEP_MAP;
-        $rawData = $steps->only(array_keys($stepMap));
-
-    $stepsWithStatus = [];
-    foreach ($stepMap as $key => $info) {
-        $value = $rawData[$key] ?? null;
-        $stepsWithStatus[$key] = [
-            'status' => $value,
-            'text' => $info['text'],
-        ];
+        return response()->json($progress);
     }
 
-    $progress = collect($stepsWithStatus)->filter(fn($step) => $step['status'])->count();
-    $percentage = intval(($progress / count($stepMap)) * 100);
-
-    $continuePath = collect($stepMap)
-        ->filter(fn($_, $key) => empty($rawData[$key]))
-        ->pluck('path')
-        ->first();
-
-    return response()->json([
-        'steps' => $stepsWithStatus,
-        'progress' => $percentage,
-        'continue_path' => $continuePath,
-    ]);
-}
-
-
+    /**
+     * Mark a setup step complete (owner user_steps write) and return GET-shaped progress.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function completeStep(CompleteOnboardingStepRequest $request)
     {
         $validated = $request->validated();
-        $user = auth()->user();
-        $steps = UserStep::firstOrCreate(['user_id' => $user->id]);
+        $result = $this->progressService->completeStep($request->user(), $validated['step']);
 
-        $steps->{$validated['step']} = true;
-        // Optional: check if all steps are completed now
-        $stepKeys = ['banner', 'footer', 'homepage_about_update', 'menu_builder', 'projects', 'properties'];
-        $remaining = collect($steps->only($stepKeys))->filter(fn ($v) => ! $v);
-
-        if ($remaining->isEmpty() && ! $steps->completed_at) {
-            $steps->completed_at = now();
+        if (! $result['ok']) {
+            return response()->json([
+                'message' => $result['error'] ?? 'Unable to complete step.',
+            ], $result['status'] ?? 422);
         }
 
-        $steps->save();
-
-        $data = $steps->only($stepKeys);
-        $progress = collect($data)->filter(fn ($v) => $v)->count();
-        $percentage = intval(($progress / count($stepKeys)) * 100);
-
-        $continuePath = collect(self::STEP_MAP)
-            ->filter(fn ($_, $key) => empty($data[$key]))
-            ->pluck('path')
-            ->first();
-
-        return response()->json([
-            'message' => 'Step marked as completed.',
-            'steps' => $data,
-            'progress' => $percentage,
-            'continue_path' => $continuePath,
-        ]);
+        return response()->json(array_merge(
+            ['message' => 'Step marked as completed.'],
+            $result['progress']
+        ));
     }
-
-
 }

--- a/app/Http/Controllers/Api/property/ApiPropertyRequestController.php
+++ b/app/Http/Controllers/Api/property/ApiPropertyRequestController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use App\Models\Api\UserPropertyRequest;
 use App\Models\User\UserCity;
 use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\Project;
 use App\Http\Requests\Api\Property\StorePropertyRequestRequest;
 use App\Http\Requests\Api\Property\UpdatePropertyRequestRequest;
 use App\Http\Requests\Api\Property\UpdateStatusPropertyRequestRequest;
@@ -91,6 +92,26 @@ class ApiPropertyRequestController extends Controller
             }
 
             $propertyIds = $validIds;
+        }
+
+        // Ensure provided project_id belongs to the resolved tenant
+        if (array_key_exists('project_id', $data) && $data['project_id'] !== null) {
+            $projectId = (int) $data['project_id'];
+            $owned = Project::query()
+                ->where('user_id', $tenant->id)
+                ->where('id', $projectId)
+                ->exists();
+
+            if (! $owned) {
+                return response()->json([
+                    'message' => 'The selected project ID is invalid or does not belong to this tenant.',
+                    'errors' => [
+                        'project_id' => ['The selected project ID is invalid or unauthorized for this tenant.'],
+                    ],
+                ], 422);
+            }
+
+            $data['project_id'] = $projectId;
         }
 
         if (! empty($data['region'])) {
@@ -192,12 +213,17 @@ class ApiPropertyRequestController extends Controller
      */
     public function storeFromInterest(Request $request): JsonResponse
     {
+        if ($request->has('project_id') && $request->input('project_id') === '') {
+            $request->merge(['project_id' => null]);
+        }
+
         $validated = $request->validate([
             'tenant_username' => 'required|string|max:255',
             'property_id' => 'required|integer|exists:user_properties,id',
             'full_name' => 'required|string|max:255',
             'phone' => 'required|string|max:20',
             'notes' => 'nullable|string|max:1000',
+            'project_id' => 'nullable|integer|exists:user_projects,id',
         ]);
 
         try {
@@ -219,6 +245,30 @@ class ApiPropertyRequestController extends Controller
                 'message' => 'Property not found.',
                 'errors' => ['property_id' => ['Property does not exist or does not belong to this tenant.']],
             ], 404);
+        }
+
+        // Body project_id wins when key present; otherwise inherit from property when set.
+        $projectId = null;
+        if (array_key_exists('project_id', $validated)) {
+            $projectId = $validated['project_id'] !== null ? (int) $validated['project_id'] : null;
+        } elseif (! empty($property->project_id)) {
+            $projectId = (int) $property->project_id;
+        }
+
+        if ($projectId !== null) {
+            $owned = Project::query()
+                ->where('user_id', $tenant->id)
+                ->where('id', $projectId)
+                ->exists();
+
+            if (! $owned) {
+                return response()->json([
+                    'message' => 'The selected project ID is invalid or does not belong to this tenant.',
+                    'errors' => [
+                        'project_id' => ['The selected project ID is invalid or unauthorized for this tenant.'],
+                    ],
+                ], 422);
+            }
         }
 
         $content = $property->contents->first();
@@ -247,6 +297,7 @@ class ApiPropertyRequestController extends Controller
             'initial_property_id' => $property->id,
             'latitude' => $property->latitude,
             'longitude' => $property->longitude,
+            'project_id' => $projectId,
         ];
 
         $data = app(PropertyRequestLocationNormalizer::class)->normalize($data, 'property_interest');

--- a/app/Http/Controllers/Api/property/PropertyController.php
+++ b/app/Http/Controllers/Api/property/PropertyController.php
@@ -32,6 +32,7 @@ use App\Models\User\RealestateManagement\UserPropertyCharacteristic;
 use App\Models\User\RealestateManagement\ApiUserCategory as Category;
 use App\Models\Analytics\AnalyticsDailySummary;
 use App\Support\Audit;
+use App\Support\PropertyFilterQuery;
 use App\Support\SourceBrokerNormalizer;
 use App\Services\GoogleAnalyticsService;
 use App\Services\DatabaseVersionService;
@@ -159,9 +160,6 @@ class PropertyController extends Controller
                     ], 422);
                 }
 
-                // Smart Method: Calculate the exact number of rows with data
-                // This avoids reading thousands of empty rows
-                $filePath = $uploadedFile->getPathname();
                 $fileSize = $uploadedFile->getSize();
 
                 // Check file size (10MB = 10485760 bytes)
@@ -180,15 +178,8 @@ class PropertyController extends Controller
                     ], 422);
                 }
 
-                $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReaderForFile($filePath);
-                $reader->setReadDataOnly(true); // Optimization: Read only data, ignore formatting
-                $spreadsheet = $reader->load($filePath);
-                $worksheet = $spreadsheet->getActiveSheet();
-                $highestRow = $worksheet->getHighestDataRow(); // This gets the last row with actual data
-
-                // Pass the smart limit to the import class
-                // highestRow includes header, so we pass it as the limit
-                $import = new PropertiesImport($user->id, $highestRow);
+                // Fixed generous row limit — avoid a third PhpSpreadsheet pre-read just for getHighestDataRow()
+                $import = new PropertiesImport($user->id, 5000);
 
                 $collection = Excel::toCollection($import, $uploadedFile);
 
@@ -294,8 +285,7 @@ class PropertyController extends Controller
             }
 
             try {
-                // Use the same smart limit for the actual import
-                $import = new PropertiesImport($user->id, $highestRow);
+                $import = new PropertiesImport($user->id, 5000);
                 Excel::import($import, $uploadedFile);
 
                 $failures = $import->sheetImport->failures();
@@ -348,13 +338,18 @@ class PropertyController extends Controller
                     $row = null;
                     $field = null;
 
+                    if ($error instanceof \App\Imports\Exceptions\RowValidationException) {
+                        $field = $error->field;
+                        $row = $error->row;
+                    }
+
                     // Extract row number if present in exception message
-                    if (preg_match('/Row (\d+):/', $message, $matches)) {
+                    if ($row === null && preg_match('/Row (\d+):/', $message, $matches)) {
                         $row = (int)$matches[1];
                     }
 
                     // Try to extract field name from error message
-                    if (preg_match('/Invalid (\w+)/i', $message, $fieldMatches)) {
+                    if ($field === null && preg_match('/Invalid (\w+)/i', $message, $fieldMatches)) {
                         $field = strtolower($fieldMatches[1]);
                     }
 
@@ -596,7 +591,28 @@ class PropertyController extends Controller
 
     public function downloadTemplate()
     {
-        return Excel::download(new \App\Exports\PropertiesTemplateExport, 'properties_import_template.xlsx');
+        try {
+            return Excel::download(new \App\Exports\PropertiesTemplateExport, 'properties_import_template.xlsx');
+        } catch (\Exception $e) {
+            Log::error('Properties import template generation error', [
+                'user_id' => auth()->id(),
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status' => 'error',
+                'code' => 'TEMPLATE_GENERATION_FAILED',
+                'message' => 'Failed to generate import template',
+                'details' => [
+                    'user_id' => auth()->id(),
+                    'error' => config('app.debug')
+                        ? $e->getMessage()
+                        : 'An error occurred while generating the import template. Please try again.',
+                ],
+                'timestamp' => now()->toIso8601String(),
+            ], 500);
+        }
     }
 
 
@@ -3717,112 +3733,7 @@ class PropertyController extends Controller
                   ->orWhere('property_status', '!=', 'rented');
             });
 
-        // Apply property IDs filter if provided
-        if (!empty($filters['ids']) && is_array($filters['ids']) && count($filters['ids']) > 0) {
-            $query->whereIn('id', $filters['ids']);
-        }
-
-        // Apply date range filter
-        if (!empty($filters['date_from'])) {
-            $query->whereDate('created_at', '>=', $filters['date_from']);
-        }
-        if (!empty($filters['date_to'])) {
-            $query->whereDate('created_at', '<=', $filters['date_to']);
-        }
-
-        // Apply purpose filter
-        if (!empty($filters['purposes_filter'])) {
-            $query->where('purpose', $filters['purposes_filter']);
-        }
-        if (!empty($filters['purpose'])) {
-            $query->where('purpose', $filters['purpose']);
-        }
-
-        // Apply property_type filter
-        if (!empty($filters['property_type'])) {
-            $query->where('property_type', $filters['property_type']);
-        }
-
-        // Apply price filters
-        if (!empty($filters['price_from'])) {
-            $query->where('price', '>=', $filters['price_from']);
-        }
-        if (!empty($filters['price_to'])) {
-            $query->where('price', '<=', $filters['price_to']);
-        }
-
-        // Apply area filters
-        if (!empty($filters['area_from'])) {
-            $query->where('area', '>=', $filters['area_from']);
-        }
-        if (!empty($filters['area_to'])) {
-            $query->where('area', '<=', $filters['area_to']);
-        }
-
-        // Apply beds filter
-        if (!empty($filters['beds'])) {
-            $query->where('beds', $filters['beds']);
-        }
-
-        // Apply bath filter
-        if (!empty($filters['bath'])) {
-            $query->where('bath', $filters['bath']);
-        }
-
-        // Apply category filter
-        if (!empty($filters['category_id'])) {
-            $query->where('category_id', $filters['category_id']);
-        }
-
-        // Apply status filter
-        if (isset($filters['status']) && $filters['status'] !== '') {
-            $query->where('status', $filters['status']);
-        }
-
-        // Apply featured filter
-        if (isset($filters['featured']) && $filters['featured'] !== '') {
-            $query->where('featured', $filters['featured']);
-        }
-
-        // Apply city filter
-        if (!empty($filters['city_id'])) {
-            $query->whereHas('contents', function ($q) use ($filters) {
-                $q->where('city_id', $filters['city_id']);
-            });
-        }
-
-        // Apply district filter
-        if (!empty($filters['district_id'])) {
-            $query->whereHas('contents', function ($q) use ($filters) {
-                $q->where('state_id', $filters['district_id']);
-            });
-        }
-
-        // Apply search filter (title/address, plus numeric property ID)
-        if (!empty($filters['search'])) {
-            $search = trim((string) $filters['search']);
-            $numericId = $this->parsePositiveIntSearchId($search);
-            $query->where(function ($q) use ($search, $numericId) {
-                $q->whereHas('contents', function ($cq) use ($search) {
-                    $cq->where(function ($inner) use ($search) {
-                        $inner->where('title', 'like', "%{$search}%")
-                              ->orWhere('address', 'like', "%{$search}%");
-                    });
-                });
-                if ($numericId !== null) {
-                    $q->orWhere('id', $numericId);
-                }
-            });
-        }
-
-        // Apply features filter
-        if (!empty($filters['features'])) {
-            $featuresArray = explode(',', $filters['features']);
-            foreach ($featuresArray as $feature) {
-                $feature = trim($feature);
-                $query->whereJsonContains('features', $feature);
-            }
-        }
+        PropertyFilterQuery::apply($query, $filters);
 
         // Optionally filter out properties with active rentals
         if (method_exists(Property::class, 'rentals')) {

--- a/app/Http/Controllers/Api/property/PropertyController.php
+++ b/app/Http/Controllers/Api/property/PropertyController.php
@@ -61,6 +61,8 @@ use App\Http\Requests\Api\Property\UpdatePropertyRequest;
 
 use Maatwebsite\Excel\Facades\Excel;
 use App\Imports\PropertiesImport;
+use App\Rules\PropertyTypeRule;
+use App\Support\PropertyCompletionRequirements;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PropertyController extends Controller
@@ -77,6 +79,8 @@ class PropertyController extends Controller
         'title' => 'اسم الوحدة',
         'description' => 'الوصف',
         'address' => 'العنوان',
+        'featured_image' => 'الصورة الرئيسية',
+        'type' => 'نوع الوحدة',
         'city_id' => 'المدينة',
         'price' => 'المبلغ',
         'pricePerMeter' => 'سعر المتر',
@@ -187,12 +191,9 @@ class PropertyController extends Controller
                 // The collection excludes the header due to WithHeadingRow trait
                 $firstSheet = $collection->first();
 
-                // Required fields for a complete property
-                $requiredFields = ['title', 'price', 'address', 'description', 'purpose', 'property_type', 'area'];
-
                 // Count rows that will be complete (have all required fields)
                 // Only complete properties count toward the limit
-                $incomingCompleteCount = $firstSheet->filter(function($row) use ($requiredFields) {
+                $incomingCompleteCount = $firstSheet->filter(function($row) {
                     $rowArray = $row->toArray();
 
                     // Skip rows marked as empty by prepareForValidation
@@ -214,28 +215,23 @@ class PropertyController extends Controller
                         return false;
                     }
 
-                    // Check if this row has all required fields (will be complete)
-                    foreach ($requiredFields as $field) {
-                        $value = $rowArray[$field] ?? null;
-                        if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
-                            return false; // Missing required field - will be incomplete
+                    // Normalize row keys (Excel imports use 'type', API uses 'property_type')
+                    $rowArray = PropertyCompletionRequirements::normalizeInput($rowArray);
+
+                    // Check if row is complete using the single source of truth
+                    if (!PropertyCompletionRequirements::isComplete($rowArray)) {
+                        return false;
+                    }
+
+                    // Validate property_type is an allowed value
+                    $propertyType = $rowArray['property_type'] ?? null;
+                    if ($propertyType !== null) {
+                        $normalized = is_string($propertyType)
+                            ? PropertyTypeRule::normalize($propertyType)
+                            : null;
+                        if (!in_array($normalized, PropertyTypeRule::allowed(), true)) {
+                            return false; // Invalid property_type - will fail validation
                         }
-                    }
-
-                    // Validate numeric fields
-                    if (isset($rowArray['price']) && !is_numeric($rowArray['price'])) {
-                        return false; // Invalid price - will fail validation
-                    }
-                    if (isset($rowArray['area']) && (!is_numeric($rowArray['area']) || $rowArray['area'] < 1)) {
-                        return false; // Invalid area - will fail validation
-                    }
-
-                    // Validate enum fields
-                    if (isset($rowArray['purpose']) && !in_array($rowArray['purpose'], ['sale', 'rent'])) {
-                        return false; // Invalid purpose - will fail validation
-                    }
-                    if (isset($rowArray['property_type']) && !in_array(strtolower((string) $rowArray['property_type']), ['residential', 'commercial', 'agricultural', 'industrial'], true)) {
-                        return false; // Invalid property_type - will fail validation
                     }
 
                     // All required fields present and valid - will be complete
@@ -3914,7 +3910,7 @@ class PropertyController extends Controller
             DB::transaction(function () use ($property, $owner, $defaultLanguage, $validated) {
                 // Update property fields
                 $propertyData = [];
-                $allowedFields = ['price', 'pricePerMeter', 'purpose', 'property_type', 'beds', 'bath', 'area',
+                $allowedFields = ['price', 'pricePerMeter', 'purpose', 'property_type', 'featured_image', 'beds', 'bath', 'area',
                     'size', 'video_url', 'virtual_tour', 'features', 'payment_method',
                     'water_meter_number', 'electricity_meter_number', 'deed_number',
                     'advertising_license', 'latitude', 'longitude', 'category_id', 'project_id', 'building_id',
@@ -3963,30 +3959,18 @@ class PropertyController extends Controller
                     }
                 }
 
-                // Recalculate missing fields
-                $requiredFields = ['title', 'price', 'address', 'description', 'purpose', 'property_type', 'area'];
-                $missing = [];
-
-                // Get current property data
+                // Recalculate missing fields against the shared five-field definition
+                $content = $property->contents()->where('language_id', $defaultLanguage->id)->first();
                 $currentData = [
-                    'title' => $property->contents()->where('language_id', $defaultLanguage->id)->value('title'),
-                    'price' => $property->price,
-                    'address' => $property->contents()->where('language_id', $defaultLanguage->id)->value('address'),
-                    'description' => $property->contents()->where('language_id', $defaultLanguage->id)->value('description'),
-                    'purpose' => $property->purpose,
+                    'title' => $content?->title,
+                    'address' => $content?->address,
+                    'description' => $content?->description,
+                    'featured_image' => $property->featured_image,
                     'property_type' => $property->property_type,
-                    'area' => $property->area,
                 ];
 
-                foreach ($requiredFields as $field) {
-                    $value = $currentData[$field] ?? null;
-                    if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
-                        $missing[] = $field;
-                    }
-                }
-
                 $property->update([
-                    'missing_fields' => $missing,
+                    'missing_fields' => PropertyCompletionRequirements::missingFrom($currentData),
                 ]);
             });
 
@@ -4072,6 +4056,7 @@ class PropertyController extends Controller
                 'description' => $validated['description'] ?? $propertyContent?->description,
                 'purpose' => $validated['purpose'] ?? $property->purpose,
                 'property_type' => $validated['property_type'] ?? $property->property_type,
+                'featured_image' => $validated['featured_image'] ?? $property->featured_image,
                 'area' => $validated['area'] ?? $property->area,
             ];
 
@@ -4100,7 +4085,7 @@ class PropertyController extends Controller
             DB::transaction(function () use ($property, $owner, $defaultLanguage, $completeData, $validated) {
                 // Update property with all data
                 $propertyData = [];
-                $allowedFields = ['price', 'pricePerMeter', 'purpose', 'property_type', 'beds', 'bath', 'area',
+                $allowedFields = ['price', 'pricePerMeter', 'purpose', 'property_type', 'featured_image', 'beds', 'bath', 'area',
                     'size', 'video_url', 'virtual_tour', 'features', 'payment_method',
                     'water_meter_number', 'electricity_meter_number', 'deed_number',
                     'advertising_license', 'latitude', 'longitude', 'category_id', 'project_id', 'building_id',
@@ -4120,6 +4105,7 @@ class PropertyController extends Controller
                 if (isset($completeData['price'])) $propertyData['price'] = $completeData['price'];
                 if (isset($completeData['purpose'])) $propertyData['purpose'] = $completeData['purpose'];
                 if (isset($completeData['property_type'])) $propertyData['property_type'] = $completeData['property_type'];
+                if (isset($completeData['featured_image'])) $propertyData['featured_image'] = $completeData['featured_image'];
                 if (isset($completeData['area'])) $propertyData['area'] = $completeData['area'];
 
                 $propertyData['status'] = 1; // Active
@@ -4272,6 +4258,7 @@ class PropertyController extends Controller
                         'description' => $propertyContent?->description,
                         'purpose' => $property->purpose,
                         'property_type' => $property->property_type,
+                        'featured_image' => $property->featured_image,
                         'area' => $property->area,
                     ];
 

--- a/app/Http/Requests/Api/Customer/StoreCustomerRequest.php
+++ b/app/Http/Requests/Api/Customer/StoreCustomerRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Api\Customer;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Models\Api\UserApiCustomerType;
+use App\Services\PropertyRequestCustomerService;
 use Illuminate\Validation\Rule;
 
 class StoreCustomerRequest extends BaseApiFormRequest
@@ -21,15 +23,24 @@ class StoreCustomerRequest extends BaseApiFormRequest
             if (is_array($v)) return array_values(array_filter(array_map('intval', $v)));
             return [];
         };
-        $this->merge([
+
+        $merge = [
             'interested_category_ids' => $toIntArray($this->input('interested_category_ids')),
             'interested_property_ids' => $toIntArray($this->input('interested_property_ids')),
-        ]);
+        ];
+
+        $typeId = $this->input('type_id');
+        if ($typeId === null || $typeId === '') {
+            $merge['type_id'] = $this->defaultTypeId();
+        }
+
+        $this->merge($merge);
     }
 
     public function rules()
     {
         $userId = auth()->id();
+        $ownerId = $this->tenantOwnerId();
 
         return [
             'name' => 'required|string|max:255',
@@ -48,16 +59,13 @@ class StoreCustomerRequest extends BaseApiFormRequest
             'district_id' => 'nullable|exists:user_districts,id',
             'note' => 'nullable|string',
             'type_id' => [
-                'required',
-                Rule::exists('users_api_customers_types', 'id')->where(fn ($q) => $q->where('user_id', $userId)),
+                'nullable',
+                Rule::exists('users_api_customers_types', 'id')->where(fn ($q) => $q->where('user_id', $ownerId)),
             ],
             'responsible_employee_id' => [
                 'nullable',
-                Rule::exists('users', 'id')->where(function ($q) {
-                    $uid = auth()->user() && method_exists(auth()->user(), 'tenantOwnerId')
-                        ? auth()->user()->tenantOwnerId()
-                        : auth()->id();
-                    $q->where('tenant_id', $uid)->where('account_type', 'employee')->where('active', true);
+                Rule::exists('users', 'id')->where(function ($q) use ($ownerId) {
+                    $q->where('tenant_id', $ownerId)->where('account_type', 'employee')->where('active', true);
                 }),
             ],
             'stage_id' => [
@@ -74,5 +82,40 @@ class StoreCustomerRequest extends BaseApiFormRequest
             'interested_property_ids' => 'nullable|array',
             'interested_property_ids.*' => 'integer|exists:user_properties,id',
         ];
+    }
+
+    /**
+     * Resolve the tenant's default customer type when the client omits type_id.
+     *
+     * The cached defaults are shared with the auto-customer flows and are only
+     * invalidated on settings changes, so they can hold a null type_id for up to
+     * the cache TTL if they were warmed before the tenant's CRM types existed.
+     * Fall back to a direct lookup in that case so an omitted type_id does not
+     * silently store a customer with no type.
+     */
+    private function defaultTypeId(): ?int
+    {
+        $ownerId = $this->tenantOwnerId();
+
+        $defaults = app(PropertyRequestCustomerService::class)
+            ->getDefaultCustomerAttributes($ownerId);
+
+        if (! empty($defaults['type_id'])) {
+            return (int) $defaults['type_id'];
+        }
+
+        return UserApiCustomerType::where('user_id', $ownerId)
+            ->where('is_active', true)
+            ->orderBy('order')
+            ->value('id');
+    }
+
+    private function tenantOwnerId(): int
+    {
+        $user = auth()->user();
+
+        return $user && method_exists($user, 'tenantOwnerId')
+            ? (int) $user->tenantOwnerId()
+            : (int) (auth()->id() ?? 0);
     }
 }

--- a/app/Http/Requests/Api/Onboarding/CompleteOnboardingStepRequest.php
+++ b/app/Http/Requests/Api/Onboarding/CompleteOnboardingStepRequest.php
@@ -14,7 +14,7 @@ class CompleteOnboardingStepRequest extends BaseApiFormRequest
     public function rules()
     {
         return [
-            'step' => 'required|in:banner,footer,homepage_about_update,menu_builder,projects,properties',
+            'step' => 'required|in:site_identity,contact_info,first_property,integrated_link,connect_site,properties',
         ];
     }
 }

--- a/app/Http/Requests/Api/Property/CompletePropertyDraftRequest.php
+++ b/app/Http/Requests/Api/Property/CompletePropertyDraftRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Api\Property;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
 use App\Http\Requests\Concerns\ValidatesTenantProjectId;
+use App\Rules\PropertyTypeRule;
 
 class CompletePropertyDraftRequest extends BaseApiFormRequest
 {
@@ -12,6 +13,12 @@ class CompletePropertyDraftRequest extends BaseApiFormRequest
     protected function prepareForValidation(): void
     {
         $this->normalizeNullableProjectId();
+
+        // Legacy clients send `type`; the column and the completeness check are
+        // both `property_type`. Alias it so the value is no longer dropped.
+        if (!$this->has('property_type') && $this->has('type')) {
+            $this->merge(['property_type' => $this->input('type')]);
+        }
     }
     public function authorize()
     {
@@ -28,6 +35,10 @@ class CompletePropertyDraftRequest extends BaseApiFormRequest
             'pricePerMeter' => 'sometimes|nullable|numeric',
             'purpose' => 'sometimes|nullable|string',
             'type' => 'sometimes|nullable|string',
+            // Required for completeness — both must be accepted here or a draft
+            // can never be completed through this endpoint.
+            'property_type' => array_merge(['sometimes'], PropertyTypeRule::nullableRule()),
+            'featured_image' => 'sometimes|nullable|string|max:500',
             'beds' => 'sometimes|nullable|integer|min:0',
             'bath' => 'sometimes|nullable|integer|min:0',
             'area' => 'sometimes|nullable|numeric|min:0',

--- a/app/Http/Requests/Api/Property/StorePropertyRequestRequest.php
+++ b/app/Http/Requests/Api/Property/StorePropertyRequestRequest.php
@@ -3,11 +3,14 @@
 namespace App\Http\Requests\Api\Property;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Http\Requests\Concerns\ValidatesTenantProjectId;
 use App\Rules\PropertyTypeRule;
 use Illuminate\Validation\Rule;
 
 class StorePropertyRequestRequest extends BaseApiFormRequest
 {
+    use ValidatesTenantProjectId;
+
     public function authorize()
     {
         return true;
@@ -15,6 +18,8 @@ class StorePropertyRequestRequest extends BaseApiFormRequest
 
     protected function prepareForValidation(): void
     {
+        $this->normalizeNullableProjectId();
+
         if ($this->has('property_type')) {
             $normalized = PropertyTypeRule::normalize(is_string($this->input('property_type')) ? $this->input('property_type') : null);
             if ($normalized !== null) {
@@ -31,6 +36,8 @@ class StorePropertyRequestRequest extends BaseApiFormRequest
             'phone' => 'required|string|max:20',
             'property_ids' => 'nullable|array',
             'property_ids.*' => 'integer|exists:user_properties,id',
+            // Ownership checked in controller after tenant resolve (public may have no auth).
+            'project_id' => 'nullable|integer|exists:user_projects,id',
             'source' => ['nullable', 'string', Rule::in([
                 'property_interest',
                 'public_form',

--- a/app/Http/Requests/Api/Property/UpdatePropertyDraftRequest.php
+++ b/app/Http/Requests/Api/Property/UpdatePropertyDraftRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Api\Property;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
 use App\Http\Requests\Concerns\ValidatesTenantProjectId;
+use App\Rules\PropertyTypeRule;
 
 class UpdatePropertyDraftRequest extends BaseApiFormRequest
 {
@@ -12,6 +13,12 @@ class UpdatePropertyDraftRequest extends BaseApiFormRequest
     protected function prepareForValidation(): void
     {
         $this->normalizeNullableProjectId();
+
+        // Legacy clients send `type`; the column and the completeness check are
+        // both `property_type`. Alias it so the value is no longer dropped.
+        if (!$this->has('property_type') && $this->has('type')) {
+            $this->merge(['property_type' => $this->input('type')]);
+        }
     }
     public function authorize()
     {
@@ -28,6 +35,10 @@ class UpdatePropertyDraftRequest extends BaseApiFormRequest
             'pricePerMeter' => 'sometimes|nullable|numeric',
             'purpose' => 'sometimes|nullable|string',
             'type' => 'sometimes|nullable|string',
+            // Required for completeness — a draft must be able to set both
+            // while it is still being edited, not only at completion time.
+            'property_type' => array_merge(['sometimes'], PropertyTypeRule::nullableRule()),
+            'featured_image' => 'sometimes|nullable|string|max:500',
             'beds' => 'sometimes|nullable|integer|min:0',
             'bath' => 'sometimes|nullable|integer|min:0',
             'area' => 'sometimes|nullable|numeric|min:0',

--- a/app/Http/Requests/Api/Property/UpdatePropertyRequestRequest.php
+++ b/app/Http/Requests/Api/Property/UpdatePropertyRequestRequest.php
@@ -3,11 +3,14 @@
 namespace App\Http\Requests\Api\Property;
 
 use App\Http\Requests\Api\BaseApiFormRequest;
+use App\Http\Requests\Concerns\ValidatesTenantProjectId;
 use App\Rules\PropertyTypeRule;
 use Illuminate\Validation\Rule;
 
 class UpdatePropertyRequestRequest extends BaseApiFormRequest
 {
+    use ValidatesTenantProjectId;
+
     public function authorize()
     {
         return true;
@@ -15,6 +18,8 @@ class UpdatePropertyRequestRequest extends BaseApiFormRequest
 
     protected function prepareForValidation(): void
     {
+        $this->normalizeNullableProjectId();
+
         if ($this->has('property_type')) {
             $normalized = PropertyTypeRule::normalize(is_string($this->input('property_type')) ? $this->input('property_type') : null);
             if ($normalized !== null) {
@@ -30,7 +35,7 @@ class UpdatePropertyRequestRequest extends BaseApiFormRequest
             ? (int) $user->tenantOwnerId()
             : (int) ($user->id ?? 0);
 
-        return [
+        return array_merge([
             'status_id' => ['nullable', 'integer', 'exists:property_request_statuses,id'],
             'full_name' => ['nullable', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20'],
@@ -94,6 +99,6 @@ class UpdatePropertyRequestRequest extends BaseApiFormRequest
             'referral_source' => ['nullable', 'string', 'max:255'],
             'detected_entities_json' => ['nullable', 'array'],
             'notes' => ['nullable', 'string', 'max:5000'],
-        ];
+        ], $this->tenantProjectIdRules(sometimes: true));
     }
 }

--- a/app/Http/Requests/Api/V2/CustomersHub/CompleteDataRequest.php
+++ b/app/Http/Requests/Api/V2/CustomersHub/CompleteDataRequest.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Requests\Api\V2\CustomersHub;
 
+use App\Http\Requests\Concerns\ValidatesTenantProjectId;
 use App\Rules\PropertyTypeRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CompleteDataRequest extends FormRequest
 {
+    use ValidatesTenantProjectId;
+
     public function authorize(): bool
     {
         return true;
@@ -14,6 +17,8 @@ class CompleteDataRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        $this->normalizeNullableProjectId();
+
         if ($this->has('property_type')) {
             $normalized = \App\Rules\PropertyTypeRule::normalize(is_string($this->input('property_type')) ? $this->input('property_type') : null);
             if ($normalized !== null) {
@@ -24,7 +29,7 @@ class CompleteDataRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
+        return array_merge([
             'property_type'  => ['sometimes', ...PropertyTypeRule::nullableRule()],
             'purpose'        => ['sometimes', 'nullable', 'string', 'in:rent,sale,buy,invest'],
             'city'           => ['sometimes', 'nullable', 'string', 'max:255'],
@@ -41,7 +46,7 @@ class CompleteDataRequest extends FormRequest
             'area_to'        => ['sometimes', 'nullable', 'integer', 'min:0'],
             'latitude'       => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
             'longitude'      => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
-        ];
+        ], $this->tenantProjectIdRules(sometimes: true));
     }
 
     /**

--- a/app/Imports/Exceptions/RowValidationException.php
+++ b/app/Imports/Exceptions/RowValidationException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Imports\Exceptions;
+
+class RowValidationException extends \Exception
+{
+    public function __construct(
+        string $message,
+        public readonly ?string $field = null,
+        public readonly ?int $row = null,
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -131,14 +131,48 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     }
 
     /**
-     * Normalize row keys: map Arabic headers to English, keep existing English keys.
+     * Arabic + Maatwebsite-slugified Arabic headers → English keys.
+     * With heading_row.formatter = slug, Maatwebsite uses Str::slug($header, '_'),
+     * so "عنوان الإعلان" arrives as "aanoan_alaaalan".
+     *
+     * @return array<string, string>
+     */
+    private static function headerKeyMap(): array
+    {
+        static $map = null;
+        if ($map !== null) {
+            return $map;
+        }
+
+        $map = [];
+        foreach (self::arabicHeaderToKey() as $arabic => $english) {
+            $map[$arabic] = $english;
+
+            $arabicSlug = Str::slug($arabic, '_');
+            if ($arabicSlug !== '') {
+                $map[$arabicSlug] = $english;
+            }
+
+            // English keys that contain Arabic (e.g. amenity_مصعد) are also slugified
+            $englishSlug = Str::slug($english, '_');
+            if ($englishSlug !== '' && $englishSlug !== $english) {
+                $map[$englishSlug] = $english;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Normalize row keys: map Arabic / slugified Arabic headers to English, keep existing English keys.
      */
     private function normalizeRowKeys(array $row): array
     {
-        $map = self::arabicHeaderToKey();
+        $map = self::headerKeyMap();
         $out = [];
         foreach ($row as $header => $value) {
-            $key = $map[$header] ?? $header;
+            $headerStr = is_string($header) ? $header : (string) $header;
+            $key = $map[$headerStr] ?? $headerStr;
             $out[$key] = $value;
         }
         return $out;
@@ -1042,14 +1076,14 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             'video_url'   => 'nullable|url|max:500',
             'virtual_tour' => 'nullable|url|max:500',
             'gallery_images' => 'nullable|string',
-            'amenity_مصعد' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_أمن' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_كاميرات_مراقبة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_تكييف_مركزي' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_تدفئة_مركزية' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_صيانة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_بواب' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
-            'amenity_إنترنت' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false',
+            'amenity_مصعد' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_أمن' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_كاميرات_مراقبة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_تكييف_مركزي' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_تدفئة_مركزية' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_صيانة' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_بواب' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
+            'amenity_إنترنت' => 'nullable|string|max:10|in:Yes,No,yes,no,1,0,true,false,نعم,لا',
             'additional_amenities' => 'nullable|string|max:1000',
             'unit_number' => 'nullable|string|max:50',
             'floor_number' => 'nullable|integer|min:0|max:200',
@@ -1083,15 +1117,31 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     }
 
     /**
-     * Prepare data for validation - skip empty rows before validation runs
+     * Prepare data for validation - remap slug/Arabic headers and map purpose/type
+     * so WithValidation rules see English keys and DB enum values.
      */
     public function prepareForValidation($data, $index)
     {
+        $data = $this->normalizeRowKeys(is_array($data) ? $data : (array) $data);
+
+        if (array_key_exists('purpose', $data)) {
+            $mapped = PropertyExcelMapping::purposeToDb($data['purpose']);
+            if ($mapped !== null) {
+                $data['purpose'] = $mapped;
+            }
+        }
+        if (array_key_exists('type', $data)) {
+            $mapped = PropertyExcelMapping::typeToDb($data['type']);
+            if ($mapped !== null) {
+                $data['type'] = $mapped;
+            }
+        }
+
         // Check if row is completely empty (all values are null or empty)
-        $hasData = !empty(array_filter($data, function($value) {
+        $hasData = !empty(array_filter($data, function ($value) {
             return !is_null($value) && $value !== '';
         }));
-        
+
         // If row is completely empty, add a special marker to skip it
         if (!$hasData) {
             // Add required fields with dummy values to pass validation
@@ -1106,7 +1156,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             $data['type'] = 'residential';
             $data['area'] = 0;
         }
-        
+
         return $data;
     }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -2,6 +2,7 @@
 
 namespace App\Imports;
 
+use App\Imports\Exceptions\RowValidationException;
 use App\Models\User\RealestateManagement\Amenity;
 use App\Models\User\RealestateManagement\City;
 use App\Models\User\RealestateManagement\Property;
@@ -26,6 +27,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithValidation, SkipsOnFailure, SkipsOnError, WithLimit
 {
@@ -127,6 +129,13 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             'مميز' => 'featured',
             'مميزات' => 'features',
             'المعرّف' => 'id',
+            // Raw PropertiesExport-only headers (mapped so reject logic can detect them)
+            'معرّف المستخدم' => 'user_id',
+            'اسم المستخدم' => 'user_name',
+            'أنشئ بواسطة' => 'created_by',
+            'اسم المنشئ' => 'creator_name',
+            'تاريخ الإنشاء' => 'created_at',
+            'تاريخ التحديث' => 'updated_at',
         ];
     }
 
@@ -163,6 +172,26 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         return $map;
     }
 
+    /**
+     * Detect PropertiesExport (raw) rows that must not be imported.
+     *
+     * @param  array<string, mixed>  $row
+     */
+    private function isRawExportRow(array $row): bool
+    {
+        if (array_key_exists('id', $row) && array_key_exists('created_at', $row) && array_key_exists('user_id', $row)) {
+            return true;
+        }
+
+        $exportOnlyColumns = ['slug', 'user_id', 'user_name', 'created_by', 'creator_name', 'created_at', 'updated_at'];
+        foreach ($exportOnlyColumns as $col) {
+            if (array_key_exists($col, $row) && $this->valueProvided($row[$col])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
     /**
      * Normalize row keys: map Arabic / slugified Arabic headers to English, keep existing English keys.
      */
@@ -346,19 +375,27 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         // Validate featured image URL format
         if (!empty($row['featured_image'])) {
             if (!$this->validateImageUrl($row['featured_image'])) {
-                throw new \Exception("Row {$rowIndex}: Invalid featured_image URL format. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid featured_image URL format. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).",
+                    field: 'featured_image',
+                    row: $rowIndex
+                );
             }
         }
 
         // Validate gallery image URLs
         foreach ($galleryImages as $galleryUrl) {
             if (!$this->validateImageUrl($galleryUrl)) {
-                throw new \Exception("Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).",
+                    field: 'gallery_images',
+                    row: $rowIndex
+                );
             }
         }
 
         // Business rule validation (after determining if it's an update)
-        $this->validateBusinessRules($row, $rowIndex, $isUpdate);
+        $businessViolations = $this->validateBusinessRules($row, $rowIndex, $isUpdate);
 
         // Check for missing required fields (only for new properties, not updates)
         $missingFields = [];
@@ -366,6 +403,22 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         
         // Add location validation errors
         $validationErrors = array_merge($validationErrors, $locationValidationErrors);
+
+        // Soft-fail business rules for creates; hard-fail for updates
+        if ($isUpdate && !empty($businessViolations)) {
+            $first = $businessViolations[0];
+            throw new RowValidationException(
+                "Row {$rowIndex}: {$first['message']}",
+                field: $first['field'],
+                row: $rowIndex
+            );
+        }
+        if (!$isUpdate && !empty($businessViolations)) {
+            $validationErrors = array_merge(
+                $validationErrors,
+                array_column($businessViolations, 'message')
+            );
+        }
         
         if (!$isUpdate) {
             $requiredFields = [
@@ -473,45 +526,21 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 // Replace gallery images (delete existing, add new)
                 if (isset($row['gallery_images'])) {
                     PropertySliderImg::where('property_id', $property->id)->delete();
-                    if (is_array($galleryImages)) {
-                        foreach ($galleryImages as $galleryUrl) {
-                            try {
-                                PropertySliderImg::storeSliderImage($this->userId, $property->id, $galleryUrl);
-                            } catch (\Exception $e) {
-                                Log::error("Row {$rowIndex}: Failed to store gallery image", [
-                                    'url' => $galleryUrl,
-                                    'error' => $e->getMessage()
-                                ]);
-                                throw new \Exception("Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}");
-                            }
-                        }
+                    if (is_array($galleryImages) && !empty($galleryImages)) {
+                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
                     }
                 }
 
                 // Replace amenities (delete existing, add new)
                 PropertyAmenity::where('property_id', $property->id)->delete();
                 if (!empty($amenityIds)) {
-                    foreach ($amenityIds as $amenityId) {
-                        PropertyAmenity::sotreAmenity($this->userId, $property->id, $amenityId);
-                    }
+                    $this->bulkInsertAmenities($property->id, $amenityIds);
                 }
 
                 // Replace specifications (delete existing, add new)
                 PropertySpecification::where('property_id', $property->id)->delete();
                 if (is_array($specifications) && !empty($specifications)) {
-                    $specIndex = 0;
-                    foreach ($specifications as $spec) {
-                        if (!is_array($spec)) {
-                            continue; // Skip invalid entries
-                        }
-                        $specData = [
-                            'language_id' => $this->defaultLanguageId,
-                            'key' => $specIndex++,
-                            'label' => $spec['label'] ?? $spec['key'] ?? '',
-                            'value' => $spec['value'] ?? '',
-                        ];
-                        PropertySpecification::storeSpecification($this->userId, $property->id, $specData);
-                    }
+                    $this->bulkInsertSpecifications($property->id, $specifications);
                 }
 
                 // Update characteristics if provided
@@ -582,41 +611,18 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     }
 
                     // Process gallery images if provided
-                    if (is_array($galleryImages)) {
-                        foreach ($galleryImages as $galleryUrl) {
-                            try {
-                                PropertySliderImg::storeSliderImage($this->userId, $property->id, $galleryUrl);
-                            } catch (\Exception $e) {
-                                Log::warning("Row {$rowIndex}: Failed to store gallery image for incomplete property", [
-                                    'url' => $galleryUrl,
-                                    'error' => $e->getMessage()
-                                ]);
-                            }
-                        }
+                    if (is_array($galleryImages) && !empty($galleryImages)) {
+                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
                     }
 
                     // Process amenities if provided
                     if (!empty($amenityIds) && is_array($amenityIds)) {
-                        foreach ($amenityIds as $amenityId) {
-                            PropertyAmenity::sotreAmenity($this->userId, $property->id, $amenityId);
-                        }
+                        $this->bulkInsertAmenities($property->id, $amenityIds);
                     }
 
                     // Process specifications if provided
                     if (is_array($specifications) && !empty($specifications)) {
-                        $specIndex = 0;
-                        foreach ($specifications as $spec) {
-                            if (!is_array($spec)) {
-                                continue; // Skip invalid spec entries
-                            }
-                            $specData = [
-                                'language_id' => $this->defaultLanguageId,
-                                'key' => $specIndex++,
-                                'label' => $spec['label'] ?? $spec['key'] ?? '',
-                                'value' => $spec['value'] ?? '',
-                            ];
-                            PropertySpecification::storeSpecification($this->userId, $property->id, $specData);
-                        }
+                        $this->bulkInsertSpecifications($property->id, $specifications);
                     }
 
                     // Create characteristics if provided
@@ -680,42 +686,18 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
 
                     // Process gallery images
-                    if (is_array($galleryImages)) {
-                        foreach ($galleryImages as $galleryUrl) {
-                            try {
-                                PropertySliderImg::storeSliderImage($this->userId, $property->id, $galleryUrl);
-                            } catch (\Exception $e) {
-                                Log::error("Row {$rowIndex}: Failed to store gallery image", [
-                                    'url' => $galleryUrl,
-                                    'error' => $e->getMessage()
-                                ]);
-                                throw new \Exception("Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}");
-                            }
-                        }
+                    if (is_array($galleryImages) && !empty($galleryImages)) {
+                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
                     }
 
                     // Process amenities (no validation - same as API store method)
                     if (!empty($amenityIds) && is_array($amenityIds)) {
-                        foreach ($amenityIds as $amenityId) {
-                            PropertyAmenity::sotreAmenity($this->userId, $property->id, $amenityId);
-                        }
+                        $this->bulkInsertAmenities($property->id, $amenityIds);
                     }
 
                     // Process specifications (use integer keys matching API behavior)
                     if (is_array($specifications) && !empty($specifications)) {
-                        $specIndex = 0; // Counter for integer keys (matching API store method)
-                        foreach ($specifications as $spec) {
-                            if (!is_array($spec)) {
-                                continue; // Skip invalid entries
-                            }
-                            $specData = [
-                                'language_id' => $this->defaultLanguageId,
-                                'key' => $specIndex++, // Use integer counter instead of string key (matching API)
-                                'label' => $spec['label'] ?? $spec['key'] ?? '',
-                                'value' => $spec['value'] ?? '',
-                            ];
-                            PropertySpecification::storeSpecification($this->userId, $property->id, $specData);
-                        }
+                        $this->bulkInsertSpecifications($property->id, $specifications);
                     }
 
                     // Create characteristics if provided
@@ -1097,7 +1079,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         // Note: Fields are intentionally NOT required here to allow incomplete properties
         // Custom validation in onRow() determines completeness and creates incomplete properties if needed
         return [
-            'id'          => 'nullable|integer|exists:user_properties,id',
+            'id' => [
+                'nullable',
+                'integer',
+                Rule::exists('user_properties', 'id')->where('user_id', $this->userId),
+            ],
             'title'       => 'nullable|string|max:255',
             'price'       => 'nullable|numeric|min:0',
             'price_per_meter' => 'nullable|numeric|min:0',
@@ -1161,6 +1147,33 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
      * Prepare data for validation - remap slug/Arabic headers and map purpose/type
      * so WithValidation rules see English keys and DB enum values.
      */
+        public function customValidationMessages(): array
+    {
+        return [
+            '_raw_export.prohibited' => 'Invalid file format. It appears you are trying to import a raw Export file which is not supported. Please copy your data into the official Import Template.',
+        ];
+    }
+
+    /**
+     * @param  \Illuminate\Validation\Validator  $validator
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            foreach ($validator->getData() as $rowIndex => $row) {
+                if (!is_array($row)) {
+                    continue;
+                }
+                // Marker set in prepareForValidation for raw PropertiesExport rows
+                if (($row['_raw_export'] ?? null) === '1') {
+                    $validator->errors()->add(
+                        $rowIndex . '._raw_export',
+                        "Row {$rowIndex}: Invalid file format. It appears you are trying to import a raw Export file which is not supported. Please copy your data into the official Import Template."
+                    );
+                }
+            }
+        });
+    }
     public function prepareForValidation($data, $index)
     {
         $data = $this->normalizeRowKeys(is_array($data) ? $data : (array) $data);
@@ -1179,6 +1192,14 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         $data = $this->castStringFieldsForValidation($data);
+
+        // Raw-export files map id + export-only columns (user_id, created_at, …).
+        // WithValidation runs before onRow(), and OnEachRow does not swallow exceptions
+        // via SkipsOnError — so reject through validation (see withValidator) instead of throwing.
+        if ($this->isRawExportRow($data)) {
+            unset($data['id']);
+            $data['_raw_export'] = '1';
+        }
 
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {
@@ -1214,19 +1235,31 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if ($this->valueProvided($cityIdRaw)) {
             $cityId = $this->resolveCityId($cityIdRaw, $rowIndex);
             if (!$cityId) {
-                throw new \Exception("Row {$rowIndex}: Invalid city_id: {$cityIdRaw}. Please use a valid ID or leave it blank and fill city_name.");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid city_id: {$cityIdRaw}. Please use a valid ID or leave it blank and fill city_name.",
+                    field: 'city_id',
+                    row: $rowIndex
+                );
             }
 
             if ($this->valueProvided($cityNameRaw)) {
                 $cityNameId = $this->resolveCityId($cityNameRaw, $rowIndex);
                 if ($cityNameId && $cityNameId !== $cityId) {
-                    throw new \Exception("Row {$rowIndex}: city_id ({$cityIdRaw}) does not match city_name ({$cityNameRaw}).");
+                    throw new RowValidationException(
+                        "Row {$rowIndex}: city_id ({$cityIdRaw}) does not match city_name ({$cityNameRaw}).",
+                        field: 'city_id',
+                        row: $rowIndex
+                    );
                 }
             }
         } elseif ($this->valueProvided($cityNameRaw)) {
             $cityId = $this->resolveCityId($cityNameRaw, $rowIndex);
             if (!$cityId) {
-                throw new \Exception("Row {$rowIndex}: Unable to find a city named '{$cityNameRaw}'. Please copy a value from the reference sheet.");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Unable to find a city named '{$cityNameRaw}'. Please copy a value from the reference sheet.",
+                    field: 'city_id',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1236,13 +1269,21 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if ($this->valueProvided($stateIdRaw)) {
             $stateId = $this->resolveDistrictId($stateIdRaw, $cityId, $rowIndex);
             if (!$stateId) {
-                throw new \Exception("Row {$rowIndex}: Invalid state_id: {$stateIdRaw}. Please use a valid ID or leave it blank and fill district_name.");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: Invalid state_id: {$stateIdRaw}. Please use a valid ID or leave it blank and fill district_name.",
+                    field: 'state_id',
+                    row: $rowIndex
+                );
             }
 
             if ($this->valueProvided($districtNameRaw)) {
                 $districtNameId = $this->resolveDistrictId($districtNameRaw, $cityId, $rowIndex);
                 if ($districtNameId && $districtNameId !== $stateId) {
-                    throw new \Exception("Row {$rowIndex}: state_id ({$stateIdRaw}) does not match district_name ({$districtNameRaw}).");
+                    throw new RowValidationException(
+                        "Row {$rowIndex}: state_id ({$stateIdRaw}) does not match district_name ({$districtNameRaw}).",
+                        field: 'state_id',
+                        row: $rowIndex
+                    );
                 }
             }
         } elseif ($this->valueProvided($districtNameRaw)) {
@@ -1307,7 +1348,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-        throw new \Exception("{$prefix}Multiple cities share the name '{$value}'. Please use city_id to specify the correct city.");
+        throw new RowValidationException(
+            "{$prefix}Multiple cities share the name '{$value}'. Please use city_id to specify the correct city.",
+            field: 'city_id',
+            row: $rowIndex
+        );
     }
 
     protected function resolveDistrictId($value, ?int $cityId = null, ?int $rowIndex = null): ?int
@@ -1330,7 +1375,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 $districtCityId = $this->getDistrictCityMapping($id);
                 if ($districtCityId !== $cityId) {
                     $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-                    throw new \Exception("{$prefix}District ID {$id} does not belong to the specified city (city_id: {$cityId}). The district belongs to city_id: {$districtCityId}.");
+                    throw new RowValidationException(
+                        "{$prefix}District ID {$id} does not belong to the specified city (city_id: {$cityId}). The district belongs to city_id: {$districtCityId}.",
+                        field: 'state_id',
+                        row: $rowIndex
+                    );
                 }
             }
             
@@ -1373,7 +1422,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
 
             if (count($cityMatches) > 1) {
                 $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-                throw new \Exception("{$prefix}Multiple districts named '{$value}' exist within the selected city. Please use state_id to specify the correct district.");
+                throw new RowValidationException(
+                    "{$prefix}Multiple districts named '{$value}' exist within the selected city. Please use state_id to specify the correct district.",
+                    field: 'state_id',
+                    row: $rowIndex
+                );
             }
 
             // If city is specified but no district found in that city, return null
@@ -1412,7 +1465,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         $prefix = $rowIndex ? "Row {$rowIndex}: " : '';
-        throw new \Exception("{$prefix}Multiple districts share the name '{$value}'. Please specify city_id/state_id for clarity.");
+        throw new RowValidationException(
+            "{$prefix}Multiple districts share the name '{$value}'. Please specify city_id/state_id for clarity.",
+            field: 'state_id',
+            row: $rowIndex
+        );
     }
 
     /**
@@ -1542,29 +1599,39 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     }
 
     /**
-     * Validate business rules for property data
-     * 
+     * Validate business rules for property data.
+     * Soft-fail fields return violation entries; hard-fail fields throw RowValidationException.
+     *
      * @param array $row Row data
      * @param int $rowIndex Row index
      * @param bool $isUpdate Whether this is an update operation
-     * @return void
-     * @throws \Exception If business rule validation fails
+     * @return array<int, array{field: string, message: string}>
+     * @throws RowValidationException
      */
-    protected function validateBusinessRules(array $row, int $rowIndex, bool $isUpdate): void
+    protected function validateBusinessRules(array $row, int $rowIndex, bool $isUpdate): array
     {
+        $violations = [];
+
         // Validate price (must be positive if provided)
         if (isset($row['price']) && $this->valueProvided($row['price'])) {
             $price = is_numeric($row['price']) ? (float)$row['price'] : null;
             if ($price === null || $price < 0) {
-                throw new \Exception("Row {$rowIndex}: The price must be a positive number. Provided: {$row['price']}");
+                $violations[] = [
+                    'field' => 'price',
+                    'message' => "The price must be a positive number. Provided: {$row['price']}",
+                ];
             }
         }
 
-        // Validate price_per_meter (must be positive if provided)
+        // Validate price_per_meter (must be positive if provided) — hard-fail
         if (isset($row['price_per_meter']) && $this->valueProvided($row['price_per_meter'])) {
             $pricePerMeter = is_numeric($row['price_per_meter']) ? (float)$row['price_per_meter'] : null;
             if ($pricePerMeter === null || $pricePerMeter < 0) {
-                throw new \Exception("Row {$rowIndex}: The price_per_meter must be a positive number. Provided: {$row['price_per_meter']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The price_per_meter must be a positive number. Provided: {$row['price_per_meter']}",
+                    field: 'price_per_meter',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1572,15 +1639,22 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['area']) && $this->valueProvided($row['area'])) {
             $area = is_numeric($row['area']) ? (float)$row['area'] : null;
             if ($area === null || $area <= 0) {
-                throw new \Exception("Row {$rowIndex}: The area must be a positive number greater than 0. Provided: {$row['area']}");
+                $violations[] = [
+                    'field' => 'area',
+                    'message' => "The area must be a positive number greater than 0. Provided: {$row['area']}",
+                ];
             }
         }
 
-        // Validate size (must be positive if provided)
+        // Validate size (must be positive if provided) — hard-fail
         if (isset($row['size']) && $this->valueProvided($row['size'])) {
             $size = is_numeric($row['size']) ? (float)$row['size'] : null;
             if ($size === null || $size < 0) {
-                throw new \Exception("Row {$rowIndex}: The size must be a positive number. Provided: {$row['size']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The size must be a positive number. Provided: {$row['size']}",
+                    field: 'size',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1588,7 +1662,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['beds']) && $this->valueProvided($row['beds'])) {
             $beds = is_numeric($row['beds']) ? (int)$row['beds'] : null;
             if ($beds === null || $beds < 0 || $beds > 50) {
-                throw new \Exception("Row {$rowIndex}: The beds must be a non-negative integer between 0 and 50. Provided: {$row['beds']}");
+                $violations[] = [
+                    'field' => 'beds',
+                    'message' => "The beds must be a non-negative integer between 0 and 50. Provided: {$row['beds']}",
+                ];
             }
         }
 
@@ -1596,23 +1673,34 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['bath']) && $this->valueProvided($row['bath'])) {
             $bath = is_numeric($row['bath']) ? (int)$row['bath'] : null;
             if ($bath === null || $bath < 0 || $bath > 50) {
-                throw new \Exception("Row {$rowIndex}: The bath must be a non-negative integer between 0 and 50. Provided: {$row['bath']}");
+                $violations[] = [
+                    'field' => 'bath',
+                    'message' => "The bath must be a non-negative integer between 0 and 50. Provided: {$row['bath']}",
+                ];
             }
         }
 
-        // Validate latitude if provided
+        // Validate latitude if provided — hard-fail
         if (isset($row['latitude']) && $this->valueProvided($row['latitude'])) {
             $latitude = is_numeric($row['latitude']) ? (float)$row['latitude'] : null;
             if ($latitude === null || $latitude < -90 || $latitude > 90) {
-                throw new \Exception("Row {$rowIndex}: The latitude must be a number between -90 and 90. Provided: {$row['latitude']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The latitude must be a number between -90 and 90. Provided: {$row['latitude']}",
+                    field: 'latitude',
+                    row: $rowIndex
+                );
             }
         }
 
-        // Validate longitude if provided
+        // Validate longitude if provided — hard-fail
         if (isset($row['longitude']) && $this->valueProvided($row['longitude'])) {
             $longitude = is_numeric($row['longitude']) ? (float)$row['longitude'] : null;
             if ($longitude === null || $longitude < -180 || $longitude > 180) {
-                throw new \Exception("Row {$rowIndex}: The longitude must be a number between -180 and 180. Provided: {$row['longitude']}");
+                throw new RowValidationException(
+                    "Row {$rowIndex}: The longitude must be a number between -180 and 180. Provided: {$row['longitude']}",
+                    field: 'longitude',
+                    row: $rowIndex
+                );
             }
         }
 
@@ -1620,10 +1708,15 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['title']) && $this->valueProvided($row['title'])) {
             $titleLength = mb_strlen(trim($row['title']));
             if ($titleLength < 3) {
-                throw new \Exception("Row {$rowIndex}: The title must be at least 3 characters long. Provided length: {$titleLength}");
-            }
-            if ($titleLength > 255) {
-                throw new \Exception("Row {$rowIndex}: The title must not exceed 255 characters. Provided length: {$titleLength}");
+                $violations[] = [
+                    'field' => 'title',
+                    'message' => "The title must be at least 3 characters long. Provided length: {$titleLength}",
+                ];
+            } elseif ($titleLength > 255) {
+                $violations[] = [
+                    'field' => 'title',
+                    'message' => "The title must not exceed 255 characters. Provided length: {$titleLength}",
+                ];
             }
         }
 
@@ -1631,7 +1724,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['description']) && $this->valueProvided($row['description'])) {
             $descriptionLength = mb_strlen(trim($row['description']));
             if ($descriptionLength < 10) {
-                throw new \Exception("Row {$rowIndex}: The description must be at least 10 characters long. Provided length: {$descriptionLength}");
+                $violations[] = [
+                    'field' => 'description',
+                    'message' => "The description must be at least 10 characters long. Provided length: {$descriptionLength}",
+                ];
             }
         }
 
@@ -1639,10 +1735,15 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['address']) && $this->valueProvided($row['address'])) {
             $addressLength = mb_strlen(trim($row['address']));
             if ($addressLength < 5) {
-                throw new \Exception("Row {$rowIndex}: The address must be at least 5 characters long. Provided length: {$addressLength}");
-            }
-            if ($addressLength > 500) {
-                throw new \Exception("Row {$rowIndex}: The address must not exceed 500 characters. Provided length: {$addressLength}");
+                $violations[] = [
+                    'field' => 'address',
+                    'message' => "The address must be at least 5 characters long. Provided length: {$addressLength}",
+                ];
+            } elseif ($addressLength > 500) {
+                $violations[] = [
+                    'field' => 'address',
+                    'message' => "The address must not exceed 500 characters. Provided length: {$addressLength}",
+                ];
             }
         }
 
@@ -1650,7 +1751,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['purpose']) && $this->valueProvided($row['purpose'])) {
             $purpose = strtolower(trim($row['purpose']));
             if (!in_array($purpose, ['sale', 'rent'])) {
-                throw new \Exception("Row {$rowIndex}: The purpose must be either 'sale' or 'rent'. Provided: {$row['purpose']}");
+                $violations[] = [
+                    'field' => 'purpose',
+                    'message' => "The purpose must be either 'sale' or 'rent'. Provided: {$row['purpose']}",
+                ];
             }
         }
 
@@ -1658,8 +1762,90 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         if (isset($row['type']) && $this->valueProvided($row['type'])) {
             $type = strtolower(trim($row['type']));
             if (!in_array($type, ['residential', 'commercial'])) {
-                throw new \Exception("Row {$rowIndex}: The type must be either 'residential' or 'commercial'. Provided: {$row['type']}");
+                $violations[] = [
+                    'field' => 'type',
+                    'message' => "The type must be either 'residential' or 'commercial'. Provided: {$row['type']}",
+                ];
             }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Bulk-insert gallery slider images for a property (N+1 fix).
+     */
+    protected function bulkInsertGalleryImages(int $propertyId, array $galleryImages): void
+    {
+        $now = now();
+        $rows = [];
+        foreach ($galleryImages as $galleryUrl) {
+            if ($galleryUrl === null || $galleryUrl === '') {
+                continue;
+            }
+            $rows[] = [
+                'user_id' => $this->userId,
+                'property_id' => $propertyId,
+                'image' => $galleryUrl,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if (!empty($rows)) {
+            PropertySliderImg::insert($rows);
+        }
+    }
+
+    /**
+     * Bulk-insert amenity pivots for a property (N+1 fix).
+     * Inlined because PropertyAmenity::sotreAmenity only supports single create().
+     */
+    protected function bulkInsertAmenities(int $propertyId, array $amenityIds): void
+    {
+        $now = now();
+        $rows = [];
+        foreach ($amenityIds as $amenityId) {
+            if ($amenityId === null || $amenityId === '') {
+                continue;
+            }
+            $rows[] = [
+                'user_id' => $this->userId,
+                'property_id' => $propertyId,
+                'amenity_id' => $amenityId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if (!empty($rows)) {
+            PropertyAmenity::insert($rows);
+        }
+    }
+
+    /**
+     * Bulk-insert specifications for a property (N+1 fix).
+     */
+    protected function bulkInsertSpecifications(int $propertyId, array $specifications): void
+    {
+        $now = now();
+        $rows = [];
+        $specIndex = 0;
+        foreach ($specifications as $spec) {
+            if (!is_array($spec)) {
+                continue;
+            }
+            $rows[] = [
+                'user_id' => $this->userId,
+                'property_id' => $propertyId,
+                'language_id' => $this->defaultLanguageId,
+                'key' => $specIndex++,
+                'label' => $spec['label'] ?? $spec['key'] ?? '',
+                'value' => $spec['value'] ?? '',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if (!empty($rows)) {
+            PropertySpecification::insert($rows);
         }
     }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -13,6 +13,8 @@ use App\Models\User\RealestateManagement\PropertySpecification;
 use App\Models\User\RealestateManagement\UserPropertyCharacteristic;
 use App\Models\User\Language;
 use App\Models\User\UserDistrict;
+use App\Rules\PropertyTypeRule;
+use App\Support\PropertyCompletionRequirements;
 use App\Support\PropertyExcelMapping;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
@@ -192,6 +194,18 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         return false;
     }
     /**
+     * Drop the trailing " *" the blank template puts on required headings.
+     *
+     * With heading_row.formatter = slug this is already handled (Str::slug drops
+     * the asterisk), so this is a safety net for the exact-Arabic lookup path and
+     * for any future switch to formatter = none.
+     */
+    private static function stripRequiredMarker(string $header): string
+    {
+        return trim(preg_replace('/\s*\*\s*$/u', '', trim($header)));
+    }
+
+    /**
      * Normalize row keys: map Arabic / slugified Arabic headers to English, keep existing English keys.
      */
     private function normalizeRowKeys(array $row): array
@@ -200,7 +214,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         $out = [];
         foreach ($row as $header => $value) {
             $headerStr = is_string($header) ? $header : (string) $header;
-            $key = $map[$headerStr] ?? $headerStr;
+            $key = $map[$headerStr] ?? $map[self::stripRequiredMarker($headerStr)] ?? $headerStr;
             if ($this->valueProvided($value)) {
                 $out[$key] = $value;
             } elseif (!array_key_exists($key, $out)) {
@@ -339,39 +353,31 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         [$cityId, $stateId] = $this->resolveLocationIds($row, $rowIndex);
         
         // Track location resolution failures as validation errors for incomplete properties
-        // Location (city_id) is REQUIRED - if missing, property must be incomplete
-        // This check is done before validation_errors array is populated
+        // Location validation: only bad city names hard-fail; missing city or
+        // unresolvable district names are soft errors (validation_errors, not row-fail).
+        // This aligns with Decision B: empty city is OK for a complete property.
         $locationValidationErrors = [];
-        
-        // Check if city_id is missing (location is required)
-        if (!$cityId) {
-            $locationValidationErrors[] = "موقع المدينة مطلوب. يرجى تقديم معرف المدينة (city_id) أو اسم المدينة (city_name).";
-        }
-        
-        // Check if district was provided but couldn't be resolved (location validation error)
+
+        // Check if district was provided but couldn't be resolved (soft error)
         if ($this->valueProvided($row['district_name'] ?? null) && !$stateId && $cityId) {
             $locationValidationErrors[] = "District '{$row['district_name']}' not found in the specified city. Please verify the district name or use state_id.";
         }
 
-        // Validate featured image URL format
-        if (!empty($row['featured_image'])) {
+        // Image URL validation: soft-fail path. Invalid featured_image or
+        // gallery URLs are tracked as validation errors, not row failures.
+        // This allows incomplete properties to be created with the bad URLs for
+        // later user correction, matching soft-incomplete Decision B.
+        if ($this->valueProvided($row['featured_image'] ?? null)) {
             if (!$this->validateImageUrl($row['featured_image'])) {
-                throw new RowValidationException(
-                    "Row {$rowIndex}: Invalid featured_image URL format. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).",
-                    field: 'featured_image',
-                    row: $rowIndex
-                );
+                $validationErrors[] = "featured_image URL format is invalid: must be http/https with jpg, jpeg, png, gif, or webp extension";
             }
         }
 
-        // Validate gallery image URLs
         foreach ($galleryImages as $galleryUrl) {
             if (!$this->validateImageUrl($galleryUrl)) {
-                throw new RowValidationException(
-                    "Row {$rowIndex}: Invalid gallery image URL: {$galleryUrl}. URL must be http/https with valid image extension (jpg, jpeg, png, gif, webp).",
-                    field: 'gallery_images',
-                    row: $rowIndex
-                );
+                $validationErrors[] = "gallery_images contains invalid URL: {$galleryUrl} (must be http/https with jpg, jpeg, png, gif, or webp extension)";
+                // Only report once per row; don't error every URL in the list
+                break;
             }
         }
 
@@ -393,52 +399,61 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             );
         }
         
-        $requiredFields = [
-            'title' => ['min' => 3, 'max' => 255],
-            'price' => ['min' => 0],
-            'address' => ['min' => 5, 'max' => 500],
-            'description' => ['min' => 10],
-            'purpose' => ['values' => ['sale', 'rent']],
-            'type' => ['values' => ['residential', 'commercial']],
-            'area' => ['min' => 1],
-        ];
-        
-        foreach ($requiredFields as $field => $rules) {
-            $value = $row[$field] ?? null;
-            
-            // Check if field is missing or empty
-            if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
-                $missingFields[] = $field;
-                continue;
-            }
-            
-            // Validate field rules
-            if (isset($rules['min']) && isset($rules['max'])) {
-                $length = is_string($value) ? strlen($value) : $value;
-                if ($length < $rules['min'] || $length > $rules['max']) {
-                    $validationErrors[] = "{$field} must be between {$rules['min']} and {$rules['max']} characters";
-                }
-            } elseif (isset($rules['min'])) {
-                if (is_string($value)) {
-                    if (strlen($value) < $rules['min']) {
-                        $validationErrors[] = "{$field} must be at least {$rules['min']} characters";
-                    }
-                } elseif (is_numeric($value) && $value < $rules['min']) {
-                    $validationErrors[] = "{$field} must be at least {$rules['min']}";
-                }
-            } elseif (isset($rules['values'])) {
-                if (!in_array($value, $rules['values'])) {
-                    $validationErrors[] = "{$field} must be one of: " . implode(', ', $rules['values']);
-                }
+        // Completeness is the shared five-field definition: title, address,
+        // description, featured_image, property_type. Reported as canonical
+        // English keys (`property_type`, never the Excel alias `type`).
+        $missingFields = PropertyCompletionRequirements::missingFrom($row);
+
+        // Format checks run only on values that were actually supplied. A blank
+        // required field is already reported once in $missingFields and must not
+        // error twice; a blank price / purpose / area is simply absent, not invalid.
+        if ($this->valueProvided($row['title'] ?? null)) {
+            $length = mb_strlen((string) $row['title']);
+            if ($length < 3 || $length > 255) {
+                $validationErrors[] = "title must be between 3 and 255 characters";
             }
         }
-        
-        // Validate numeric fields
-        if (isset($row['price']) && !is_numeric($row['price'])) {
-            $validationErrors[] = "price must be a number";
+
+        if ($this->valueProvided($row['address'] ?? null)) {
+            $length = mb_strlen((string) $row['address']);
+            if ($length < 5 || $length > 500) {
+                $validationErrors[] = "address must be between 5 and 500 characters";
+            }
         }
-        if (isset($row['area']) && !is_numeric($row['area'])) {
-            $validationErrors[] = "area must be a number";
+
+        if ($this->valueProvided($row['description'] ?? null)
+            && mb_strlen((string) $row['description']) < 10) {
+            $validationErrors[] = "description must be at least 10 characters";
+        }
+
+        if ($this->valueProvided($row['price'] ?? null)) {
+            if (!is_numeric($row['price'])) {
+                $validationErrors[] = "price must be a number";
+            } elseif ($row['price'] < 0) {
+                $validationErrors[] = "price must be at least 0";
+            }
+        }
+
+        if ($this->valueProvided($row['area'] ?? null)) {
+            if (!is_numeric($row['area'])) {
+                $validationErrors[] = "area must be a number";
+            } elseif ($row['area'] < 1) {
+                $validationErrors[] = "area must be at least 1";
+            }
+        }
+
+        if ($this->valueProvided($row['purpose'] ?? null)
+            && !in_array($row['purpose'], ['sale', 'rent'], true)) {
+            $validationErrors[] = "purpose must be one of: sale, rent";
+        }
+
+        $rowType = $row['type'] ?? null;
+        if ($this->valueProvided($rowType)) {
+            $normalizedType = is_string($rowType) ? PropertyTypeRule::normalize($rowType) : null;
+            if ($normalizedType === null || !in_array($normalizedType, PropertyTypeRule::allowed(), true)) {
+                $validationErrors[] = 'property_type must be one of: '
+                    . implode(', ', PropertyTypeRule::allowed());
+            }
         }
 
         // Wrap entire row processing in transaction (create-only)
@@ -488,12 +503,14 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     $this->actorId
                 );
 
-                // Only create PropertyContent if title and address are provided
-                if (!empty($row['title']) && !empty($row['address'])) {
+                // Create PropertyContent when EITHER title or address is present.
+                // Requiring both left a title-only draft with no content row at
+                // all, so it showed up nameless in the drafts UI.
+                if ($this->valueProvided($row['title'] ?? null) || $this->valueProvided($row['address'] ?? null)) {
                     $contentData = [
                         'language_id'      => $this->defaultLanguageId,
-                        'title'            => $row['title'],
-                        'address'          => $row['address'],
+                        'title'            => $row['title'] ?? '',
+                        'address'          => $row['address'] ?? '',
                         'description'      => $row['description'] ?? '',
                         'meta_keyword'     => null,
                         'meta_description' => !empty($row['description']) ? Str::limit($row['description'], 150) : null,
@@ -525,15 +542,18 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 
                 $this->incompleteCount++;
             } else {
-                // All required fields present - create complete property
+                // All required fields present - create complete property.
+                // price / purpose / area are optional now, so every read must be
+                // null-safe: Property::storeProperty() indexes price and area
+                // directly and would fatal on an absent key.
                 $propertyData = [
-                    'price'           => $row['price'],
+                    'price'           => $row['price'] ?? null,
                     'pricePerMeter'   => $row['price_per_meter'] ?? null,
-                    'purpose'         => $row['purpose'],
-                    'type'            => $row['type'],
+                    'purpose'         => $row['purpose'] ?? null,
+                    'property_type'   => $row['type'] ?? null,
                     'beds'            => $row['beds'] ?? null,
                     'bath'            => $row['bath'] ?? null,
-                    'area'            => $row['area'],
+                    'area'            => $row['area'] ?? null,
                     'video_url'       => $row['video_url'] ?? null,
                     'status'          => $row['status'] ?? 1,
                     'latitude'        => null,
@@ -545,6 +565,9 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     'show_reservations' => true,
                     'payment_method'  => $this->mapPaymentMethod($row['payment_method'] ?? null),
                     'completion_status' => 'complete',
+                    // Was missing: complete rows were never tagged with their batch,
+                    // so the bulk-import report could not see them.
+                    'import_batch_id' => $this->importBatchId,
                 ];
 
                 // Images (Expect URLs)
@@ -572,7 +595,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                     'address'          => $row['address'],
                     'description'      => $row['description'],
                     'meta_keyword'     => null,
-                    'meta_description' => Str::limit($row['description'], 150),
+                    'meta_description' => Str::limit((string) $row['description'], 150),
                     'category_id'      => $property->category_id,
                     'city_id'          => $cityId,
                     'state_id'         => $stateId, // District ID from user_districts table
@@ -979,7 +1002,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             'address'     => 'nullable|string|max:500',
             'description' => 'nullable|string',
             'purpose'     => 'nullable|in:sale,rent',
-            'type'        => 'nullable|in:residential,commercial',
+            'type'        => 'nullable|in:residential,commercial,agricultural,industrial',
             'area'        => 'nullable|numeric|min:0',
             'size'        => 'nullable|numeric|min:0',
             'beds'        => 'nullable|integer|min:0|max:50',
@@ -988,7 +1011,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             'city_name'   => 'nullable|string|max:255',
             'district_name' => 'nullable|string|max:255',
             'country_name' => 'nullable|string|max:255',
-            'featured_image' => 'nullable|url|max:500',
+            'featured_image' => 'nullable|string|max:500',
             'video_url'   => 'nullable|url|max:500',
             'virtual_tour' => 'nullable|url|max:500',
             'gallery_images' => 'nullable|string',

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -27,7 +27,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rule;
 
 class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithValidation, SkipsOnFailure, SkipsOnError, WithLimit
 {
@@ -301,6 +300,9 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             throw new \Exception("Row {$rowIndex}: Invalid file format. This appears to be a raw export file. Please use the official Import Template or the 'Export for Import' feature to get a safe, re-importable file.");
         }
 
+        // Bulk import is create-only: ignore المعرّف / id (do not update existing rows).
+        unset($row['id']);
+
         // Parse new relational columns
         $galleryImages = $this->parseCommaSeparated($row['gallery_images'] ?? null);
         $amenityIds = $this->parseAmenities($row, $rowIndex);
@@ -334,27 +336,6 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             Log::warning("Row {$rowIndex}: Failed to parse amenity_ids", ['value' => $row['amenity_ids']]);
         }
 
-        // Check if this is an update (id column exists and has value)
-        $propertyId = isset($row['id']) && !empty($row['id']) ? (int)$row['id'] : null;
-        $isUpdate = false;
-        $existingProperty = null;
-
-        if ($propertyId) {
-            // Check if property exists and belongs to user
-            $existingProperty = Property::where('id', $propertyId)
-                ->where('user_id', $this->userId)
-                ->first();
-            
-            if ($existingProperty) {
-                $isUpdate = true;
-            } else {
-                // ID provided but property doesn't exist or doesn't belong to user
-                // Log warning and create new property instead
-                Log::warning("Row {$rowIndex}: Property ID {$propertyId} not found or doesn't belong to user. Creating new property.");
-                $propertyId = null;
-            }
-        }
-
         [$cityId, $stateId] = $this->resolveLocationIds($row, $rowIndex);
         
         // Track location resolution failures as validation errors for incomplete properties
@@ -363,7 +344,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         $locationValidationErrors = [];
         
         // Check if city_id is missing (location is required)
-        if (!$cityId && !$isUpdate) {
+        if (!$cityId) {
             $locationValidationErrors[] = "موقع المدينة مطلوب. يرجى تقديم معرف المدينة (city_id) أو اسم المدينة (city_name).";
         }
         
@@ -394,329 +375,230 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             }
         }
 
-        // Business rule validation (after determining if it's an update)
-        $businessViolations = $this->validateBusinessRules($row, $rowIndex, $isUpdate);
+        // Business rule validation (create-only import)
+        $businessViolations = $this->validateBusinessRules($row, $rowIndex, false);
 
-        // Check for missing required fields (only for new properties, not updates)
+        // Check for missing required fields
         $missingFields = [];
         $validationErrors = [];
         
         // Add location validation errors
         $validationErrors = array_merge($validationErrors, $locationValidationErrors);
 
-        // Soft-fail business rules for creates; hard-fail for updates
-        if ($isUpdate && !empty($businessViolations)) {
-            $first = $businessViolations[0];
-            throw new RowValidationException(
-                "Row {$rowIndex}: {$first['message']}",
-                field: $first['field'],
-                row: $rowIndex
-            );
-        }
-        if (!$isUpdate && !empty($businessViolations)) {
+        // Soft-fail business rules for creates
+        if (!empty($businessViolations)) {
             $validationErrors = array_merge(
                 $validationErrors,
                 array_column($businessViolations, 'message')
             );
         }
         
-        if (!$isUpdate) {
-            $requiredFields = [
-                'title' => ['min' => 3, 'max' => 255],
-                'price' => ['min' => 0],
-                'address' => ['min' => 5, 'max' => 500],
-                'description' => ['min' => 10],
-                'purpose' => ['values' => ['sale', 'rent']],
-                'type' => ['values' => ['residential', 'commercial']],
-                'area' => ['min' => 1],
-            ];
+        $requiredFields = [
+            'title' => ['min' => 3, 'max' => 255],
+            'price' => ['min' => 0],
+            'address' => ['min' => 5, 'max' => 500],
+            'description' => ['min' => 10],
+            'purpose' => ['values' => ['sale', 'rent']],
+            'type' => ['values' => ['residential', 'commercial']],
+            'area' => ['min' => 1],
+        ];
+        
+        foreach ($requiredFields as $field => $rules) {
+            $value = $row[$field] ?? null;
             
-            foreach ($requiredFields as $field => $rules) {
-                $value = $row[$field] ?? null;
-                
-                // Check if field is missing or empty
-                if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
-                    $missingFields[] = $field;
-                    continue;
-                }
-                
-                // Validate field rules
-                if (isset($rules['min']) && isset($rules['max'])) {
-                    $length = is_string($value) ? strlen($value) : $value;
-                    if ($length < $rules['min'] || $length > $rules['max']) {
-                        $validationErrors[] = "{$field} must be between {$rules['min']} and {$rules['max']} characters";
-                    }
-                } elseif (isset($rules['min'])) {
-                    if (is_string($value)) {
-                        if (strlen($value) < $rules['min']) {
-                            $validationErrors[] = "{$field} must be at least {$rules['min']} characters";
-                        }
-                    } elseif (is_numeric($value) && $value < $rules['min']) {
-                        $validationErrors[] = "{$field} must be at least {$rules['min']}";
-                    }
-                } elseif (isset($rules['values'])) {
-                    if (!in_array($value, $rules['values'])) {
-                        $validationErrors[] = "{$field} must be one of: " . implode(', ', $rules['values']);
-                    }
-                }
+            // Check if field is missing or empty
+            if (is_null($value) || (is_string($value) && trim($value) === '') || $value === '') {
+                $missingFields[] = $field;
+                continue;
             }
             
-            // Validate numeric fields
-            if (isset($row['price']) && !is_numeric($row['price'])) {
-                $validationErrors[] = "price must be a number";
-            }
-            if (isset($row['area']) && !is_numeric($row['area'])) {
-                $validationErrors[] = "area must be a number";
+            // Validate field rules
+            if (isset($rules['min']) && isset($rules['max'])) {
+                $length = is_string($value) ? strlen($value) : $value;
+                if ($length < $rules['min'] || $length > $rules['max']) {
+                    $validationErrors[] = "{$field} must be between {$rules['min']} and {$rules['max']} characters";
+                }
+            } elseif (isset($rules['min'])) {
+                if (is_string($value)) {
+                    if (strlen($value) < $rules['min']) {
+                        $validationErrors[] = "{$field} must be at least {$rules['min']} characters";
+                    }
+                } elseif (is_numeric($value) && $value < $rules['min']) {
+                    $validationErrors[] = "{$field} must be at least {$rules['min']}";
+                }
+            } elseif (isset($rules['values'])) {
+                if (!in_array($value, $rules['values'])) {
+                    $validationErrors[] = "{$field} must be one of: " . implode(', ', $rules['values']);
+                }
             }
         }
+        
+        // Validate numeric fields
+        if (isset($row['price']) && !is_numeric($row['price'])) {
+            $validationErrors[] = "price must be a number";
+        }
+        if (isset($row['area']) && !is_numeric($row['area'])) {
+            $validationErrors[] = "area must be a number";
+        }
 
-        // Wrap entire row processing in transaction
-        DB::transaction(function () use ($row, $rowIndex, $galleryImages, $amenityIds, $specifications, $cityId, $stateId, $features, $featured, $isUpdate, $existingProperty, $propertyId, $missingFields, $validationErrors) {
-            if ($isUpdate && $existingProperty) {
-                // UPDATE EXISTING PROPERTY
-                $property = $existingProperty;
+        // Wrap entire row processing in transaction (create-only)
+        DB::transaction(function () use ($row, $rowIndex, $galleryImages, $amenityIds, $specifications, $cityId, $stateId, $features, $featured, $missingFields, $validationErrors) {
+            // CREATE NEW PROPERTY
+            
+            // Check if this is an incomplete property (missing required fields)
+            if (!empty($missingFields) || !empty($validationErrors)) {
+                // Create incomplete property with partial data
+                $propertyData = [
+                    'price'           => $row['price'] ?? null,
+                    'pricePerMeter'   => $row['price_per_meter'] ?? null,
+                    'purpose'         => $row['purpose'] ?? null,
+                    'property_type'   => $row['type'] ?? null,
+                    'beds'            => $row['beds'] ?? null,
+                    'bath'            => $row['bath'] ?? null,
+                    'area'            => $row['area'] ?? null,
+                    'video_url'       => $row['video_url'] ?? null,
+                    'status'          => 0, // Hidden
+                    'latitude'        => null,
+                    'longitude'       => null,
+                    'features'        => $features,
+                    'region_id'       => null,
+                    'city_id'         => $cityId,
+                    'category_id'     => null,
+                    'show_reservations' => true,
+                    'payment_method'  => $this->mapPaymentMethod($row['payment_method'] ?? null),
+                    'completion_status' => 'incomplete',
+                    'missing_fields'  => $missingFields,
+                    'validation_errors' => $validationErrors,
+                    'import_batch_id' => $this->importBatchId,
+                ];
 
-                // Prepare update data (only include fields that are present in the row)
-                $propertyData = [];
-                if (isset($row['price'])) $propertyData['price'] = $row['price'];
-                if (isset($row['price_per_meter'])) $propertyData['pricePerMeter'] = $row['price_per_meter'];
-                if (isset($row['purpose'])) $propertyData['purpose'] = $row['purpose'];
-                if (isset($row['type'])) $propertyData['property_type'] = $row['type'];
-                if (isset($row['beds'])) $propertyData['beds'] = $row['beds'];
-                if (isset($row['bath'])) $propertyData['bath'] = $row['bath'];
-                if (isset($row['area'])) $propertyData['area'] = $row['area'];
-                if (isset($row['video_url'])) $propertyData['video_url'] = $row['video_url'];
-                if (isset($row['virtual_tour'])) $propertyData['virtual_tour'] = $row['virtual_tour'];
-                if (isset($row['status'])) $propertyData['status'] = $row['status'];
-                if (isset($row['features'])) $propertyData['features'] = $features;
-                if (isset($row['payment_method'])) $propertyData['payment_method'] = $this->mapPaymentMethod($row['payment_method']);
-                if (isset($row['water_meter_number'])) $propertyData['water_meter_number'] = $row['water_meter_number'];
-                if (isset($row['electricity_meter_number'])) $propertyData['electricity_meter_number'] = $row['electricity_meter_number'];
-                if (isset($row['deed_number'])) $propertyData['deed_number'] = $row['deed_number'];
-                if (isset($row['show_reservations'])) $propertyData['show_reservations'] = strtolower($row['show_reservations']) === '1' || strtolower($row['show_reservations']) === 'yes';
-                $propertyData['featured'] = $featured;
+                // Images (Expect URLs)
+                $featuredImage = $row['featured_image'] ?? null;
+                $videoImage    = null;
+                $floorPlans    = null;
 
-                // Update featured image if provided
-                if (isset($row['featured_image']) && !empty($row['featured_image'])) {
-                    $propertyData['featured_image'] = $row['featured_image'];
-                }
+                // Create incomplete Property
+                $property = Property::storeProperty(
+                    $this->userId,
+                    $propertyData,
+                    $featuredImage,
+                    $floorPlans,
+                    $videoImage,
+                    $featured,
+                    $this->actorId
+                );
 
-                // Update property
-                $property->updateProperty($propertyData);
-
-                // Update Property Content
-                // Capture the existing content BEFORE it's deleted below, so fields not
-                // present in this import row (e.g. meta_keyword/meta_description, which
-                // the import template never carries) are preserved instead of wiped.
-                $existingContent = PropertyContent::where('property_id', $property->id)->first();
-
-                $contentData = [];
-                if (isset($row['title'])) $contentData['title'] = $row['title'];
-                if (isset($row['address'])) $contentData['address'] = $row['address'];
-                if (isset($row['description'])) {
-                    $contentData['description'] = $row['description'];
-                    $contentData['meta_description'] = Str::limit($row['description'], 150);
-                }
-                if ($cityId) $contentData['city_id'] = $cityId;
-                if ($stateId) $contentData['state_id'] = $stateId;
-
-                // Delete existing content and create new (same as API update method)
-                PropertyContent::where('property_id', $property->id)->delete();
-                if (!empty($contentData) || $cityId || $stateId) {
-                    $contentData['language_id'] = $this->defaultLanguageId;
-                    $contentData['category_id'] = $property->category_id;
-                    $contentData['title'] ??= $existingContent->title ?? '';
-                    $contentData['address'] ??= $existingContent->address ?? '';
-                    $contentData['description'] ??= $existingContent->description ?? '';
-                    $contentData['meta_keyword'] ??= $existingContent->meta_keyword ?? null;
-                    $contentData['meta_description'] ??= $existingContent->meta_description ?? null;
-                    $contentData['city_id'] ??= $existingContent->city_id ?? null;
-                    $contentData['state_id'] ??= $existingContent->state_id ?? null;
-                    PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
-                }
-
-                // Replace gallery images (delete existing, add new)
-                if (isset($row['gallery_images'])) {
-                    PropertySliderImg::where('property_id', $property->id)->delete();
-                    if (is_array($galleryImages) && !empty($galleryImages)) {
-                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
-                    }
-                }
-
-                // Replace amenities (delete existing, add new)
-                PropertyAmenity::where('property_id', $property->id)->delete();
-                if (!empty($amenityIds)) {
-                    $this->bulkInsertAmenities($property->id, $amenityIds);
-                }
-
-                // Replace specifications (delete existing, add new)
-                PropertySpecification::where('property_id', $property->id)->delete();
-                if (is_array($specifications) && !empty($specifications)) {
-                    $this->bulkInsertSpecifications($property->id, $specifications);
-                }
-
-                // Update characteristics if provided
-                $this->updateCharacteristics($property, $row, $rowIndex);
-
-                $this->updatedCount++;
-            } else {
-                // CREATE NEW PROPERTY
-                
-                // Check if this is an incomplete property (missing required fields)
-                if (!empty($missingFields) || !empty($validationErrors)) {
-                    // Create incomplete property with partial data
-                    $propertyData = [
-                        'price'           => $row['price'] ?? null,
-                        'pricePerMeter'   => $row['price_per_meter'] ?? null,
-                        'purpose'         => $row['purpose'] ?? null,
-                        'property_type'   => $row['type'] ?? null,
-                        'beds'            => $row['beds'] ?? null,
-                        'bath'            => $row['bath'] ?? null,
-                        'area'            => $row['area'] ?? null,
-                        'video_url'       => $row['video_url'] ?? null,
-                        'status'          => 0, // Hidden
-                        'latitude'        => null,
-                        'longitude'       => null,
-                        'features'        => $features,
-                        'region_id'       => null,
-                        'city_id'         => $cityId,
-                        'category_id'     => null,
-                        'show_reservations' => true,
-                        'payment_method'  => $this->mapPaymentMethod($row['payment_method'] ?? null),
-                        'completion_status' => 'incomplete',
-                        'missing_fields'  => $missingFields,
-                        'validation_errors' => $validationErrors,
-                        'import_batch_id' => $this->importBatchId,
-                    ];
-
-                    // Images (Expect URLs)
-                    $featuredImage = $row['featured_image'] ?? null;
-                    $videoImage    = null;
-                    $floorPlans    = null;
-
-                    // Create incomplete Property
-                    $property = Property::storeProperty(
-                        $this->userId,
-                        $propertyData,
-                        $featuredImage,
-                        $floorPlans,
-                        $videoImage,
-                        $featured,
-                        $this->actorId
-                    );
-
-                    // Only create PropertyContent if title and address are provided
-                    if (!empty($row['title']) && !empty($row['address'])) {
-                        $contentData = [
-                            'language_id'      => $this->defaultLanguageId,
-                            'title'            => $row['title'],
-                            'address'          => $row['address'],
-                            'description'      => $row['description'] ?? '',
-                            'meta_keyword'     => null,
-                            'meta_description' => !empty($row['description']) ? Str::limit($row['description'], 150) : null,
-                            'category_id'      => $property->category_id,
-                            'city_id'          => $cityId,
-                            'state_id'         => $stateId,
-                        ];
-
-                        PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
-                    }
-
-                    // Process gallery images if provided
-                    if (is_array($galleryImages) && !empty($galleryImages)) {
-                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
-                    }
-
-                    // Process amenities if provided
-                    if (!empty($amenityIds) && is_array($amenityIds)) {
-                        $this->bulkInsertAmenities($property->id, $amenityIds);
-                    }
-
-                    // Process specifications if provided
-                    if (is_array($specifications) && !empty($specifications)) {
-                        $this->bulkInsertSpecifications($property->id, $specifications);
-                    }
-
-                    // Create characteristics if provided
-                    $this->updateCharacteristics($property, $row, $rowIndex);
-                    
-                    $this->incompleteCount++;
-                } else {
-                    // All required fields present - create complete property
-                    $propertyData = [
-                        'price'           => $row['price'],
-                        'pricePerMeter'   => $row['price_per_meter'] ?? null,
-                        'purpose'         => $row['purpose'],
-                        'type'            => $row['type'],
-                        'beds'            => $row['beds'] ?? null,
-                        'bath'            => $row['bath'] ?? null,
-                        'area'            => $row['area'],
-                        'video_url'       => $row['video_url'] ?? null,
-                        'status'          => $row['status'] ?? 1,
-                        'latitude'        => null,
-                        'longitude'       => null,
-                        'features'        => $features,
-                        'region_id'       => null, // Region is automatically set to السعودية
-                        'city_id'         => $cityId,
-                        'category_id'     => null,
-                        'show_reservations' => true,
-                        'payment_method'  => $this->mapPaymentMethod($row['payment_method'] ?? null),
-                        'completion_status' => 'complete',
-                    ];
-
-                    // Images (Expect URLs)
-                    $featuredImage = $row['featured_image'] ?? null;
-                    $videoImage    = null;
-                    $floorPlans    = null;
-                    // $featured is now set above based on row data
-
-                    // Create Property
-                    $property = Property::storeProperty(
-                        $this->userId,
-                        $propertyData,
-                        $featuredImage,
-                        $floorPlans,
-                        $videoImage,
-                        $featured,
-                        $this->actorId
-                    );
-
-                    // Create Property Content (Title, Description, Address)
-                    // Note: slug is auto-generated by PropertyContent::storePropertyContent
+                // Only create PropertyContent if title and address are provided
+                if (!empty($row['title']) && !empty($row['address'])) {
                     $contentData = [
                         'language_id'      => $this->defaultLanguageId,
                         'title'            => $row['title'],
                         'address'          => $row['address'],
-                        'description'      => $row['description'],
+                        'description'      => $row['description'] ?? '',
                         'meta_keyword'     => null,
-                        'meta_description' => Str::limit($row['description'], 150),
+                        'meta_description' => !empty($row['description']) ? Str::limit($row['description'], 150) : null,
                         'category_id'      => $property->category_id,
                         'city_id'          => $cityId,
-                        'state_id'         => $stateId, // District ID from user_districts table
+                        'state_id'         => $stateId,
                     ];
 
                     PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
-
-                    // Process gallery images
-                    if (is_array($galleryImages) && !empty($galleryImages)) {
-                        $this->bulkInsertGalleryImages($property->id, $galleryImages);
-                    }
-
-                    // Process amenities (no validation - same as API store method)
-                    if (!empty($amenityIds) && is_array($amenityIds)) {
-                        $this->bulkInsertAmenities($property->id, $amenityIds);
-                    }
-
-                    // Process specifications (use integer keys matching API behavior)
-                    if (is_array($specifications) && !empty($specifications)) {
-                        $this->bulkInsertSpecifications($property->id, $specifications);
-                    }
-
-                    // Create characteristics if provided
-                    $this->updateCharacteristics($property, $row, $rowIndex);
-                    
-                    $this->importedCount++;
                 }
+
+                // Process gallery images if provided
+                if (is_array($galleryImages) && !empty($galleryImages)) {
+                    $this->bulkInsertGalleryImages($property->id, $galleryImages);
+                }
+
+                // Process amenities if provided
+                if (!empty($amenityIds) && is_array($amenityIds)) {
+                    $this->bulkInsertAmenities($property->id, $amenityIds);
+                }
+
+                // Process specifications if provided
+                if (is_array($specifications) && !empty($specifications)) {
+                    $this->bulkInsertSpecifications($property->id, $specifications);
+                }
+
+                // Create characteristics if provided
+                $this->updateCharacteristics($property, $row, $rowIndex);
+                
+                $this->incompleteCount++;
+            } else {
+                // All required fields present - create complete property
+                $propertyData = [
+                    'price'           => $row['price'],
+                    'pricePerMeter'   => $row['price_per_meter'] ?? null,
+                    'purpose'         => $row['purpose'],
+                    'type'            => $row['type'],
+                    'beds'            => $row['beds'] ?? null,
+                    'bath'            => $row['bath'] ?? null,
+                    'area'            => $row['area'],
+                    'video_url'       => $row['video_url'] ?? null,
+                    'status'          => $row['status'] ?? 1,
+                    'latitude'        => null,
+                    'longitude'       => null,
+                    'features'        => $features,
+                    'region_id'       => null, // Region is automatically set to السعودية
+                    'city_id'         => $cityId,
+                    'category_id'     => null,
+                    'show_reservations' => true,
+                    'payment_method'  => $this->mapPaymentMethod($row['payment_method'] ?? null),
+                    'completion_status' => 'complete',
+                ];
+
+                // Images (Expect URLs)
+                $featuredImage = $row['featured_image'] ?? null;
+                $videoImage    = null;
+                $floorPlans    = null;
+                // $featured is now set above based on row data
+
+                // Create Property
+                $property = Property::storeProperty(
+                    $this->userId,
+                    $propertyData,
+                    $featuredImage,
+                    $floorPlans,
+                    $videoImage,
+                    $featured,
+                    $this->actorId
+                );
+
+                // Create Property Content (Title, Description, Address)
+                // Note: slug is auto-generated by PropertyContent::storePropertyContent
+                $contentData = [
+                    'language_id'      => $this->defaultLanguageId,
+                    'title'            => $row['title'],
+                    'address'          => $row['address'],
+                    'description'      => $row['description'],
+                    'meta_keyword'     => null,
+                    'meta_description' => Str::limit($row['description'], 150),
+                    'category_id'      => $property->category_id,
+                    'city_id'          => $cityId,
+                    'state_id'         => $stateId, // District ID from user_districts table
+                ];
+
+                PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
+
+                // Process gallery images
+                if (is_array($galleryImages) && !empty($galleryImages)) {
+                    $this->bulkInsertGalleryImages($property->id, $galleryImages);
+                }
+
+                // Process amenities (no validation - same as API store method)
+                if (!empty($amenityIds) && is_array($amenityIds)) {
+                    $this->bulkInsertAmenities($property->id, $amenityIds);
+                }
+
+                // Process specifications (use integer keys matching API behavior)
+                if (is_array($specifications) && !empty($specifications)) {
+                    $this->bulkInsertSpecifications($property->id, $specifications);
+                }
+
+                // Create characteristics if provided
+                $this->updateCharacteristics($property, $row, $rowIndex);
+                
+                $this->importedCount++;
             }
         });
     }
@@ -1091,11 +973,6 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         // Note: Fields are intentionally NOT required here to allow incomplete properties
         // Custom validation in onRow() determines completeness and creates incomplete properties if needed
         return [
-            'id' => [
-                'nullable',
-                'integer',
-                Rule::exists('user_properties', 'id')->where('user_id', $this->userId),
-            ],
             'title'       => 'nullable|string|max:255',
             'price'       => 'nullable|numeric|min:0',
             'price_per_meter' => 'nullable|numeric|min:0',
@@ -1212,6 +1089,9 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             unset($data['id']);
             $data['_raw_export'] = '1';
         }
+
+        // Bulk import is create-only: ignore المعرّف / id even on import-safe files.
+        unset($data['id']);
 
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -14,6 +14,7 @@ use App\Models\User\RealestateManagement\UserPropertyCharacteristic;
 use App\Models\User\Language;
 use App\Models\User\UserDistrict;
 use App\Rules\PropertyTypeRule;
+use App\Services\PropertyConflictDetectionService;
 use App\Support\PropertyCompletionRequirements;
 use App\Support\PropertyExcelMapping;
 use Maatwebsite\Excel\Concerns\OnEachRow;
@@ -432,6 +433,25 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             if ($normalizedType === null || !in_array($normalizedType, PropertyTypeRule::allowed(), true)) {
                 $validationErrors[] = 'property_type must be one of: '
                     . implode(', ', PropertyTypeRule::allowed());
+            }
+        }
+
+        // Exact five-field duplicate check only for rows that would land complete.
+        // Use onError (SkipsErrors) — do NOT throw from onRow (aborts whole import).
+        if (empty($missingFields) && empty($validationErrors)) {
+            $dup = app(PropertyConflictDetectionService::class)->findExactCompletionDuplicate(
+                (int) $this->userId,
+                array_merge($row, ['property_type' => $row['type'] ?? $row['property_type'] ?? null]),
+                null,
+                $this->defaultLanguageId
+            );
+            if ($dup) {
+                $this->onError(new RowValidationException(
+                    "Row {$rowIndex}: A property with the same title, address, description, featured image, and property type already exists",
+                    field: 'completion_identity',
+                    row: $rowIndex
+                ));
+                return;
             }
         }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -505,6 +505,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 $property->updateProperty($propertyData);
 
                 // Update Property Content
+                // Capture the existing content BEFORE it's deleted below, so fields not
+                // present in this import row (e.g. meta_keyword/meta_description, which
+                // the import template never carries) are preserved instead of wiped.
+                $existingContent = PropertyContent::where('property_id', $property->id)->first();
+
                 $contentData = [];
                 if (isset($row['title'])) $contentData['title'] = $row['title'];
                 if (isset($row['address'])) $contentData['address'] = $row['address'];
@@ -520,6 +525,13 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
                 if (!empty($contentData) || $cityId || $stateId) {
                     $contentData['language_id'] = $this->defaultLanguageId;
                     $contentData['category_id'] = $property->category_id;
+                    $contentData['title'] ??= $existingContent->title ?? '';
+                    $contentData['address'] ??= $existingContent->address ?? '';
+                    $contentData['description'] ??= $existingContent->description ?? '';
+                    $contentData['meta_keyword'] ??= $existingContent->meta_keyword ?? null;
+                    $contentData['meta_description'] ??= $existingContent->meta_description ?? null;
+                    $contentData['city_id'] ??= $existingContent->city_id ?? null;
+                    $contentData['state_id'] ??= $existingContent->state_id ?? null;
                     PropertyContent::storePropertyContent($this->userId, $property->id, $contentData);
                 }
 

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -1137,6 +1137,10 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             }
         }
 
+        if (array_key_exists('unit_number', $data) && $data['unit_number'] !== null && $data['unit_number'] !== '') {
+            $data['unit_number'] = (string) $data['unit_number'];
+        }
+
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {
             return !is_null($value) && $value !== '';

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -173,9 +173,50 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         foreach ($row as $header => $value) {
             $headerStr = is_string($header) ? $header : (string) $header;
             $key = $map[$headerStr] ?? $headerStr;
-            $out[$key] = $value;
+            if ($this->valueProvided($value)) {
+                $out[$key] = $value;
+            } elseif (!array_key_exists($key, $out)) {
+                $out[$key] = $value;
+            }
         }
         return $out;
+    }
+
+    /**
+     * Excel often stores 0/1 and numeric unit numbers as integers; Laravel string rules reject them.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function castStringFieldsForValidation(array $data): array
+    {
+        $stringFields = [
+            'amenity_مصعد',
+            'amenity_أمن',
+            'amenity_كاميرات_مراقبة',
+            'amenity_تكييف_مركزي',
+            'amenity_تدفئة_مركزية',
+            'amenity_صيانة',
+            'amenity_بواب',
+            'amenity_إنترنت',
+            'unit_number',
+            'view_type',
+            'furnished',
+            'balcony',
+            'maid_room',
+            'storage_room',
+            'swimming_pool',
+            'gym',
+            'featured',
+        ];
+
+        foreach ($stringFields as $field) {
+            if (array_key_exists($field, $data) && $data[$field] !== null && $data[$field] !== '') {
+                $data[$field] = (string) $data[$field];
+            }
+        }
+
+        return $data;
     }
 
     public function onRow(Row $row)
@@ -1137,9 +1178,7 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             }
         }
 
-        if (array_key_exists('unit_number', $data) && $data['unit_number'] !== null && $data['unit_number'] !== '') {
-            $data['unit_number'] = (string) $data['unit_number'];
-        }
+        $data = $this->castStringFieldsForValidation($data);
 
         // Check if row is completely empty (all values are null or empty)
         $hasData = !empty(array_filter($data, function ($value) {

--- a/app/Imports/PropertiesSingleSheetImport.php
+++ b/app/Imports/PropertiesSingleSheetImport.php
@@ -176,19 +176,27 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
     /**
      * Detect PropertiesExport (raw) rows that must not be imported.
      *
+     * Option A: only reject when export-only metadata columns carry VALUES.
+     * Template / ImportReady / new clean exports (template columns only, or
+     * empty metadata headers) must pass. Legacy raw exports with user_id,
+     * created_at, etc. filled in are rejected with a clear message.
+     *
+     * المعرّف / id alone is ignored (create-only) and does not mark raw export.
+     *
      * @param  array<string, mixed>  $row
      */
     private function isRawExportRow(array $row): bool
     {
-        if (array_key_exists('id', $row) && array_key_exists('created_at', $row) && array_key_exists('user_id', $row)) {
-            return true;
-        }
-
         $exportOnlyColumns = ['slug', 'user_id', 'user_name', 'created_by', 'creator_name', 'created_at', 'updated_at'];
         foreach ($exportOnlyColumns as $col) {
             if (array_key_exists($col, $row) && $this->valueProvided($row[$col])) {
                 return true;
             }
+        }
+
+        // Old comma-separated amenities column without individual amenity_* flags
+        if ($this->valueProvided($row['amenities'] ?? null) && !isset($row['amenity_مصعد'])) {
+            return true;
         }
 
         return false;
@@ -290,27 +298,11 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
             return;
         }
 
-        // SAFETY CHECK: Reject raw exports
-        // Raw exports contain 'user_id' and 'created_at' which are not in the official template.
-        if (isset($row['id']) && isset($row['created_at']) && isset($row['user_id'])) {
-             throw new \Exception("Row {$rowIndex}: Invalid file format. It appears you are trying to import a raw Export file which is not supported. Please copy your data into the official Import Template.");
-        }
-
-        // SAFETY CHECK: Detect raw export files (not import-safe)
-        // Export-only columns that should NOT be in import templates:
-        $exportOnlyColumns = ['slug', 'user_id', 'user_name', 'created_by', 'creator_name', 'created_at', 'updated_at'];
-        $hasExportOnlyColumn = false;
-        foreach ($exportOnlyColumns as $col) {
-            if (isset($row[$col]) && $this->valueProvided($row[$col])) {
-                $hasExportOnlyColumn = true;
-                break;
-            }
-        }
-
-        // Also check if they're using the old 'amenities' comma-separated column (should use individual amenity_* columns)
-        $hasOldAmenitiesFormat = isset($row['amenities']) && $this->valueProvided($row['amenities']) && !isset($row['amenity_مصعد']);
-
-        if ($hasExportOnlyColumn || $hasOldAmenitiesFormat) {
+        // SAFETY CHECK: Reject raw exports only when metadata columns have values
+        // (see isRawExportRow). Clean template / ImportReady files must pass.
+        // Prefer validation (_raw_export) when WithValidation runs first; this is
+        // a belt-and-suspenders path if onRow sees the row anyway.
+        if ($this->isRawExportRow($row)) {
             throw new \Exception("Row {$rowIndex}: Invalid file format. This appears to be a raw export file. Please use the official Import Template or the 'Export for Import' feature to get a safe, re-importable file.");
         }
 
@@ -351,22 +343,19 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         }
 
         [$cityId, $stateId] = $this->resolveLocationIds($row, $rowIndex);
-        
-        // Track location resolution failures as validation errors for incomplete properties
-        // Location validation: only bad city names hard-fail; missing city or
-        // unresolvable district names are soft errors (validation_errors, not row-fail).
-        // This aligns with Decision B: empty city is OK for a complete property.
-        $locationValidationErrors = [];
 
-        // Check if district was provided but couldn't be resolved (soft error)
+        // Soft validation_errors (Decision B): missing requireds + format issues
+        // create an incomplete draft; only bad city / raw-export hard-fail the row.
+        $missingFields = [];
+        $validationErrors = [];
+
+        // Location: empty city is OK for complete; unresolvable district is soft.
         if ($this->valueProvided($row['district_name'] ?? null) && !$stateId && $cityId) {
-            $locationValidationErrors[] = "District '{$row['district_name']}' not found in the specified city. Please verify the district name or use state_id.";
+            $validationErrors[] = "District '{$row['district_name']}' not found in the specified city. Please verify the district name or use state_id.";
         }
 
-        // Image URL validation: soft-fail path. Invalid featured_image or
-        // gallery URLs are tracked as validation errors, not row failures.
-        // This allows incomplete properties to be created with the bad URLs for
-        // later user correction, matching soft-incomplete Decision B.
+        // Image URL validation: soft-fail. Invalid featured_image / gallery URLs
+        // go into validation_errors → incomplete draft (not a hard row failure).
         if ($this->valueProvided($row['featured_image'] ?? null)) {
             if (!$this->validateImageUrl($row['featured_image'])) {
                 $validationErrors[] = "featured_image URL format is invalid: must be http/https with jpg, jpeg, png, gif, or webp extension";
@@ -376,22 +365,12 @@ class PropertiesSingleSheetImport implements OnEachRow, WithHeadingRow, WithVali
         foreach ($galleryImages as $galleryUrl) {
             if (!$this->validateImageUrl($galleryUrl)) {
                 $validationErrors[] = "gallery_images contains invalid URL: {$galleryUrl} (must be http/https with jpg, jpeg, png, gif, or webp extension)";
-                // Only report once per row; don't error every URL in the list
                 break;
             }
         }
 
-        // Business rule validation (create-only import)
-        $businessViolations = $this->validateBusinessRules($row, $rowIndex, false);
-
-        // Check for missing required fields
-        $missingFields = [];
-        $validationErrors = [];
-        
-        // Add location validation errors
-        $validationErrors = array_merge($validationErrors, $locationValidationErrors);
-
         // Soft-fail business rules for creates
+        $businessViolations = $this->validateBusinessRules($row, $rowIndex, false);
         if (!empty($businessViolations)) {
             $validationErrors = array_merge(
                 $validationErrors,

--- a/app/Models/Api/UserPropertyRequest.php
+++ b/app/Models/Api/UserPropertyRequest.php
@@ -82,6 +82,7 @@ class UserPropertyRequest extends Model
         'customers_hub_stage_id',
         'property_ids',
         'initial_property_id',
+        'project_id',
         'responsible_employee_id',
         'inquiry_type',
         'currency',
@@ -158,6 +159,11 @@ class UserPropertyRequest extends Model
     public function initialProperty()
     {
         return $this->belongsTo(\App\Models\User\RealestateManagement\Property::class, 'initial_property_id');
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(\App\Models\User\RealestateManagement\Project::class, 'project_id');
     }
 
     /**

--- a/app/Models/User/RealestateManagement/City.php
+++ b/app/Models/User/RealestateManagement/City.php
@@ -13,7 +13,6 @@ class City extends Model
     public $table = "user_cities";
 
     protected $fillable = [
-        'user_id',
         'language_id',
         'country_id',
         'state_id',
@@ -30,32 +29,6 @@ class City extends Model
         return Attribute::make(
             set: fn($value) => make_slug($value),
         );
-    }
-
-    public static function storeCity($userId, $request, $image, $countryId = null, $stateId = null)
-    {
-        return self::create([
-            'user_id' => $userId,
-            'language_id' => $request['language'],
-            'country_id' => $countryId,
-            'state_id' => $stateId,
-            'name' => $request['name'],
-            'slug' => $request['name'],
-            'status' => $request['status'],
-            'image' => $image,
-            'serial_number' => $request['serial_number']
-        ]);
-    }
-
-    public function updateCity($request, $image)
-    {
-        return $this->update([
-            'name' => $request['name'],
-            'slug' => $request['name'],
-            'status' => $request['status'],
-            'image' => $image,
-            'serial_number' => $request['serial_number']
-        ]);
     }
 
     public function country()

--- a/app/Models/User/RealestateManagement/PropertyContent.php
+++ b/app/Models/User/RealestateManagement/PropertyContent.php
@@ -85,15 +85,15 @@ class PropertyContent extends Model
             'category_id' => $requestData['category_id'],
             'country_id' => $requestData['country_id'] ?? null,
             'state_id' => $requestData['state_id'] ?? null,
-            'city_id' => $requestData['city_id'],
+            'city_id' => $requestData['city_id'] ?? null,
 
-            'title' => $requestData['title'],
+            'title' => $requestData['title'] ?? '',
             // 'slug' => $requestData['slug'],
-            'slug' => self::generateUniqueSlug($requestData['title'], $propertyId),
-            'address' => $requestData['address'],
-            'description' => $requestData['description'],
-            'meta_keyword' => $requestData['meta_keyword'],
-            'meta_description' => $requestData['meta_description'],
+            'slug' => self::generateUniqueSlug($requestData['title'] ?? '', $propertyId),
+            'address' => $requestData['address'] ?? '',
+            'description' => $requestData['description'] ?? '',
+            'meta_keyword' => $requestData['meta_keyword'] ?? null,
+            'meta_description' => $requestData['meta_description'] ?? null,
         ]);
     }
 

--- a/app/Observers/PropertyObserver.php
+++ b/app/Observers/PropertyObserver.php
@@ -2,9 +2,11 @@
 
 namespace App\Observers;
 
+use App\Models\User;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\Logs\PropertyLog;
 use App\Services\Audit\EntityAuditLogger;
+use App\Services\SiteSetupProgressService;
 use App\Support\AuditContext;
 use App\Support\PropertyAuditFields;
 use App\Support\CacheInvalidationHelper;
@@ -90,6 +92,12 @@ class PropertyObserver
         
         // Clear property-related caches when new property is created
         $this->clearPropertyCachesForUser($m->user_id);
+
+        // Sync owner user_steps.properties for site setup progress (GET still derives from DB).
+        $propertyOwner = User::find($m->user_id);
+        if ($propertyOwner) {
+            app(SiteSetupProgressService::class)->syncPropertiesFlag($propertyOwner);
+        }
     }
     
     public function updated(Property $m): void {

--- a/app/Services/PropertyConflictDetectionService.php
+++ b/app/Services/PropertyConflictDetectionService.php
@@ -2,38 +2,62 @@
 
 namespace App\Services;
 
+use App\Models\User\Language;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
 use App\Rules\PropertyTypeRule;
 use App\Support\PropertyCompletionRequirements;
-use Illuminate\Support\Facades\DB;
 
 class PropertyConflictDetectionService
 {
     /**
-     * Find a complete property owned by the same user that already uses this
-     * title + address pair. Incomplete drafts are not peers — only completed
-     * listings can be duplicated.
+     * Find a complete property owned by the same user whose five completion-
+     * identity fields match $data exactly (after canonicalize).
+     *
+     * Folding strategy:
+     * - PHP: PropertyCompletionRequirements::canonicalize (trim, collapse
+     *   internal whitespace, mb_strtolower) + PropertyTypeRule::normalize for type
+     * - SQL: REGEXP_REPLACE(LOWER(TRIM(col)), '[[:space:]]+', ' ') compared to
+     *   already-canonical bindings, so a DB value with irregular internal
+     *   spacing still folds to the same key as the PHP side (MariaDB/MySQL 8+;
+     *   plain LOWER(TRIM()) alone does not collapse mid-string whitespace).
      *
      * @param  int  $userId  Tenant owner id
+     * @param  array<string, mixed>  $data
      * @param  int|null  $excludePropertyId  Property being completed, if any
+     * @param  int|null  $languageId  Defaults to the owner's default language
      */
-    public function findTitleAddressDuplicate(
+    public function findExactCompletionDuplicate(
         int $userId,
-        ?string $title,
-        ?string $address,
-        ?int $excludePropertyId = null
+        array $data,
+        ?int $excludePropertyId = null,
+        ?int $languageId = null
     ): ?PropertyContent {
-        if (!PropertyCompletionRequirements::valueProvided($title)
-            || !PropertyCompletionRequirements::valueProvided($address)) {
+        $identity = PropertyCompletionRequirements::identityValues($data);
+        if ($identity === null) {
             return null;
         }
 
-        return PropertyContent::where('title', $title)
-            ->where('address', $address)
-            ->whereHas('property', function ($q) use ($userId, $excludePropertyId) {
-                $q->where('user_id', $userId)
-                  ->where('completion_status', 'complete');
+        if ($languageId === null) {
+            $languageId = Language::where('user_id', $userId)
+                ->where('is_default', 1)
+                ->value('id');
+        }
+
+        if ($languageId === null) {
+            return null;
+        }
+
+        return PropertyContent::query()
+            ->where('user_id', $userId)
+            ->where('language_id', $languageId)
+            ->whereRaw("REGEXP_REPLACE(LOWER(TRIM(title)), '[[:space:]]+', ' ') = ?", [$identity['title']])
+            ->whereRaw("REGEXP_REPLACE(LOWER(TRIM(address)), '[[:space:]]+', ' ') = ?", [$identity['address']])
+            ->whereRaw("REGEXP_REPLACE(LOWER(TRIM(description)), '[[:space:]]+', ' ') = ?", [$identity['description']])
+            ->whereHas('property', function ($q) use ($excludePropertyId, $identity) {
+                $q->where('completion_status', 'complete')
+                    ->whereRaw("REGEXP_REPLACE(LOWER(TRIM(featured_image)), '[[:space:]]+', ' ') = ?", [$identity['featured_image']])
+                    ->whereRaw("REGEXP_REPLACE(LOWER(TRIM(property_type)), '[[:space:]]+', ' ') = ?", [$identity['property_type']]);
 
                 if ($excludePropertyId !== null) {
                     $q->where('id', '!=', $excludePropertyId);
@@ -54,19 +78,18 @@ class PropertyConflictDetectionService
         $conflicts = [];
         $data = PropertyCompletionRequirements::normalizeInput($data);
 
-        // Check for duplicate title + address combination
-        $duplicate = $this->findTitleAddressDuplicate(
+        // Exact match on all five completion-identity fields vs a complete peer
+        $duplicate = $this->findExactCompletionDuplicate(
             $property->user_id,
-            $data['title'] ?? null,
-            $data['address'] ?? null,
+            $data,
             $property->id
         );
 
         if ($duplicate) {
             $conflicts[] = [
                 'type' => 'duplicate',
-                'field' => 'title+address',
-                'message' => 'A property with the same title and address already exists',
+                'field' => 'completion_identity',
+                'message' => 'A property with the same title, address, description, featured image, and property type already exists',
                 'severity' => 'error'
             ];
         }

--- a/app/Services/PropertyConflictDetectionService.php
+++ b/app/Services/PropertyConflictDetectionService.php
@@ -4,13 +4,47 @@ namespace App\Services;
 
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
+use App\Rules\PropertyTypeRule;
+use App\Support\PropertyCompletionRequirements;
 use Illuminate\Support\Facades\DB;
 
 class PropertyConflictDetectionService
 {
     /**
+     * Find a complete property owned by the same user that already uses this
+     * title + address pair. Incomplete drafts are not peers — only completed
+     * listings can be duplicated.
+     *
+     * @param  int  $userId  Tenant owner id
+     * @param  int|null  $excludePropertyId  Property being completed, if any
+     */
+    public function findTitleAddressDuplicate(
+        int $userId,
+        ?string $title,
+        ?string $address,
+        ?int $excludePropertyId = null
+    ): ?PropertyContent {
+        if (!PropertyCompletionRequirements::valueProvided($title)
+            || !PropertyCompletionRequirements::valueProvided($address)) {
+            return null;
+        }
+
+        return PropertyContent::where('title', $title)
+            ->where('address', $address)
+            ->whereHas('property', function ($q) use ($userId, $excludePropertyId) {
+                $q->where('user_id', $userId)
+                  ->where('completion_status', 'complete');
+
+                if ($excludePropertyId !== null) {
+                    $q->where('id', '!=', $excludePropertyId);
+                }
+            })
+            ->first();
+    }
+
+    /**
      * Check for conflicts before completing a property
-     * 
+     *
      * @param Property $property
      * @param array $data
      * @return array Array of conflicts with severity levels
@@ -18,38 +52,28 @@ class PropertyConflictDetectionService
     public function detectConflicts(Property $property, array $data): array
     {
         $conflicts = [];
-        
+        $data = PropertyCompletionRequirements::normalizeInput($data);
+
         // Check for duplicate title + address combination
-        if (isset($data['title']) && isset($data['address'])) {
-            $duplicate = PropertyContent::where('title', $data['title'])
-                ->where('address', $data['address'])
-                ->whereHas('property', function($q) use ($property) {
-                    $q->where('user_id', $property->user_id)
-                      ->where('id', '!=', $property->id)
-                      ->where('completion_status', 'complete');
-                })
-                ->first();
-            
-            if ($duplicate) {
-                $conflicts[] = [
-                    'type' => 'duplicate',
-                    'field' => 'title+address',
-                    'message' => 'A property with the same title and address already exists',
-                    'severity' => 'error'
-                ];
-            }
+        $duplicate = $this->findTitleAddressDuplicate(
+            $property->user_id,
+            $data['title'] ?? null,
+            $data['address'] ?? null,
+            $property->id
+        );
+
+        if ($duplicate) {
+            $conflicts[] = [
+                'type' => 'duplicate',
+                'field' => 'title+address',
+                'message' => 'A property with the same title and address already exists',
+                'severity' => 'error'
+            ];
         }
-        
-        // Validate required fields are present
-        $requiredFields = ['title', 'price', 'address', 'description', 'purpose', 'type', 'area'];
-        $missing = [];
-        
-        foreach ($requiredFields as $field) {
-            if (!isset($data[$field]) || (is_string($data[$field]) && trim($data[$field]) === '') || $data[$field] === null) {
-                $missing[] = $field;
-            }
-        }
-        
+
+        // Validate required fields are present (shared five-field definition)
+        $missing = PropertyCompletionRequirements::missingFrom($data);
+
         if (!empty($missing)) {
             $conflicts[] = [
                 'type' => 'missing_fields',
@@ -59,8 +83,12 @@ class PropertyConflictDetectionService
             ];
         }
         
-        // Validate data formats
-        if (isset($data['price']) && (!is_numeric($data['price']) || $data['price'] < 0)) {
+        // Validate data formats.
+        // price / purpose / area are optional for completeness — only their
+        // FORMAT is checked, and only when a value was actually supplied.
+        // An empty string is "not supplied", not "invalid".
+        if (PropertyCompletionRequirements::valueProvided($data['price'] ?? null)
+            && (!is_numeric($data['price']) || $data['price'] < 0)) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'price',
@@ -68,8 +96,9 @@ class PropertyConflictDetectionService
                 'severity' => 'error'
             ];
         }
-        
-        if (isset($data['area']) && (!is_numeric($data['area']) || $data['area'] < 1)) {
+
+        if (PropertyCompletionRequirements::valueProvided($data['area'] ?? null)
+            && (!is_numeric($data['area']) || $data['area'] < 1)) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'area',
@@ -77,8 +106,9 @@ class PropertyConflictDetectionService
                 'severity' => 'error'
             ];
         }
-        
-        if (isset($data['purpose']) && !in_array($data['purpose'], ['sale', 'rent'])) {
+
+        if (PropertyCompletionRequirements::valueProvided($data['purpose'] ?? null)
+            && !in_array($data['purpose'], ['sale', 'rent'])) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'purpose',
@@ -86,19 +116,23 @@ class PropertyConflictDetectionService
                 'severity' => 'error'
             ];
         }
-        
-        $propertyType = $data['property_type'] ?? ($data['type'] ?? null);
-        if ($propertyType !== null && !in_array($propertyType, ['residential', 'commercial'])) {
+
+        $allowedTypes = PropertyTypeRule::allowed();
+        $rawType = $data['property_type'] ?? null;
+        $propertyType = is_string($rawType) ? PropertyTypeRule::normalize($rawType) : null;
+        if ($propertyType !== null && !in_array($propertyType, $allowedTypes, true)) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'property_type',
-                'message' => 'Property type must be either "residential" or "commercial"',
+                'message' => 'Property type must be one of: ' . implode(', ', $allowedTypes),
                 'severity' => 'error'
             ];
         }
-        
-        // Validate title length
-        if (isset($data['title']) && (strlen($data['title']) < 3 || strlen($data['title']) > 255)) {
+
+        // Length checks run only on supplied values — a blank required field is
+        // already reported once as missing_fields and must not error twice.
+        if (PropertyCompletionRequirements::valueProvided($data['title'] ?? null)
+            && (mb_strlen($data['title']) < 3 || mb_strlen($data['title']) > 255)) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'title',
@@ -106,9 +140,9 @@ class PropertyConflictDetectionService
                 'severity' => 'error'
             ];
         }
-        
-        // Validate address length
-        if (isset($data['address']) && (strlen($data['address']) < 5 || strlen($data['address']) > 500)) {
+
+        if (PropertyCompletionRequirements::valueProvided($data['address'] ?? null)
+            && (mb_strlen($data['address']) < 5 || mb_strlen($data['address']) > 500)) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'address',
@@ -116,9 +150,9 @@ class PropertyConflictDetectionService
                 'severity' => 'error'
             ];
         }
-        
-        // Validate description length
-        if (isset($data['description']) && strlen($data['description']) < 10) {
+
+        if (PropertyCompletionRequirements::valueProvided($data['description'] ?? null)
+            && mb_strlen($data['description']) < 10) {
             $conflicts[] = [
                 'type' => 'validation',
                 'field' => 'description',
@@ -126,7 +160,7 @@ class PropertyConflictDetectionService
                 'severity' => 'error'
             ];
         }
-        
+
         return $conflicts;
     }
     

--- a/app/Services/PropertyRequestCustomerService.php
+++ b/app/Services/PropertyRequestCustomerService.php
@@ -125,7 +125,7 @@ class PropertyRequestCustomerService
      * Get default customer attributes for a user (cached)
      * Returns array with default type_id, priority_id, procedure_id
      */
-    protected function getDefaultCustomerAttributes(int $userId): array
+    public function getDefaultCustomerAttributes(int $userId): array
     {
         $cacheKey = "customer_defaults:{$userId}";
 

--- a/app/Services/SiteSetupProgressService.php
+++ b/app/Services/SiteSetupProgressService.php
@@ -2,69 +2,279 @@
 
 namespace App\Services;
 
-use App\Domain\Domain\Models\CustomDomain;
+use App\Models\Api\ApiDomainSetting;
+use App\Models\Api\FooterSetting;
 use App\Models\Api\marketing\MarketingChannel;
 use App\Models\User;
+use App\Models\User\BasicSetting;
+use App\Models\User\RealestateManagement\Property;
 use App\Models\UserStep;
+use App\Models\WhatsappUser;
 
 class SiteSetupProgressService
 {
+    private const TOTAL_STEPS = 5;
+
+    private const PLACEHOLDER_PHONES = [
+        '+966 5XXXXXXXX',
+        '+9665XXXXXXXX',
+        '5XXXXXXXX',
+    ];
+
+    private const PLACEHOLDER_EMAILS = [
+        'info@example.com',
+    ];
+
     /**
-     * Site setup checklist for the dashboard widget (5 steps).
-     * Uses tenant owner id so employees see the same progress as the account owner.
+     * Canonical FE setup-progress payload (5 steps).
+     * Derives each status from tenant-owner data; employees share owner progress.
+     *
+     * @return array<string, mixed>|null Null when owner cannot be resolved (fail closed).
      */
-    public function getProgress(User $user): array
+    public function getProgress(User $user): ?array
     {
         $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return null;
+        }
 
-        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
-        $hasDomain = CustomDomain::where('user_id', $ownerId)->exists();
-        $hasWhatsApp = MarketingChannel::where('user_id', $ownerId)
-            ->where('type', MarketingChannel::TYPE_WHATSAPP)
-            ->where('is_connected', true)
-            ->exists();
+        $owner = User::find($ownerId);
+        if (! $owner) {
+            return null;
+        }
+
+        $statuses = [
+            'site_identity' => (bool) $owner->onboarding_completed,
+            'contact_info' => $this->isContactInfoComplete($owner),
+            'first_property' => Property::where('user_id', $ownerId)->exists(),
+            'integrated_link' => $this->hasIntegratedLink($ownerId),
+            'connect_site' => ApiDomainSetting::where('user_id', $ownerId)
+                ->where('status', 'active')
+                ->exists(),
+        ];
 
         $stepDefs = [
             [
-                'key' => 'site_identity',
-                'label' => 'هوية الموقع',
-                'completed' => (bool) ($steps->logo_uploaded && $steps->website_named),
-                'path' => '/basic-settings',
+                'id' => 'site_identity',
+                'label_ar' => 'هوية الموقع',
+                'order' => 1,
+                'href_incomplete' => null,
             ],
             [
-                'key' => 'contact_data',
-                'label' => 'بيانات التواصل',
-                'completed' => (bool) $steps->contacts_social_info,
-                'path' => '/contact-info',
+                'id' => 'contact_info',
+                'label_ar' => 'بيانات التواصل',
+                'order' => 2,
+                'href_incomplete' => '/dashboard/my-account/personal',
             ],
             [
-                'key' => 'first_property',
-                'label' => 'أول عقار',
-                'completed' => (bool) $steps->properties,
-                'path' => '/properties/add',
+                'id' => 'first_property',
+                'label_ar' => 'أول عقار',
+                'order' => 3,
+                'href_incomplete' => '/dashboard/properties/add',
             ],
             [
-                'key' => 'domain_link',
-                'label' => 'ربط الموقع',
-                'completed' => $hasDomain,
-                'path' => '/domain-settings',
+                'id' => 'integrated_link',
+                'label_ar' => 'الرابط المتكامل',
+                'order' => 4,
+                'href_incomplete' => '/dashboard/apps',
             ],
             [
-                'key' => 'integration',
-                'label' => 'الرابط المتكامل',
-                'completed' => $hasWhatsApp,
-                'path' => '/whatsapp',
+                'id' => 'connect_site',
+                'label_ar' => 'ربط الموقع',
+                'order' => 5,
+                'href_incomplete' => '/dashboard/my-account/domains',
             ],
         ];
 
-        $completedCount = collect($stepDefs)->filter(fn ($s) => $s['completed'])->count();
-        $total = count($stepDefs);
+        $steps = [];
+        $done = 0;
+
+        foreach ($stepDefs as $def) {
+            $complete = (bool) ($statuses[$def['id']] ?? false);
+            if ($complete) {
+                $done++;
+            }
+
+            $steps[] = [
+                'id' => $def['id'],
+                'label_ar' => $def['label_ar'],
+                'status' => $complete,
+                'href' => $complete ? null : $def['href_incomplete'],
+                'order' => $def['order'],
+                'locked' => false,
+            ];
+        }
+
+        $progress = self::TOTAL_STEPS > 0
+            ? round($done / self::TOTAL_STEPS, 4)
+            : 0.0;
 
         return [
-            'steps' => $stepDefs,
-            'completed_count' => $completedCount,
-            'total_steps' => $total,
-            'progress_percentage' => $total > 0 ? (int) (($completedCount / $total) * 100) : 0,
+            'progress' => $progress,
+            'done' => $done,
+            'total' => self::TOTAL_STEPS,
+            'headline_key' => $this->headlineKeyForDone($done),
+            'dismissed' => false,
+            'steps' => $steps,
         ];
+    }
+
+    /**
+     * Map POST /steps/complete to owner user_steps flags, then return GET-shaped progress.
+     *
+     * @return array{ok: bool, progress: ?array, error?: string, status?: int}
+     */
+    public function completeStep(User $user, string $step): array
+    {
+        $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return ['ok' => false, 'progress' => null, 'error' => 'Unable to resolve tenant owner.', 'status' => 403];
+        }
+
+        $canonical = $step === 'properties' ? 'first_property' : $step;
+
+        $noopSteps = ['site_identity', 'integrated_link', 'connect_site'];
+        $flagMap = [
+            'first_property' => 'properties',
+            'contact_info' => 'contacts_social_info',
+        ];
+
+        if (in_array($canonical, $noopSteps, true)) {
+            // no-op on user_steps; GET remains source of truth
+        } elseif (isset($flagMap[$canonical])) {
+            $column = $flagMap[$canonical];
+            $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+            $steps->{$column} = true;
+            $steps->save();
+        } else {
+            return [
+                'ok' => false,
+                'progress' => null,
+                'error' => 'The selected step is invalid.',
+                'status' => 422,
+            ];
+        }
+
+        $progress = $this->getProgress($user);
+        if ($progress === null) {
+            return ['ok' => false, 'progress' => null, 'error' => 'Unable to resolve tenant owner.', 'status' => 403];
+        }
+
+        return ['ok' => true, 'progress' => $progress];
+    }
+
+    /**
+     * Sync contacts_social_info on the owner row when contact_info derives true.
+     */
+    public function syncContactsSocialInfo(User $owner): void
+    {
+        $ownerId = (int) ($owner->id ?: 0);
+        if (! $ownerId) {
+            return;
+        }
+
+        if (! $this->isContactInfoComplete($owner)) {
+            return;
+        }
+
+        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+        if ($steps->contacts_social_info) {
+            return;
+        }
+
+        $steps->contacts_social_info = true;
+        $steps->save();
+    }
+
+    /**
+     * Sync properties flag on the owner row after a property is created.
+     * Early-returns if already true.
+     */
+    public function syncPropertiesFlag(User $user): void
+    {
+        $ownerId = $user->tenantOwnerId();
+        if (! $ownerId) {
+            return;
+        }
+
+        $steps = UserStep::firstOrCreate(['user_id' => $ownerId]);
+        if ($steps->properties) {
+            return;
+        }
+
+        $steps->properties = true;
+        $steps->save();
+    }
+
+    public function isContactInfoComplete(User $owner): bool
+    {
+        $footer = FooterSetting::where('user_id', $owner->id)->first();
+        $general = is_array($footer?->general) ? $footer->general : [];
+
+        $phone = trim((string) ($general['phone'] ?? ''));
+        if ($phone === '' || $this->isPlaceholderPhone($phone)) {
+            return false;
+        }
+
+        $basic = BasicSetting::where('user_id', $owner->id)->first();
+        $basicEmail = trim((string) ($basic?->email ?? ''));
+        $footerEmail = trim((string) ($general['email'] ?? ''));
+
+        $email = $basicEmail !== '' ? $basicEmail : $footerEmail;
+        if ($email === '' || $this->isPlaceholderEmail($email)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hasIntegratedLink(int $ownerId): bool
+    {
+        $whatsappActive = WhatsappUser::where('user_id', $ownerId)
+            ->where('status', 'active')
+            ->exists();
+
+        if ($whatsappActive) {
+            return true;
+        }
+
+        return MarketingChannel::where('user_id', $ownerId)
+            ->where('type', MarketingChannel::TYPE_WHATSAPP)
+            ->where('is_connected', true)
+            ->exists();
+    }
+
+    private function headlineKeyForDone(int $done): string
+    {
+        return match (true) {
+            $done <= 0 => 'start',
+            $done === 1 => 'early',
+            $done <= 3 => 'mid',
+            $done === 4 => 'almost',
+            default => 'done',
+        };
+    }
+
+    private function isPlaceholderPhone(string $phone): bool
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($phone)) ?? '';
+        $compact = preg_replace('/\s+/', '', $normalized) ?? '';
+
+        foreach (self::PLACEHOLDER_PHONES as $placeholder) {
+            $pNorm = preg_replace('/\s+/', ' ', $placeholder) ?? '';
+            $pCompact = preg_replace('/\s+/', '', $placeholder) ?? '';
+            if (strcasecmp($normalized, $pNorm) === 0 || strcasecmp($compact, $pCompact) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPlaceholderEmail(string $email): bool
+    {
+        $email = strtolower(trim($email));
+
+        return in_array($email, array_map('strtolower', self::PLACEHOLDER_EMAILS), true);
     }
 }

--- a/app/Services/TenantCrmBootstrapService.php
+++ b/app/Services/TenantCrmBootstrapService.php
@@ -3,7 +3,10 @@
 namespace App\Services;
 
 use App\Models\Api\PropertyRequestAutoCustomerSetting;
+use App\Models\Api\UserApiCustomerPriority;
+use App\Models\Api\UserApiCustomerProcedure;
 use App\Models\Api\UserApiCustomerStage;
+use App\Models\Api\UserApiCustomerType;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
@@ -24,16 +27,159 @@ class TenantCrmBootstrapService
     }
 
     /**
-     * Ensure default CRM stages exist and auto-customer settings are enabled.
+     * Default customer types for a new tenant (single source of truth).
+     *
+     * @return list<array{name: string, value: string, order: int, icon: string, color: string}>
+     */
+    public static function defaultTypes(): array
+    {
+        return [
+            ['name' => 'Rent',   'value' => 'Rent',   'order' => 1, 'icon' => 'home',      'color' => '#2196f3'],
+            ['name' => 'Sale',   'value' => 'Sale',   'order' => 2, 'icon' => 'dollar',    'color' => '#4caf50'],
+            ['name' => 'Rented', 'value' => 'Rented', 'order' => 3, 'icon' => 'check',     'color' => '#9e9e9e'],
+            ['name' => 'Sold',   'value' => 'Sold',   'order' => 4, 'icon' => 'check-all', 'color' => '#9e9e9e'],
+            ['name' => 'Both',   'value' => 'Both',   'order' => 5, 'icon' => 'arrows',    'color' => '#ff9800'],
+        ];
+    }
+
+    /**
+     * Default customer priorities for a new tenant (single source of truth).
+     *
+     * @return list<array{name: string, value: int, order: int, icon: string, color: string}>
+     */
+    public static function defaultPriorities(): array
+    {
+        return [
+            ['name' => 'Low',    'value' => 1, 'order' => 1, 'icon' => 'arrow-down', 'color' => '#4caf50'],
+            ['name' => 'Medium', 'value' => 2, 'order' => 2, 'icon' => 'minus',      'color' => '#ff9800'],
+            ['name' => 'High',   'value' => 3, 'order' => 3, 'icon' => 'arrow-up',   'color' => '#f44336'],
+        ];
+    }
+
+    /**
+     * Default customer procedures for a new tenant (single source of truth).
+     *
+     * @return list<array{procedure_name: string, order: int, icon: string, color: string}>
+     */
+    public static function defaultProcedures(): array
+    {
+        return [
+            ['procedure_name' => 'meeting', 'order' => 1, 'icon' => 'users', 'color' => '#2196f3'],
+            ['procedure_name' => 'visit',   'order' => 2, 'icon' => 'map',   'color' => '#ff9800'],
+        ];
+    }
+
+    /**
+     * Ensure the tenant's CRM lookup rows exist and auto-customer settings are enabled.
+     *
+     * Types, priorities and procedures used to be seeded as a side effect of
+     * GET /api/crm, so a tenant that never opened the CRM dashboard had none —
+     * which left customer creation with no type to default to.
      */
     public function ensureForTenant(int $userId): void
     {
+        $this->ensureDefaultTypes($userId);
+        $this->ensureDefaultPriorities($userId);
+        $this->ensureDefaultProcedures($userId);
+
         if (!$this->stagesTableReady() || !$this->settingsTableReady()) {
             return;
         }
 
         $this->ensureDefaultStages($userId);
         $this->ensureAutoCustomerSettings($userId);
+    }
+
+    /**
+     * Create the default customer types the tenant is missing.
+     */
+    public function ensureDefaultTypes(int $userId): void
+    {
+        if (!$this->typesTableReady()) {
+            return;
+        }
+
+        $created = false;
+
+        foreach (self::defaultTypes() as $type) {
+            $row = UserApiCustomerType::firstOrCreate(
+                ['user_id' => $userId, 'value' => $type['value']],
+                [
+                    'name' => $type['name'],
+                    'order' => $type['order'],
+                    'icon' => $type['icon'],
+                    'color' => $type['color'],
+                    'is_active' => true,
+                ]
+            );
+
+            $created = $created || $row->wasRecentlyCreated;
+        }
+
+        if ($created) {
+            PropertyRequestCustomerService::clearSettingsCache($userId);
+        }
+    }
+
+    /**
+     * Create the default customer priorities the tenant is missing.
+     */
+    public function ensureDefaultPriorities(int $userId): void
+    {
+        if (!$this->prioritiesTableReady()) {
+            return;
+        }
+
+        $created = false;
+
+        foreach (self::defaultPriorities() as $priority) {
+            $row = UserApiCustomerPriority::firstOrCreate(
+                ['user_id' => $userId, 'value' => $priority['value']],
+                [
+                    'name' => $priority['name'],
+                    'order' => $priority['order'],
+                    'icon' => $priority['icon'],
+                    'color' => $priority['color'],
+                    'is_active' => true,
+                ]
+            );
+
+            $created = $created || $row->wasRecentlyCreated;
+        }
+
+        if ($created) {
+            PropertyRequestCustomerService::clearSettingsCache($userId);
+        }
+    }
+
+    /**
+     * Create the default customer procedures the tenant is missing.
+     */
+    public function ensureDefaultProcedures(int $userId): void
+    {
+        if (!$this->proceduresTableReady()) {
+            return;
+        }
+
+        $created = false;
+
+        foreach (self::defaultProcedures() as $procedure) {
+            $row = UserApiCustomerProcedure::firstOrCreate(
+                ['user_id' => $userId, 'procedure_name' => $procedure['procedure_name']],
+                [
+                    'order' => $procedure['order'],
+                    'icon' => $procedure['icon'],
+                    'color' => $procedure['color'],
+                    'is_active' => true,
+                ]
+            );
+
+            $created = $created || $row->wasRecentlyCreated;
+        }
+
+        if ($created) {
+            PropertyRequestCustomerService::clearSettingsCache($userId);
+        }
     }
 
     /**
@@ -113,6 +259,21 @@ class TenantCrmBootstrapService
     private function stagesTableReady(): bool
     {
         return Schema::hasTable('users_api_customers_stages');
+    }
+
+    private function typesTableReady(): bool
+    {
+        return Schema::hasTable('users_api_customers_types');
+    }
+
+    private function prioritiesTableReady(): bool
+    {
+        return Schema::hasTable('users_api_customers_priorities');
+    }
+
+    private function proceduresTableReady(): bool
+    {
+        return Schema::hasTable('users_api_customers_procedures');
     }
 
     private function settingsTableReady(): bool

--- a/app/Support/LocationLookupCache.php
+++ b/app/Support/LocationLookupCache.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Cache keys for the public /api/cities and /api/districts lookups.
+ *
+ * The payloads are effectively static between runs of `import:cities-districts`,
+ * but they are read on every tenant site load, so they are cached for a day.
+ *
+ * Keys carry a version stamp instead of being forgotten individually: /districts
+ * is cached per city_id, so there are ~473 possible keys and no practical way to
+ * enumerate them. Bumping the version orphans every key at once, and unlike a
+ * Redis SCAN sweep it works the same on the file driver used outside production.
+ */
+class LocationLookupCache
+{
+    const VERSION_KEY = 'api:locations:version';
+    const TTL_SECONDS = 86400;
+
+    /**
+     * @param  string  $bucket  "cities" or "districts"
+     * @param  mixed   $scope   country_id / city_id, or null for the unfiltered list
+     */
+    public static function key(string $bucket, $scope = null): string
+    {
+        $scope = ($scope === null || $scope === '') ? 'all' : $scope;
+
+        return 'api:locations:v' . self::version() . ':' . $bucket . ':' . $scope;
+    }
+
+    public static function version(): int
+    {
+        return (int) Cache::rememberForever(self::VERSION_KEY, function () {
+            return 1;
+        });
+    }
+
+    /**
+     * Invalidate every cached cities/districts payload. Called after a sync writes.
+     */
+    public static function flush(): void
+    {
+        Cache::forever(self::VERSION_KEY, self::version() + 1);
+    }
+}

--- a/app/Support/PropertyCompletionRequirements.php
+++ b/app/Support/PropertyCompletionRequirements.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Single source of truth for the fields a property must have to be "complete".
+ *
+ * Deliberately a SUBSET of single create (POST /properties, PropertyStoreRequest),
+ * which additionally requires slider_images, latitude/longitude, category_id,
+ * city_id and an uploaded featured_image file. Excel import and draft-complete
+ * accept URL/path images and do not require location, so they enforce these five.
+ */
+class PropertyCompletionRequirements
+{
+    /**
+     * Canonical required field keys, in reporting order.
+     *
+     * @return array<int, string>
+     */
+    public static function fields(): array
+    {
+        return ['title', 'address', 'description', 'featured_image', 'property_type'];
+    }
+
+    /**
+     * Map incoming aliases onto canonical keys (Excel/legacy `type` → `property_type`).
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public static function normalizeInput(array $data): array
+    {
+        if (!array_key_exists('property_type', $data) && array_key_exists('type', $data)) {
+            $data['property_type'] = $data['type'];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Required fields absent or blank in $data, as canonical English keys.
+     *
+     * Callers persist these into `missing_fields`; Arabic labels are applied at
+     * the response layer, never stored.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<int, string>
+     */
+    public static function missingFrom(array $data): array
+    {
+        $data = self::normalizeInput($data);
+
+        $missing = [];
+        foreach (self::fields() as $field) {
+            if (!self::valueProvided($data[$field] ?? null)) {
+                $missing[] = $field;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function isComplete(array $data): bool
+    {
+        return self::missingFrom($data) === [];
+    }
+
+    /**
+     * A value counts as provided when it is not null, not '' and not an empty array.
+     * Matches PropertiesSingleSheetImport::valueProvided() so import and API agree.
+     */
+    public static function valueProvided($value): bool
+    {
+        if (is_null($value)) {
+            return false;
+        }
+
+        if (is_string($value)) {
+            return trim($value) !== '';
+        }
+
+        if (is_array($value)) {
+            return $value !== [];
+        }
+
+        return true;
+    }
+}

--- a/app/Support/PropertyCompletionRequirements.php
+++ b/app/Support/PropertyCompletionRequirements.php
@@ -2,6 +2,8 @@
 
 namespace App\Support;
 
+use App\Rules\PropertyTypeRule;
+
 /**
  * Single source of truth for the fields a property must have to be "complete".
  *
@@ -35,6 +37,71 @@ class PropertyCompletionRequirements
         }
 
         return $data;
+    }
+
+    /**
+     * Fold a string for exact-identity comparison: trim, collapse internal
+     * whitespace, then lowercase.
+     */
+    public static function canonicalize(string $v): string
+    {
+        $v = trim($v);
+        $v = preg_replace('/\s+/u', ' ', $v) ?? $v;
+
+        return mb_strtolower($v);
+    }
+
+    /**
+     * Canonical five identity values, or null if any field is blank / un-normalizable.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array{title: string, address: string, description: string, featured_image: string, property_type: string}|null
+     */
+    public static function identityValues(array $data): ?array
+    {
+        $data = self::normalizeInput($data);
+        $values = [];
+
+        foreach (self::fields() as $field) {
+            $raw = $data[$field] ?? null;
+
+            if ($field === 'property_type') {
+                $normalized = is_string($raw) ? PropertyTypeRule::normalize($raw) : null;
+                if ($normalized === null) {
+                    return null;
+                }
+                $values[$field] = self::canonicalize($normalized);
+                continue;
+            }
+
+            if (!self::valueProvided($raw)) {
+                return null;
+            }
+
+            $values[$field] = self::canonicalize((string) $raw);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Stable hashable key for the five identity values (tests / optional in-memory sets).
+     *
+     * @param  array{title: string, address: string, description: string, featured_image: string, property_type: string}|null  $values
+     */
+    public static function identityKey(?array $values): ?string
+    {
+        if ($values === null) {
+            return null;
+        }
+
+        return implode("\x1f", [
+            $values['title'],
+            $values['address'],
+            $values['description'],
+            $values['featured_image'],
+            $values['property_type'],
+        ]);
     }
 
     /**

--- a/app/Support/PropertyExcelHeaderMapping.php
+++ b/app/Support/PropertyExcelHeaderMapping.php
@@ -35,6 +35,12 @@ class PropertyExcelHeaderMapping
             return '';
         }
 
+        // Strip trailing asterisk (and surrounding whitespace) used to mark required columns
+        $header = trim(preg_replace('/\s*\*\s*$/', '', $header));
+        if ($header === '') {
+            return '';
+        }
+
         $map = self::arabicHeaderToKey();
         if (isset($map[$header])) {
             return $map[$header];

--- a/app/Support/PropertyExcelMapping.php
+++ b/app/Support/PropertyExcelMapping.php
@@ -133,7 +133,9 @@ class PropertyExcelMapping
             return self::TYPE_TO_DB[$v];
         }
         $lower = mb_strtolower($v);
-        return in_array($lower, ['residential', 'commercial']) ? $lower : $value;
+        return in_array($lower, ['residential', 'commercial', 'agricultural', 'industrial'], true)
+            ? $lower
+            : $value;
     }
 
     public static function purposeExcelOptions(): string

--- a/app/Support/PropertyExcelMapping.php
+++ b/app/Support/PropertyExcelMapping.php
@@ -19,6 +19,8 @@ class PropertyExcelMapping
     public const TYPE_TO_EXCEL = [
         'residential' => 'سكني',
         'commercial' => 'تجاري',
+        'agricultural' => 'زراعي',
+        'industrial' => 'صناعي',
     ];
 
     /** Excel (Arabic or English) → DB (purpose) */
@@ -33,8 +35,12 @@ class PropertyExcelMapping
     public const TYPE_TO_DB = [
         'سكني' => 'residential',
         'تجاري' => 'commercial',
+        'زراعي' => 'agricultural',
+        'صناعي' => 'industrial',
         'residential' => 'residential',
         'commercial' => 'commercial',
+        'agricultural' => 'agricultural',
+        'industrial' => 'industrial',
     ];
 
     /** Lookup sheet title for City-District Reference (used in title() and setFormula1) */
@@ -137,7 +143,7 @@ class PropertyExcelMapping
 
     public static function typeExcelOptions(): string
     {
-        return 'سكني,تجاري';
+        return 'سكني,تجاري,زراعي,صناعي';
     }
 
     /**

--- a/app/Support/PropertyFilterQuery.php
+++ b/app/Support/PropertyFilterQuery.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Shared property list/export filter chain.
+ * Accepts both `property_type` and `type` for the type filter (controller vs export key drift).
+ */
+class PropertyFilterQuery
+{
+    public static function apply(Builder $query, array $filters): Builder
+    {
+        // Apply property IDs filter if provided
+        if (!empty($filters['ids']) && is_array($filters['ids']) && count($filters['ids']) > 0) {
+            $query->whereIn('id', $filters['ids']);
+        }
+
+        // Apply date range filter
+        if (!empty($filters['date_from'])) {
+            $query->whereDate('created_at', '>=', $filters['date_from']);
+        }
+        if (!empty($filters['date_to'])) {
+            $query->whereDate('created_at', '<=', $filters['date_to']);
+        }
+
+        // Apply purpose filter
+        if (!empty($filters['purposes_filter'])) {
+            $query->where('purpose', $filters['purposes_filter']);
+        }
+        if (!empty($filters['purpose'])) {
+            $query->where('purpose', $filters['purpose']);
+        }
+
+        // Apply type filter (accept both property_type and type keys)
+        $propertyType = $filters['property_type'] ?? $filters['type'] ?? null;
+        if (!empty($propertyType)) {
+            $query->where('property_type', $propertyType);
+        }
+
+        // Apply price filters
+        if (!empty($filters['price_from'])) {
+            $query->where('price', '>=', $filters['price_from']);
+        }
+        if (!empty($filters['price_to'])) {
+            $query->where('price', '<=', $filters['price_to']);
+        }
+
+        // Apply area filters
+        if (!empty($filters['area_from'])) {
+            $query->where('area', '>=', $filters['area_from']);
+        }
+        if (!empty($filters['area_to'])) {
+            $query->where('area', '<=', $filters['area_to']);
+        }
+
+        // Apply beds filter
+        if (!empty($filters['beds'])) {
+            $query->where('beds', $filters['beds']);
+        }
+
+        // Apply bath filter
+        if (!empty($filters['bath'])) {
+            $query->where('bath', $filters['bath']);
+        }
+
+        // Apply category filter
+        if (!empty($filters['category_id'])) {
+            $query->where('category_id', $filters['category_id']);
+        }
+
+        // Apply status filter
+        if (isset($filters['status']) && $filters['status'] !== '') {
+            $query->where('status', $filters['status']);
+        }
+
+        // Apply featured filter
+        if (isset($filters['featured']) && $filters['featured'] !== '') {
+            $query->where('featured', $filters['featured']);
+        }
+
+        // Apply city filter
+        if (!empty($filters['city_id'])) {
+            $query->whereHas('contents', function ($q) use ($filters) {
+                $q->where('city_id', $filters['city_id']);
+            });
+        }
+
+        // Apply district filter
+        if (!empty($filters['district_id'])) {
+            $query->whereHas('contents', function ($q) use ($filters) {
+                $q->where('state_id', $filters['district_id']);
+            });
+        }
+
+        // Apply search filter (title/description/address, plus numeric property ID)
+        if (!empty($filters['search'])) {
+            $search = trim((string) $filters['search']);
+            $numericId = self::parsePositiveIntSearchId($search);
+            $query->where(function ($q) use ($search, $numericId) {
+                $q->whereHas('contents', function ($cq) use ($search) {
+                    $cq->where(function ($inner) use ($search) {
+                        $inner->where('title', 'like', "%{$search}%")
+                              ->orWhere('description', 'like', "%{$search}%")
+                              ->orWhere('address', 'like', "%{$search}%");
+                    });
+                });
+                if ($numericId !== null) {
+                    $q->orWhere('id', $numericId);
+                }
+            });
+        }
+
+        // Apply features filter
+        if (!empty($filters['features'])) {
+            $featuresArray = explode(',', $filters['features']);
+            foreach ($featuresArray as $feature) {
+                $feature = trim($feature);
+                $query->whereJsonContains('features', $feature);
+            }
+        }
+
+        return $query;
+    }
+
+    private static function parsePositiveIntSearchId(?string $searchTerm): ?int
+    {
+        $searchTerm = trim((string) $searchTerm);
+        if ($searchTerm === ''
+            || !ctype_digit($searchTerm)
+            || strlen($searchTerm) > 18
+            || (int) $searchTerm <= 0
+        ) {
+            return null;
+        }
+
+        return (int) $searchTerm;
+    }
+}

--- a/database/migrations/2026_08_07_000001_add_project_id_to_users_property_requests.php
+++ b/database/migrations/2026_08_07_000001_add_project_id_to_users_property_requests.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users_property_requests')) {
+            return;
+        }
+
+        Schema::table('users_property_requests', function (Blueprint $table) {
+            if (! Schema::hasColumn('users_property_requests', 'project_id')) {
+                $table->unsignedBigInteger('project_id')->nullable()->after('initial_property_id');
+                $table->index('project_id');
+                $table->foreign('project_id')
+                    ->references('id')
+                    ->on('user_projects')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('users_property_requests')) {
+            return;
+        }
+
+        Schema::table('users_property_requests', function (Blueprint $table) {
+            if (Schema::hasColumn('users_property_requests', 'project_id')) {
+                $table->dropForeign(['project_id']);
+                $table->dropIndex(['project_id']);
+                $table->dropColumn('project_id');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_08_09_000001_prepare_user_locations_for_nzl_sync.php
+++ b/database/migrations/2026_08_09_000001_prepare_user_locations_for_nzl_sync.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Prepares user_cities / user_districts for the one-time nzl-backend sync.
+ *
+ * 1. region_id becomes nullable: 68 Saudi cities exist only inside the districts
+ *    payload (as denormalized city_name_*) and carry no region from nzl. The region
+ *    code embedded in the district id is not reliable (it matches nzl's own
+ *    region_id for just 37 of 397 known cities), so NULL is recorded instead.
+ *
+ * 2. AUTO_INCREMENT is pushed clear of nzl's id space. Both tables use $table->id(),
+ *    so after the sync the counter would sit at 11302271197 -- precisely the id nzl
+ *    hands to its next district. Any locally created row would collide. Reserving a
+ *    dedicated range makes the origin of a location readable from its id alone:
+ *
+ *        nzl-owned      : cities <= 23696,   districts 1xxxxxxxxxx
+ *        taearif-native : cities >= 900001,  districts >= 90000000001
+ */
+return new class extends Migration
+{
+    const CITY_ID_BASE = 900001;
+    const DISTRICT_ID_BASE = 90000000001;
+
+    public function up()
+    {
+        Schema::table('user_cities', function (Blueprint $table) {
+            $table->unsignedBigInteger('region_id')->nullable()->change();
+        });
+
+        $this->bumpAutoIncrement('user_cities', self::CITY_ID_BASE);
+        $this->bumpAutoIncrement('user_districts', self::DISTRICT_ID_BASE);
+    }
+
+    public function down()
+    {
+        // The AUTO_INCREMENT bump is intentionally not reverted: lowering it back into
+        // nzl's range would hand out colliding ids for any row created since.
+        DB::table('user_cities')->whereNull('region_id')->update(['region_id' => 0]);
+
+        Schema::table('user_cities', function (Blueprint $table) {
+            $table->unsignedBigInteger('region_id')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * MySQL ignores an AUTO_INCREMENT value at or below the current maximum id,
+     * so this is safe to run before or after the sync inserts its rows.
+     */
+    private function bumpAutoIncrement($table, $value)
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement("ALTER TABLE `{$table}` AUTO_INCREMENT = {$value}");
+    }
+};

--- a/tests/Feature/Api/LocationLookupApiTest.php
+++ b/tests/Feature/Api/LocationLookupApiTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User\UserCity;
+use App\Models\User\UserDistrict;
+use App\Support\LocationLookupCache;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * Covers the public /api/cities and /api/districts lookups after the nzl sync.
+ *
+ * Ids here sit in the taearif-native range reserved by
+ * 2026_08_09_000001_prepare_user_locations_for_nzl_sync so they cannot clash
+ * with real nzl-owned rows in the database the suite runs against.
+ */
+class LocationLookupApiTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    const TEST_CITY_ID = 900777;
+    const TEST_CITY_WITH_DISTRICTS_ID = 900778;
+    const TEST_DISTRICT_ID = 90000000777;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['user_cities', 'user_districts'] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+
+        if (! $this->regionIdIsNullable()) {
+            $this->markTestSkipped('user_cities.region_id is still NOT NULL. Run migrations.');
+        }
+
+        // Keys are versioned, so this isolates each test from cached payloads.
+        LocationLookupCache::flush();
+    }
+
+    protected function tearDown(): void
+    {
+        LocationLookupCache::flush();
+
+        parent::tearDown();
+    }
+
+    private function regionIdIsNullable(): bool
+    {
+        $column = collect(Schema::getConnection()->select('SHOW COLUMNS FROM user_cities'))
+            ->firstWhere('Field', 'region_id');
+
+        return $column !== null && $column->Null === 'YES';
+    }
+
+    private function makeCity(int $id, string $nameAr = 'مدينة اختبار'): UserCity
+    {
+        return UserCity::create([
+            'id' => $id,
+            'name_ar' => $nameAr,
+            'name_en' => 'Test City',
+            'country_id' => 1,
+            'region_id' => null,
+        ]);
+    }
+
+    private function makeDistrict(int $id, int $cityId): UserDistrict
+    {
+        return UserDistrict::create([
+            'id' => $id,
+            'name_ar' => 'حي اختبار',
+            'name_en' => 'Test District',
+            'city_id' => $cityId,
+            'city_name_ar' => 'مدينة اختبار',
+            'city_name_en' => 'Test City',
+            'country_name_ar' => 'السعودية',
+            'country_name_en' => 'Saudi Arabia',
+        ]);
+    }
+
+    /** @test */
+    public function cities_endpoint_exposes_only_id_and_names(): void
+    {
+        $this->makeCity(self::TEST_CITY_ID);
+
+        $response = $this->getJson('/api/cities');
+
+        $response->assertOk()->assertJsonStructure(['data' => [['id', 'name_ar', 'name_en']]]);
+
+        $city = collect($response->json('data'))->firstWhere('id', self::TEST_CITY_ID);
+
+        $this->assertNotNull($city);
+        $this->assertSame(['id', 'name_ar', 'name_en'], array_keys($city));
+    }
+
+    /**
+     * The endpoint used to derive its list from user_districts, so a city with no
+     * districts was invisible. Seven real Saudi cities are in that position.
+     *
+     * @test
+     */
+    public function cities_endpoint_includes_a_city_that_has_no_districts(): void
+    {
+        $this->makeCity(self::TEST_CITY_ID, 'مدينة بلا أحياء');
+
+        $this->assertSame(0, UserDistrict::where('city_id', self::TEST_CITY_ID)->count());
+
+        $ids = collect($this->getJson('/api/cities')->assertOk()->json('data'))->pluck('id');
+
+        $this->assertTrue($ids->contains(self::TEST_CITY_ID));
+    }
+
+    /**
+     * Previously the city_id rule was `exists:user_districts,city_id`, so asking for
+     * the districts of a district-less city returned 422 instead of an empty list.
+     *
+     * @test
+     */
+    public function districts_endpoint_returns_empty_list_for_a_city_without_districts(): void
+    {
+        $this->makeCity(self::TEST_CITY_ID);
+
+        $this->getJson('/api/districts?city_id=' . self::TEST_CITY_ID)
+            ->assertOk()
+            ->assertJson(['data' => []]);
+    }
+
+    /** @test */
+    public function districts_endpoint_filters_by_city(): void
+    {
+        $this->makeCity(self::TEST_CITY_WITH_DISTRICTS_ID);
+        $this->makeDistrict(self::TEST_DISTRICT_ID, self::TEST_CITY_WITH_DISTRICTS_ID);
+
+        $data = $this->getJson('/api/districts?city_id=' . self::TEST_CITY_WITH_DISTRICTS_ID)
+            ->assertOk()
+            ->json('data');
+
+        $this->assertCount(1, $data);
+        $this->assertSame(self::TEST_DISTRICT_ID, $data[0]['id']);
+        $this->assertSame(self::TEST_CITY_WITH_DISTRICTS_ID, $data[0]['city_id']);
+    }
+
+    /** @test */
+    public function cities_endpoint_still_accepts_the_legacy_country_id_parameter(): void
+    {
+        $this->makeCity(self::TEST_CITY_ID);
+
+        $ids = collect($this->getJson('/api/cities?country_id=1')->assertOk()->json('data'))->pluck('id');
+
+        $this->assertTrue($ids->contains(self::TEST_CITY_ID));
+    }
+
+    /** @test */
+    public function districts_endpoint_rejects_a_non_numeric_city_id(): void
+    {
+        $this->getJson('/api/districts?city_id=abc')->assertStatus(422);
+    }
+
+    /**
+     * The payloads are cached for a day, so the sync command must invalidate them.
+     *
+     * @test
+     */
+    public function cached_cities_payload_is_invalidated_by_a_cache_flush(): void
+    {
+        $before = collect($this->getJson('/api/cities')->assertOk()->json('data'))->pluck('id');
+        $this->assertFalse($before->contains(self::TEST_CITY_ID));
+
+        $this->makeCity(self::TEST_CITY_ID);
+
+        $stale = collect($this->getJson('/api/cities')->assertOk()->json('data'))->pluck('id');
+        $this->assertFalse($stale->contains(self::TEST_CITY_ID), 'Expected the cached payload to still be served.');
+
+        LocationLookupCache::flush();
+
+        $fresh = collect($this->getJson('/api/cities')->assertOk()->json('data'))->pluck('id');
+        $this->assertTrue($fresh->contains(self::TEST_CITY_ID), 'Expected the flush to expose the new city.');
+    }
+}

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -561,4 +561,248 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $this->assertNotNull($content);
         $this->assertSame('شقة مكتملة بالحد الأدنى', $content->title);
     }
+
+    /**
+     * @param  array{title: string, address: string, description: string, featured_image: string, property_type: string}  $identity
+     */
+    private function seedCompletePeer(User $tenant, Language $language, array $identity): Property
+    {
+        $property = Property::create([
+            'user_id' => $tenant->id,
+            'created_by' => $tenant->id,
+            'price' => 100000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'published',
+            'property_type' => $identity['property_type'],
+            'area' => 100,
+            'status' => 1,
+            'completion_status' => 'complete',
+            'featured' => 0,
+            'featured_image' => $identity['featured_image'],
+            'completed_at' => now(),
+        ]);
+
+        PropertyContent::create([
+            'user_id' => $tenant->id,
+            'property_id' => $property->id,
+            'language_id' => $language->id,
+            'title' => $identity['title'],
+            'slug' => 'complete-peer-' . $property->id . '-' . uniqid(),
+            'address' => $identity['address'],
+            'description' => $identity['description'],
+        ]);
+
+        return $property->fresh();
+    }
+
+    /** @return list<string> */
+    private function fiveFieldHeaders(): array
+    {
+        return [
+            'عنوان الإعلان *',
+            'العنوان *',
+            'الوصف *',
+            'النوع *',
+            'الصورة الرئيسية *',
+        ];
+    }
+
+    /**
+     * @param  array{title: string, address: string, description: string, property_type: string, featured_image: string}  $identity
+     * @return list<mixed>
+     */
+    private function fiveFieldRow(array $identity): array
+    {
+        return [
+            $identity['title'],
+            $identity['address'],
+            $identity['description'],
+            $identity['property_type'] === 'residential' ? 'سكني' : $identity['property_type'],
+            $identity['featured_image'],
+        ];
+    }
+
+    public function test_import_same_title_address_different_description_creates(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $peerIdentity = [
+            'title' => 'Villa Dup Test A',
+            'address' => 'Street 1 District Test',
+            'description' => 'Original description long enough',
+            'featured_image' => 'https://example.com/img.jpg',
+            'property_type' => 'residential',
+        ];
+        $this->seedCompletePeer($tenant, $language, $peerIdentity);
+
+        $before = Property::where('user_id', $tenant->id)->count();
+
+        $file = $this->makeExcelUpload(
+            $this->fiveFieldHeaders(),
+            [$this->fiveFieldRow(array_merge($peerIdentity, [
+                'description' => 'Different description long enough',
+            ]))],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(0, (int) ($response->json('imported_count') ?? 0), $response->getContent());
+        $this->assertSame($before + 1, Property::where('user_id', $tenant->id)->count());
+    }
+
+    public function test_import_exact_five_field_match_fails_row_but_continues_file(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $peerIdentity = [
+            'title' => 'Exact Match Peer Villa',
+            'address' => 'Match Street Address Here',
+            'description' => 'Matching description text here',
+            'featured_image' => 'https://example.com/match.jpg',
+            'property_type' => 'residential',
+        ];
+        $this->seedCompletePeer($tenant, $language, $peerIdentity);
+
+        $before = Property::where('user_id', $tenant->id)->count();
+
+        $other = [
+            'title' => 'Other Unique Villa Row',
+            'address' => 'Other Street Address Here',
+            'description' => 'Other description text here ok',
+            'featured_image' => 'https://example.com/other.jpg',
+            'property_type' => 'residential',
+        ];
+
+        $file = $this->makeExcelUpload(
+            $this->fiveFieldHeaders(),
+            [
+                $this->fiveFieldRow($peerIdentity),
+                $this->fiveFieldRow($other),
+            ],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(1, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(0, (int) ($response->json('imported_count') ?? 0), $response->getContent());
+        $this->assertSame($before + 1, Property::where('user_id', $tenant->id)->count());
+
+        $created = PropertyContent::where('user_id', $tenant->id)
+            ->where('title', $other['title'])
+            ->first();
+        $this->assertNotNull($created);
+
+        $dupTitles = PropertyContent::where('user_id', $tenant->id)
+            ->where('title', $peerIdentity['title'])
+            ->count();
+        $this->assertSame(1, $dupTitles);
+    }
+
+    public function test_import_two_identical_five_field_rows_second_fails(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant] = $this->actingAsTenantWithCreate();
+
+        $identity = [
+            'title' => 'Twin Row Villa Import',
+            'address' => 'Twin Street Address Here',
+            'description' => 'Twin description text here ok',
+            'featured_image' => 'https://example.com/twin.jpg',
+            'property_type' => 'residential',
+        ];
+
+        $before = Property::where('user_id', $tenant->id)->count();
+        $row = $this->fiveFieldRow($identity);
+
+        $file = $this->makeExcelUpload($this->fiveFieldHeaders(), [$row, $row]);
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(1, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertSame(1, (int) ($response->json('imported_count') ?? 0), $response->getContent());
+        $this->assertSame($before + 1, Property::where('user_id', $tenant->id)->count());
+    }
+
+    public function test_import_invalid_featured_image_url_creates_incomplete_not_duplicate(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $peerIdentity = [
+            'title' => 'Invalid Image Peer Villa',
+            'address' => 'Invalid Image Street Addr',
+            'description' => 'Invalid image peer description',
+            'featured_image' => 'https://example.com/valid.jpg',
+            'property_type' => 'residential',
+        ];
+        $this->seedCompletePeer($tenant, $language, $peerIdentity);
+
+        $before = Property::where('user_id', $tenant->id)->count();
+
+        $file = $this->makeExcelUpload(
+            $this->fiveFieldHeaders(),
+            [$this->fiveFieldRow(array_merge($peerIdentity, [
+                'featured_image' => 'not-a-valid-image-url',
+            ]))],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(0, (int) ($response->json('incomplete_count') ?? 0), $response->getContent());
+        $this->assertSame($before + 1, Property::where('user_id', $tenant->id)->count());
+
+        $created = Property::where('user_id', $tenant->id)->latest('id')->first();
+        $this->assertNotNull($created);
+        $this->assertSame('incomplete', $created->completion_status);
+    }
+
+    public function test_import_casing_whitespace_variant_treated_as_duplicate(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $peerIdentity = [
+            'title' => 'Villa A',
+            'address' => 'Main Street Address',
+            'description' => 'Canonical description text',
+            'featured_image' => 'https://example.com/case.jpg',
+            'property_type' => 'residential',
+        ];
+        $this->seedCompletePeer($tenant, $language, $peerIdentity);
+
+        $before = Property::where('user_id', $tenant->id)->count();
+
+        $file = $this->makeExcelUpload(
+            $this->fiveFieldHeaders(),
+            [$this->fiveFieldRow([
+                'title' => 'villa a ',
+                'address' => '  Main   Street Address  ',
+                'description' => 'Canonical description text',
+                'featured_image' => 'https://example.com/case.jpg',
+                'property_type' => 'residential',
+            ])],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(1, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertSame(0, (int) ($response->json('imported_count') ?? 0), $response->getContent());
+        $this->assertSame($before, Property::where('user_id', $tenant->id)->count());
+    }
 }

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -309,6 +309,60 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $this->assertSame('commercial', $property->property_type);
     }
 
+    public function test_bulk_import_update_via_id_does_not_crash_and_preserves_meta_fields(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant] = $this->actingAsTenantWithCreate();
+
+        // Create an initial property via import (mirrors the create path)
+        $file = $this->makeExcelUpload(
+            ['عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة'],
+            [['شقة أصلية', 500000, 'حي الأصلي الرياض', 'وصف عقار أصلي للاختبار', 'بيع', 'سكني', 100]],
+        );
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], ['Accept' => 'application/json']);
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+
+        $property = Property::where('user_id', $tenant->id)->latest('id')->first();
+        $this->assertNotNull($property);
+
+        // The import template has no SEO meta fields; simulate a value set some other way
+        // (e.g. via the property edit UI) that a re-import must not silently wipe.
+        PropertyContent::where('property_id', $property->id)->update([
+            'meta_keyword' => 'شقة مميزة, عقار الرياض',
+            'meta_description' => 'وصف ميتا مخصص للسيو',
+        ]);
+
+        // Re-import an update row referencing this property's id, as export-for-import round-trips do
+        $updateFile = $this->makeExcelUpload(
+            ['المعرّف', 'عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة'],
+            [[$property->id, 'شقة محدثة', 600000, 'حي محدث الرياض', 'وصف عقار محدث للاختبار', 'بيع', 'سكني', 120]],
+        );
+
+        $updateResponse = $this->post('/api/properties/bulk-import', ['file' => $updateFile], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(
+            200,
+            $updateResponse->status(),
+            'Update-via-id import must not crash (e.g. undefined array key): ' . $updateResponse->getContent()
+        );
+        $this->assertSame(0, (int) ($updateResponse->json('failed_count') ?? 0), $updateResponse->getContent());
+        $this->assertGreaterThan(0, (int) ($updateResponse->json('updated_count') ?? 0), $updateResponse->getContent());
+
+        $property->refresh();
+        $this->assertEquals(600000, (float) $property->price);
+
+        $content = PropertyContent::where('property_id', $property->id)->first();
+        $this->assertNotNull($content);
+        $this->assertSame('شقة محدثة', $content->title);
+        // meta_keyword has no column in the import template at all — must be preserved, not wiped to null
+        $this->assertSame('شقة مميزة, عقار الرياض', $content->meta_keyword);
+        // meta_description is intentionally re-derived from the row's (changed) description
+        $this->assertNotNull($content->meta_description);
+        $this->assertStringContainsString('وصف عقار محدث للاختبار', $content->meta_description);
+    }
+
     public function test_raw_export_numeric_zero_cells_do_not_fail_string_validation(): void
     {
         $this->skipIfMissingSchema();

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -472,4 +472,93 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
             'Raw export fixture should not fail string validation: ' . json_encode($stringErrors, JSON_UNESCAPED_UNICODE)
         );
     }
+
+    public function test_import_ready_shaped_file_is_not_rejected_as_raw_export(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        // Same columns as PropertiesImportReadyExport / blank template (no metadata).
+        $file = $this->makeExcelUpload(
+            [
+                'عنوان الإعلان',
+                'السعر',
+                'العنوان',
+                'الوصف',
+                'الغرض',
+                'النوع',
+                'المساحة',
+                'الصورة الرئيسية',
+            ],
+            [[
+                'عقار من تصدير للاستيراد',
+                250000,
+                'حي النرجس الرياض',
+                'وصف عقار كافٍ لاستيراد ملف تصدير جاهز',
+                'بيع',
+                'سكني',
+                140,
+                'https://example.com/ready.jpg',
+            ]],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $errors = $response->json('errors') ?? [];
+        foreach ($errors as $error) {
+            $message = (string) ($error['error'] ?? '');
+            $this->assertStringNotContainsString('raw Export', $message, $response->getContent());
+            $this->assertStringNotContainsString('raw export', $message, $response->getContent());
+            $this->assertStringNotContainsString('_raw_export', $message, $response->getContent());
+        }
+
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(
+            0,
+            (int) ($response->json('imported_count') ?? 0) + (int) ($response->json('incomplete_count') ?? 0),
+            $response->getContent()
+        );
+    }
+
+    public function test_asterisk_required_headers_map_and_five_fields_create_complete(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant] = $this->actingAsTenantWithCreate();
+
+        $file = $this->makeExcelUpload(
+            [
+                'عنوان الإعلان *',
+                'العنوان *',
+                'الوصف *',
+                'النوع *',
+                'الصورة الرئيسية *',
+            ],
+            [[
+                'شقة مكتملة بالحد الأدنى',
+                'شارع الاختبار حي العليا',
+                'وصف عقار كافٍ لاكتمال الاستيراد بالخمسة',
+                'سكني',
+                'https://example.com/complete.jpg',
+            ]],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(0, (int) ($response->json('imported_count') ?? 0), $response->getContent());
+        $this->assertSame(0, (int) ($response->json('incomplete_count') ?? 0), $response->getContent());
+
+        $property = Property::where('user_id', $tenant->id)->latest('id')->first();
+        $this->assertNotNull($property);
+        $this->assertSame('complete', $property->completion_status);
+        $this->assertSame('residential', $property->property_type);
+
+        $content = PropertyContent::where('property_id', $property->id)->first();
+        $this->assertNotNull($content);
+        $this->assertSame('شقة مكتملة بالحد الأدنى', $content->title);
+    }
 }

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -309,12 +309,12 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $this->assertSame('commercial', $property->property_type);
     }
 
-    public function test_bulk_import_update_via_id_does_not_crash_and_preserves_meta_fields(): void
+    public function test_bulk_import_ignores_id_column_and_creates_instead_of_updating(): void
     {
         $this->skipIfMissingSchema();
         [$tenant] = $this->actingAsTenantWithCreate();
 
-        // Create an initial property via import (mirrors the create path)
+        // Create an initial property via import
         $file = $this->makeExcelUpload(
             ['عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة'],
             [['شقة أصلية', 500000, 'حي الأصلي الرياض', 'وصف عقار أصلي للاختبار', 'بيع', 'سكني', 100]],
@@ -322,45 +322,54 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $response = $this->post('/api/properties/bulk-import', ['file' => $file], ['Accept' => 'application/json']);
         $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
 
-        $property = Property::where('user_id', $tenant->id)->latest('id')->first();
-        $this->assertNotNull($property);
+        $existing = Property::where('user_id', $tenant->id)->latest('id')->first();
+        $this->assertNotNull($existing);
+        $existingId = $existing->id;
+        $existingUpdatedAt = $existing->updated_at?->toDateTimeString();
 
-        // The import template has no SEO meta fields; simulate a value set some other way
-        // (e.g. via the property edit UI) that a re-import must not silently wipe.
-        PropertyContent::where('property_id', $property->id)->update([
+        PropertyContent::where('property_id', $existing->id)->update([
             'meta_keyword' => 'شقة مميزة, عقار الرياض',
             'meta_description' => 'وصف ميتا مخصص للسيو',
         ]);
 
-        // Re-import an update row referencing this property's id, as export-for-import round-trips do
-        $updateFile = $this->makeExcelUpload(
+        // File still includes المعرّف (legacy export-for-import) — must be ignored (create-only)
+        $createFile = $this->makeExcelUpload(
             ['المعرّف', 'عنوان الإعلان', 'السعر', 'العنوان', 'الوصف', 'الغرض', 'النوع', 'المساحة'],
-            [[$property->id, 'شقة محدثة', 600000, 'حي محدث الرياض', 'وصف عقار محدث للاختبار', 'بيع', 'سكني', 120]],
+            [[$existingId, 'شقة جديدة من الاستيراد', 600000, 'حي جديد الرياض', 'وصف عقار جديد للاختبار', 'بيع', 'سكني', 120]],
         );
 
-        $updateResponse = $this->post('/api/properties/bulk-import', ['file' => $updateFile], [
+        $createResponse = $this->post('/api/properties/bulk-import', ['file' => $createFile], [
             'Accept' => 'application/json',
         ]);
 
-        $this->assertSame(
-            200,
-            $updateResponse->status(),
-            'Update-via-id import must not crash (e.g. undefined array key): ' . $updateResponse->getContent()
+        $this->assertContains($createResponse->status(), [200, 422], $createResponse->getContent());
+        $this->assertSame(0, (int) ($createResponse->json('failed_count') ?? 0), $createResponse->getContent());
+        $this->assertSame(0, (int) ($createResponse->json('updated_count') ?? 0), $createResponse->getContent());
+        $this->assertGreaterThan(
+            0,
+            (int) ($createResponse->json('imported_count') ?? 0) + (int) ($createResponse->json('incomplete_count') ?? 0),
+            $createResponse->getContent()
         );
-        $this->assertSame(0, (int) ($updateResponse->json('failed_count') ?? 0), $updateResponse->getContent());
-        $this->assertGreaterThan(0, (int) ($updateResponse->json('updated_count') ?? 0), $updateResponse->getContent());
 
-        $property->refresh();
-        $this->assertEquals(600000, (float) $property->price);
+        $existing->refresh();
+        $this->assertEquals(500000, (float) $existing->price);
+        $this->assertSame($existingUpdatedAt, $existing->updated_at?->toDateTimeString());
 
-        $content = PropertyContent::where('property_id', $property->id)->first();
-        $this->assertNotNull($content);
-        $this->assertSame('شقة محدثة', $content->title);
-        // meta_keyword has no column in the import template at all — must be preserved, not wiped to null
-        $this->assertSame('شقة مميزة, عقار الرياض', $content->meta_keyword);
-        // meta_description is intentionally re-derived from the row's (changed) description
-        $this->assertNotNull($content->meta_description);
-        $this->assertStringContainsString('وصف عقار محدث للاختبار', $content->meta_description);
+        $existingContent = PropertyContent::where('property_id', $existingId)->first();
+        $this->assertNotNull($existingContent);
+        $this->assertSame('شقة أصلية', $existingContent->title);
+        $this->assertSame('شقة مميزة, عقار الرياض', $existingContent->meta_keyword);
+
+        $created = Property::where('user_id', $tenant->id)
+            ->where('id', '!=', $existingId)
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($created);
+        $this->assertEquals(600000, (float) $created->price);
+
+        $createdContent = PropertyContent::where('property_id', $created->id)->first();
+        $this->assertNotNull($createdContent);
+        $this->assertSame('شقة جديدة من الاستيراد', $createdContent->title);
     }
 
     public function test_raw_export_numeric_zero_cells_do_not_fail_string_validation(): void

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -386,8 +386,22 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         ]);
 
         $errors = $response->json('errors') ?? [];
-        $stringErrors = array_filter($errors, function ($error) {
-            return str_contains((string) ($error['error'] ?? ''), 'must be a string');
+        $errorMessages = array_map(
+            static fn ($error) => (string) ($error['error'] ?? ''),
+            $errors
+        );
+        $combined = implode("\n", $errorMessages);
+
+        $this->assertNotEmpty($errors, 'Raw export fixture should be rejected with errors: ' . $response->getContent());
+        $this->assertTrue(
+            str_contains($combined, 'raw Export file')
+                || str_contains($combined, 'raw export file')
+                || str_contains($combined, 'not supported'),
+            'Expected raw-export rejection message, got: ' . json_encode($errorMessages, JSON_UNESCAPED_UNICODE)
+        );
+
+        $stringErrors = array_filter($errorMessages, static function (string $message) {
+            return str_contains($message, 'must be a string');
         });
 
         $this->assertEmpty(

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -308,4 +308,91 @@ class PropertiesBulkImportArabicHeadersTest extends TestCase
         $this->assertSame('rent', $property->purpose);
         $this->assertSame('commercial', $property->property_type);
     }
+
+    public function test_raw_export_numeric_zero_cells_do_not_fail_string_validation(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        $file = $this->makeExcelUpload(
+            [
+                'عنوان الإعلان',
+                'السعر',
+                'العنوان',
+                'الوصف',
+                'الغرض',
+                'النوع',
+                'المساحة',
+                'مميز',
+                'مصعد',
+                'بلكونة',
+                'غرفة خادمة',
+                'غرفة تخزين',
+                'مسبح',
+            ],
+            [
+                [
+                    'عقار من تصدير خام',
+                    100000,
+                    'شارع الاختبار',
+                    'وصف كافي للاستيراد التجريبي',
+                    'بيع',
+                    'سكني',
+                    120,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            ],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        foreach ($response->json('errors') ?? [] as $error) {
+            $this->assertStringNotContainsString(
+                'must be a string',
+                (string) ($error['error'] ?? ''),
+                'Unexpected string validation failure: ' . json_encode($error, JSON_UNESCAPED_UNICODE)
+            );
+        }
+    }
+
+    public function test_user_raw_export_fixture_has_no_string_validation_errors(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        $fixture = base_path('tests/fixtures/properties-export-2026-08-05.xlsx');
+        if (! is_file($fixture)) {
+            $this->markTestSkipped('Fixture tests/fixtures/properties-export-2026-08-05.xlsx not found.');
+        }
+
+        $file = new UploadedFile(
+            $fixture,
+            'properties-export-2026-08-05.xlsx',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            null,
+            true,
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $errors = $response->json('errors') ?? [];
+        $stringErrors = array_filter($errors, function ($error) {
+            return str_contains((string) ($error['error'] ?? ''), 'must be a string');
+        });
+
+        $this->assertEmpty(
+            $stringErrors,
+            'Raw export fixture should not fail string validation: ' . json_encode($stringErrors, JSON_UNESCAPED_UNICODE)
+        );
+    }
 }

--- a/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
+++ b/tests/Feature/Api/PropertiesBulkImportArabicHeadersTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Membership;
+use App\Models\Package;
+use App\Models\User;
+use App\Models\User\Language;
+use App\Models\User\RealestateManagement\Amenity;
+use App\Models\User\RealestateManagement\City;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\PropertyContent;
+use App\Services\MembershipCacheService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\Concerns\EnsuresPropertyStatusColumns;
+use Tests\TestCase;
+
+class PropertiesBulkImportArabicHeadersTest extends TestCase
+{
+    use DatabaseTransactions;
+    use EnsuresPropertyStatusColumns;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensurePropertyStatusColumns();
+    }
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach ([
+            'users',
+            'user_properties',
+            'user_property_contents',
+            'memberships',
+            'packages',
+            'user_languages',
+            'api_permissions',
+            'api_model_has_permissions',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function grantPermissions(User $user, User $tenant, array $permissions): void
+    {
+        if (! Schema::hasTable('api_permissions')) {
+            $this->markTestSkipped('api_permissions table not available.');
+        }
+
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->setPermissionsTeamId((int) $tenant->id);
+        $registrar->forgetCachedPermissions();
+
+        foreach ($permissions as $permissionName) {
+            try {
+                $permission = Permission::findByName($permissionName, 'sanctum');
+            } catch (\Throwable $e) {
+                $permission = Permission::create([
+                    'name' => $permissionName,
+                    'guard_name' => 'sanctum',
+                    'team_id' => $tenant->id,
+                ]);
+            }
+
+            $user->givePermissionTo($permission);
+        }
+
+        $registrar->forgetCachedPermissions();
+    }
+
+    private function seedTenantContext(User $tenant, int $propertyLimit = 100): Language
+    {
+        $package = Package::firstOrCreate(
+            ['title' => 'Bulk Arabic Headers Test Package'],
+            [
+                'slug' => 'bulk-arabic-headers-test-package',
+                'price' => 0,
+                'term' => 'monthly',
+                'status' => 1,
+                'is_active' => 1,
+                'project_limit_number' => 100,
+                'real_estate_limit_number' => $propertyLimit,
+                'serial_number' => 994,
+            ]
+        );
+
+        $package->update(['real_estate_limit_number' => $propertyLimit]);
+
+        $membership = Membership::firstOrNew(['user_id' => $tenant->id]);
+        $membership->status = 1;
+        $membership->start_date = now()->subDay();
+        $membership->expire_date = now()->addMonth();
+        $membership->package_id = $package->id;
+        $membership->price = 0;
+        $membership->currency = 'USD';
+        $membership->currency_symbol = '$';
+        $membership->payment_method = 'test';
+        $membership->transaction_id = 'bulk-ar-headers-' . uniqid();
+        $membership->save();
+
+        MembershipCacheService::clearCache($tenant->id);
+
+        return Language::firstOrCreate(
+            ['user_id' => $tenant->id, 'is_default' => 1],
+            [
+                'name' => 'Arabic',
+                'code' => 'ar',
+                'rtl' => 1,
+            ]
+        );
+    }
+
+    private function actingAsTenantWithCreate(): array
+    {
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $language = $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, $tenant, ['properties.create']);
+        Sanctum::actingAs($tenant);
+
+        return [$tenant, $language];
+    }
+
+    /**
+     * @param  list<string>  $headers
+     * @param  list<list<mixed>>  $rows
+     */
+    private function makeExcelUpload(array $headers, array $rows): UploadedFile
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        foreach ($headers as $i => $header) {
+            $sheet->setCellValueByColumnAndRow($i + 1, 1, $header);
+        }
+
+        foreach ($rows as $rIndex => $row) {
+            foreach ($row as $cIndex => $value) {
+                $sheet->setCellValueByColumnAndRow($cIndex + 1, $rIndex + 2, $value);
+            }
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'xlsx');
+        (new Xlsx($spreadsheet))->save($path);
+
+        return new UploadedFile(
+            $path,
+            'arabic-template.xlsx',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            null,
+            true,
+        );
+    }
+
+    public function test_arabic_template_headers_and_values_import_via_bulk_import(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $cityName = null;
+        if (Schema::hasTable('user_cities')) {
+            try {
+                $city = City::create([
+                    'user_id' => $tenant->id,
+                    'language_id' => $language->id,
+                    'country_id' => null,
+                    'state_id' => null,
+                    'name' => 'الرياض',
+                    'slug' => 'riyadh-ar-import-' . uniqid(),
+                    'featured' => 0,
+                    'status' => 1,
+                    'serial_number' => 1,
+                ]);
+                $cityName = $city->name;
+            } catch (\Throwable $e) {
+                $cityName = null;
+            }
+        }
+
+        if (Schema::hasTable('user_amenities')) {
+            try {
+                Amenity::firstOrCreate(
+                    ['user_id' => $tenant->id, 'name' => 'مصعد'],
+                    [
+                        'language_id' => $language->id,
+                        'slug' => 'msaad-import-' . uniqid(),
+                        'icon' => 'elevator',
+                        'status' => 1,
+                        'serial_number' => 1,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                // Amenity seed is optional; header/value mapping is the assertion target.
+            }
+        }
+
+        $headers = [
+            'عنوان الإعلان',
+            'السعر',
+            'العنوان',
+            'الوصف',
+            'الغرض',
+            'النوع',
+            'المساحة',
+            'مصعد',
+            'أمن',
+        ];
+        $row = [
+            'شقة اختبار عربية',
+            750000,
+            'حي النرجس الرياض',
+            'وصف عقار كامل للاختبار العربي',
+            'بيع',
+            'سكني',
+            150,
+            'نعم',
+            'لا',
+        ];
+
+        if ($cityName !== null) {
+            $headers[] = 'المدينة';
+            $row[] = $cityName;
+        }
+
+        $file = $this->makeExcelUpload($headers, [$row]);
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertContains(
+            $response->status(),
+            [200, 422],
+            'Expected success or partial_success HTTP status, got: ' . $response->status() . ' ' . $response->getContent()
+        );
+
+        $failedCount = (int) ($response->json('failed_count') ?? 0);
+        $this->assertSame(0, $failedCount, 'Arabic purpose/type/amenities should not fail validation: ' . $response->getContent());
+
+        $imported = (int) ($response->json('imported_count') ?? 0);
+        $incomplete = (int) ($response->json('incomplete_count') ?? 0);
+        $this->assertGreaterThan(0, $imported + $incomplete, 'Expected at least one created property');
+
+        $property = Property::where('user_id', $tenant->id)
+            ->where('import_batch_id', '!=', null)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($property);
+        $this->assertSame('sale', $property->purpose);
+        $this->assertSame('residential', $property->property_type);
+        $this->assertEquals(750000, (float) $property->price);
+        $this->assertEquals(150, (float) $property->area);
+
+        $content = PropertyContent::where('property_id', $property->id)->first();
+        $this->assertNotNull($content);
+        $this->assertSame('شقة اختبار عربية', $content->title);
+
+        $missing = $property->missing_fields ?? [];
+        if (is_string($missing)) {
+            $missing = json_decode($missing, true) ?: [];
+        }
+        $this->assertNotContains('title', $missing);
+        $this->assertNotContains('purpose', $missing);
+        $this->assertNotContains('type', $missing);
+        $this->assertNotContains('price', $missing);
+    }
+
+    public function test_arabic_purpose_type_and_amenity_values_do_not_skip_row(): void
+    {
+        $this->skipIfMissingSchema();
+        $this->actingAsTenantWithCreate();
+
+        $file = $this->makeExcelUpload(
+            ['عنوان الإعلان', 'الغرض', 'النوع', 'مصعد', 'السعر'],
+            [
+                ['وحدة إيجار', 'إيجار', 'تجاري', 'نعم', 12000],
+            ],
+        );
+
+        $response = $this->post('/api/properties/bulk-import', ['file' => $file], [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertContains($response->status(), [200, 422]);
+        $this->assertSame(0, (int) ($response->json('failed_count') ?? 0), $response->getContent());
+        $this->assertGreaterThan(
+            0,
+            (int) ($response->json('imported_count') ?? 0) + (int) ($response->json('incomplete_count') ?? 0)
+        );
+
+        $property = Property::query()->latest('id')->first();
+        $this->assertNotNull($property);
+        $this->assertSame('rent', $property->purpose);
+        $this->assertSame('commercial', $property->property_type);
+    }
+}

--- a/tests/Feature/Api/PropertyDraftCompletionIdentityDuplicateTest.php
+++ b/tests/Feature/Api/PropertyDraftCompletionIdentityDuplicateTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Membership;
+use App\Models\Package;
+use App\Models\User;
+use App\Models\User\Language;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\User\RealestateManagement\PropertyContent;
+use App\Services\MembershipCacheService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\Concerns\EnsuresPropertyStatusColumns;
+use Tests\TestCase;
+
+/**
+ * Draft complete must reject when all five completion-identity fields match
+ * another complete property on the same owner. Unlike
+ * PropertyDraftCompletionRequirementsTest (ORPHAN_USER_ID / read-only), this
+ * seeds real DB peers so findExactCompletionDuplicate can match.
+ */
+class PropertyDraftCompletionIdentityDuplicateTest extends TestCase
+{
+    use DatabaseTransactions;
+    use EnsuresPropertyStatusColumns;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensurePropertyStatusColumns();
+    }
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach ([
+            'users',
+            'user_properties',
+            'user_property_contents',
+            'memberships',
+            'packages',
+            'user_languages',
+            'api_permissions',
+            'api_model_has_permissions',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function grantPermissions(User $user, User $tenant, array $permissions): void
+    {
+        if (! Schema::hasTable('api_permissions')) {
+            $this->markTestSkipped('api_permissions table not available.');
+        }
+
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->setPermissionsTeamId((int) $tenant->id);
+        $registrar->forgetCachedPermissions();
+
+        foreach ($permissions as $permissionName) {
+            try {
+                $permission = Permission::findByName($permissionName, 'sanctum');
+            } catch (\Throwable $e) {
+                $permission = Permission::create([
+                    'name' => $permissionName,
+                    'guard_name' => 'sanctum',
+                    'team_id' => $tenant->id,
+                ]);
+            }
+
+            $user->givePermissionTo($permission);
+        }
+
+        $registrar->forgetCachedPermissions();
+    }
+
+    private function seedTenantContext(User $tenant, int $propertyLimit = 100): Language
+    {
+        $package = Package::firstOrCreate(
+            ['title' => 'Draft Completion Identity Dup Package'],
+            [
+                'slug' => 'draft-completion-identity-dup-package',
+                'price' => 0,
+                'term' => 'monthly',
+                'status' => 1,
+                'is_active' => 1,
+                'project_limit_number' => 100,
+                'real_estate_limit_number' => $propertyLimit,
+                'serial_number' => 993,
+            ]
+        );
+
+        $package->update(['real_estate_limit_number' => $propertyLimit]);
+
+        $membership = Membership::firstOrNew(['user_id' => $tenant->id]);
+        $membership->status = 1;
+        $membership->start_date = now()->subDay();
+        $membership->expire_date = now()->addMonth();
+        $membership->package_id = $package->id;
+        $membership->price = 0;
+        $membership->currency = 'USD';
+        $membership->currency_symbol = '$';
+        $membership->payment_method = 'test';
+        $membership->transaction_id = 'draft-identity-dup-' . uniqid();
+        $membership->save();
+
+        MembershipCacheService::clearCache($tenant->id);
+
+        return Language::firstOrCreate(
+            ['user_id' => $tenant->id, 'is_default' => 1],
+            [
+                'name' => 'Arabic',
+                'code' => 'ar',
+                'rtl' => 1,
+            ]
+        );
+    }
+
+    /**
+     * @return array{0: User, 1: Language}
+     */
+    private function actingAsTenantWithCreate(): array
+    {
+        $tenant = User::factory()->create(['account_type' => 'tenant']);
+        $language = $this->seedTenantContext($tenant);
+        $this->grantPermissions($tenant, $tenant, ['properties.create']);
+        Sanctum::actingAs($tenant);
+
+        return [$tenant, $language];
+    }
+
+    /**
+     * @param  array{title: string, address: string, description: string, featured_image: string, property_type: string}  $identity
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPropertyWithIdentity(
+        User $tenant,
+        Language $language,
+        array $identity,
+        string $completionStatus,
+        array $overrides = []
+    ): Property {
+        $property = Property::create(array_merge([
+            'user_id' => $tenant->id,
+            'created_by' => $tenant->id,
+            'price' => 250000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => $completionStatus === 'complete' ? 'published' : 'draft',
+            'property_type' => $identity['property_type'],
+            'area' => 120,
+            'status' => $completionStatus === 'complete' ? 1 : 0,
+            'completion_status' => $completionStatus,
+            'featured' => 0,
+            'featured_image' => $identity['featured_image'],
+            'completed_at' => $completionStatus === 'complete' ? now() : null,
+        ], $overrides));
+
+        PropertyContent::create([
+            'user_id' => $tenant->id,
+            'property_id' => $property->id,
+            'language_id' => $language->id,
+            'title' => $identity['title'],
+            'slug' => 'draft-identity-' . $property->id . '-' . uniqid(),
+            'address' => $identity['address'],
+            'description' => $identity['description'],
+        ]);
+
+        return $property->fresh();
+    }
+
+    /** @return array{title: string, address: string, description: string, featured_image: string, property_type: string} */
+    private function identity(array $overrides = []): array
+    {
+        return array_merge([
+            'title' => 'Draft Identity Villa',
+            'address' => 'Identity Street Address',
+            'description' => 'Identity description long enough',
+            'featured_image' => 'https://example.com/img.jpg',
+            'property_type' => 'residential',
+        ], $overrides);
+    }
+
+    public function test_complete_draft_rejects_when_all_five_match_complete_peer(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $identity = $this->identity([
+            'title' => 'Conflict Peer Villa Exact',
+            'address' => 'Conflict Peer Street Exact',
+            'description' => 'Conflict peer description exact',
+            'featured_image' => 'https://example.com/conflict.jpg',
+        ]);
+
+        $this->createPropertyWithIdentity($tenant, $language, $identity, 'complete');
+        $draft = $this->createPropertyWithIdentity(
+            $tenant,
+            $language,
+            $this->identity(['title' => 'Incomplete Draft Title']),
+            'incomplete',
+            ['featured_image' => null, 'property_type' => null]
+        );
+
+        $response = $this->postJson("/api/properties/drafts/{$draft->id}/complete", $identity);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 'error');
+
+        $conflicts = $response->json('conflicts') ?? [];
+        $this->assertNotEmpty($conflicts, $response->getContent());
+
+        $fields = array_column($conflicts, 'field');
+        $this->assertContains('completion_identity', $fields, $response->getContent());
+
+        $draft->refresh();
+        $this->assertSame('incomplete', $draft->completion_status);
+    }
+
+    public function test_complete_draft_succeeds_when_one_identity_field_differs(): void
+    {
+        $this->skipIfMissingSchema();
+        [$tenant, $language] = $this->actingAsTenantWithCreate();
+
+        $peerIdentity = $this->identity([
+            'title' => 'Success Peer Villa Exact',
+            'address' => 'Success Peer Street Exact',
+            'description' => 'Success peer description exact',
+            'featured_image' => 'https://example.com/success-peer.jpg',
+        ]);
+        $this->createPropertyWithIdentity($tenant, $language, $peerIdentity, 'complete');
+
+        $draft = $this->createPropertyWithIdentity(
+            $tenant,
+            $language,
+            $this->identity(['title' => 'Draft Waiting Complete']),
+            'incomplete',
+            ['featured_image' => null, 'property_type' => null]
+        );
+
+        $payload = array_merge($peerIdentity, [
+            'description' => 'Different description for draft ok',
+        ]);
+
+        $response = $this->postJson("/api/properties/drafts/{$draft->id}/complete", $payload);
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'success');
+
+        $draft->refresh();
+        $this->assertSame('complete', $draft->completion_status);
+        $this->assertSame($payload['featured_image'], $draft->featured_image);
+        $this->assertSame('residential', $draft->property_type);
+
+        $content = PropertyContent::where('property_id', $draft->id)->first();
+        $this->assertNotNull($content);
+        $this->assertSame($payload['title'], $content->title);
+        $this->assertSame($payload['description'], $content->description);
+    }
+}

--- a/tests/Feature/Api/PropertyRequestMapTest.php
+++ b/tests/Feature/Api/PropertyRequestMapTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Api\UserPropertyRequest;
 use App\Models\User;
+use App\Models\User\RealestateManagement\Project;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
 use App\Models\User\UserCity;
@@ -34,6 +35,35 @@ class PropertyRequestMapTest extends TestCase
         if (! Schema::hasColumn('users_property_requests', 'initial_property_id')) {
             $this->markTestSkipped('initial_property_id column required. Run migration.');
         }
+    }
+
+    private function skipIfMissingProjectIdColumn(): void
+    {
+        $this->skipIfMissingSchema();
+
+        if (! Schema::hasTable('user_projects')) {
+            $this->markTestSkipped('user_projects table required.');
+        }
+
+        if (! Schema::hasColumn('users_property_requests', 'project_id')) {
+            $this->markTestSkipped('project_id column required on users_property_requests. Run migration.');
+        }
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
     }
 
     private function grantPermissions(User $tenant, array $permissions): void
@@ -279,6 +309,91 @@ class PropertyRequestMapTest extends TestCase
             'id' => $requestId,
             'initial_property_id' => $property->id,
             'source' => 'property_interest',
+        ]);
+    }
+
+    public function test_store_from_interest_inherits_project_id_from_property_when_omitted(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        $project = $this->createProject($tenant);
+        $property = $this->createProperty($tenant, ['project_id' => $project->id]);
+
+        $response = $this->postJson('/api/v1/property-requests/interest', [
+            'tenant_username' => $tenant->username,
+            'property_id' => $property->id,
+            'full_name' => 'Interest Inherit Project',
+            'phone' => '+966501112244',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.property_id', $property->id)
+            ->assertJsonMissingPath('data.project_id');
+
+        $requestId = (int) $response->json('data.request_id');
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'initial_property_id' => $property->id,
+            'project_id' => $project->id,
+            'source' => 'property_interest',
+        ]);
+    }
+
+    public function test_store_from_interest_body_project_id_overrides_property_project(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        $propertyProject = $this->createProject($tenant);
+        $overrideProject = $this->createProject($tenant);
+        $property = $this->createProperty($tenant, ['project_id' => $propertyProject->id]);
+
+        $response = $this->postJson('/api/v1/property-requests/interest', [
+            'tenant_username' => $tenant->username,
+            'property_id' => $property->id,
+            'full_name' => 'Interest Override Project',
+            'phone' => '+966501112255',
+            'project_id' => $overrideProject->id,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonMissingPath('data.project_id');
+
+        $requestId = (int) $response->json('data.request_id');
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => $overrideProject->id,
+            'source' => 'property_interest',
+        ]);
+    }
+
+    public function test_public_store_with_valid_project_id_persists(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        $city = UserCity::query()->first();
+        if (! $city) {
+            $this->markTestSkipped('user_cities must have at least one row.');
+        }
+        $project = $this->createProject($tenant);
+
+        $response = $this->postJson('/api/v1/property-requests/public', [
+            'tenant_username' => $tenant->username,
+            'full_name' => 'Public Project User',
+            'phone' => '+966502223355',
+            'region' => $city->id,
+            'project_id' => $project->id,
+        ]);
+
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $response->json('data.id'),
+            'user_id' => $tenant->id,
+            'project_id' => $project->id,
+            'source' => 'public_form',
         ]);
     }
 

--- a/tests/Feature/Api/StepsProgressApiTest.php
+++ b/tests/Feature/Api/StepsProgressApiTest.php
@@ -1,0 +1,589 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Api\ApiDomainSetting;
+use App\Models\Api\FooterSetting;
+use App\Models\Api\marketing\MarketingChannel;
+use App\Models\User;
+use App\Models\User\BasicSetting;
+use App\Models\User\RealestateManagement\Property;
+use App\Models\UserStep;
+use App\Models\WhatsappUser;
+use App\Services\SiteSetupProgressService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class StepsProgressApiTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach ([
+            'users',
+            'user_steps',
+            'user_basic_settings',
+            'api_footer_settings',
+            'user_properties',
+            'whatsapp_users',
+            'marketing_channels',
+            'api_domains_settings',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    private function createTenant(array $overrides = []): User
+    {
+        return User::factory()->tenant()->create(array_merge([
+            'email' => 'steps-' . uniqid('', true) . '@example.com',
+            'username' => 'steps' . substr(md5(uniqid('', true)), 0, 10),
+            'onboarding_completed' => false,
+        ], $overrides));
+    }
+
+    private function createEmployeeFor(User $tenant, array $overrides = []): User
+    {
+        return User::factory()->employee()->create(array_merge([
+            'tenant_id' => $tenant->id,
+            'email' => 'emp-' . uniqid('', true) . '@example.com',
+            'username' => 'emp' . substr(md5(uniqid('', true)), 0, 10),
+        ], $overrides));
+    }
+
+    private function seedPlaceholderContact(User $owner): void
+    {
+        FooterSetting::create([
+            'user_id' => $owner->id,
+            'general' => [
+                'phone' => '+966 5XXXXXXXX',
+                'email' => 'info@example.com',
+            ],
+            'social' => [],
+            'columns' => [],
+            'newsletter' => [],
+            'style' => [],
+            'status' => true,
+        ]);
+
+        BasicSetting::create([
+            'user_id' => $owner->id,
+            'email' => 'info@example.com',
+        ]);
+    }
+
+    private function seedRealContact(User $owner): void
+    {
+        FooterSetting::updateOrCreate(
+            ['user_id' => $owner->id],
+            [
+                'general' => [
+                    'phone' => '+966 512345678',
+                    'email' => 'office@realestate.test',
+                ],
+                'social' => [],
+                'columns' => [],
+                'newsletter' => [],
+                'style' => [],
+                'status' => true,
+            ]
+        );
+
+        BasicSetting::updateOrCreate(
+            ['user_id' => $owner->id],
+            ['email' => 'office@realestate.test']
+        );
+    }
+
+    private function assertProgressShape(array $json): void
+    {
+        $this->assertArrayHasKey('progress', $json);
+        $this->assertArrayHasKey('done', $json);
+        $this->assertArrayHasKey('total', $json);
+        $this->assertArrayHasKey('headline_key', $json);
+        $this->assertArrayHasKey('dismissed', $json);
+        $this->assertArrayHasKey('steps', $json);
+        $this->assertFalse($json['dismissed']);
+        $this->assertSame(5, $json['total']);
+        $this->assertIsFloat((float) $json['progress']);
+        $this->assertSame(
+            (float) $json['done'] / 5,
+            (float) $json['progress']
+        );
+
+        $ids = array_column($json['steps'], 'id');
+        $this->assertSame(
+            ['site_identity', 'contact_info', 'first_property', 'integrated_link', 'connect_site'],
+            $ids
+        );
+
+        foreach ($json['steps'] as $index => $step) {
+            $this->assertArrayHasKey('locked', $step);
+            $this->assertFalse($step['locked']);
+            $this->assertArrayHasKey('href', $step);
+            $this->assertArrayHasKey('status', $step);
+            $this->assertArrayHasKey('label_ar', $step);
+            $this->assertSame($index + 1, $step['order']);
+
+            if ($step['status'] === true) {
+                $this->assertNull($step['href']);
+            } elseif ($step['id'] !== 'site_identity') {
+                $this->assertNotNull($step['href']);
+            }
+        }
+
+        $this->assertSame(4, $json['steps'][3]['order']);
+        $this->assertSame('integrated_link', $json['steps'][3]['id']);
+        $this->assertSame(5, $json['steps'][4]['order']);
+        $this->assertSame('connect_site', $json['steps'][4]['id']);
+    }
+
+    private function stepStatus(array $json, string $id): bool
+    {
+        foreach ($json['steps'] as $step) {
+            if ($step['id'] === $id) {
+                return (bool) $step['status'];
+            }
+        }
+
+        $this->fail("Step {$id} missing from response");
+    }
+
+    public function test_get_progress_returns_fe_shape_and_start_headline(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $response = $this->getJson('/api/steps/progress');
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertProgressShape($json);
+        $this->assertSame(0, $json['done']);
+        $this->assertSame('start', $json['headline_key']);
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+    }
+
+    public function test_placeholders_keep_contact_info_incomplete(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => false]);
+        $this->seedPlaceholderContact($tenant);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+    }
+
+    public function test_site_identity_from_onboarding_completed(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'site_identity'));
+        $this->assertSame(1, $json['done']);
+        $this->assertSame('early', $json['headline_key']);
+    }
+
+    public function test_contact_info_from_real_company_phone_and_email(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $this->seedRealContact($tenant);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'contact_info'));
+        $contact = collect($json['steps'])->firstWhere('id', 'contact_info');
+        $this->assertNull($contact['href']);
+    }
+
+    public function test_first_property_from_draft_property_count(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'price' => 100000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'test.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'first_property'));
+    }
+
+    public function test_integrated_link_from_whatsapp_users_active(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'number' => '966500000001',
+            'name' => 'WA',
+            'status' => 'active',
+            'request_status' => 'active',
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'integrated_link'));
+    }
+
+    public function test_integrated_link_from_marketing_channel_connected(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        MarketingChannel::create([
+            'user_id' => $tenant->id,
+            'name' => 'WhatsApp',
+            'type' => MarketingChannel::TYPE_WHATSAPP,
+            'number' => '966500000002',
+            'is_connected' => true,
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'integrated_link'));
+    }
+
+    public function test_connect_site_from_active_domain(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'active-' . uniqid('', true) . '.example.com',
+            'status' => 'active',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'pending-' . uniqid('', true) . '.example.com',
+            'status' => 'pending',
+            'primary' => false,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'connect_site'));
+    }
+
+    public function test_pending_domain_does_not_complete_connect_site(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'only-pending-' . uniqid('', true) . '.example.com',
+            'status' => 'pending',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+        Sanctum::actingAs($tenant);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'connect_site'));
+    }
+
+    public function test_headline_key_buckets(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $service = app(SiteSetupProgressService::class);
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($tenant);
+
+        $progress = $service->getProgress($tenant);
+        $this->assertSame(2, $progress['done']);
+        $this->assertSame('mid', $progress['headline_key']);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'price' => 1,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 't.jpg',
+            'property_type' => 'apartment',
+        ]);
+        WhatsappUser::create([
+            'user_id' => $tenant->id,
+            'number' => '966500000099',
+            'name' => 'WA',
+            'status' => 'active',
+            'request_status' => 'active',
+        ]);
+
+        $progress = $service->getProgress($tenant->fresh());
+        $this->assertSame(4, $progress['done']);
+        $this->assertSame('almost', $progress['headline_key']);
+
+        ApiDomainSetting::create([
+            'user_id' => $tenant->id,
+            'custom_name' => 'done-' . uniqid('', true) . '.example.com',
+            'status' => 'active',
+            'primary' => true,
+            'ssl' => false,
+            'added_date' => now(),
+        ]);
+
+        $progress = $service->getProgress($tenant->fresh());
+        $this->assertSame(5, $progress['done']);
+        $this->assertSame('done', $progress['headline_key']);
+        $this->assertSame(1.0, (float) $progress['progress']);
+    }
+
+    public function test_employee_sees_owner_progress(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($tenant);
+        $employee = $this->createEmployeeFor($tenant);
+
+        Sanctum::actingAs($employee);
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertTrue($this->stepStatus($json, 'site_identity'));
+        $this->assertTrue($this->stepStatus($json, 'contact_info'));
+        $this->assertSame(2, $json['done']);
+    }
+
+    public function test_post_first_property_writes_owner_properties_flag(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/steps/complete', ['step' => 'first_property']);
+
+        $response->assertOk()
+            ->assertJsonPath('message', 'Step marked as completed.')
+            ->assertJsonStructure(['progress', 'done', 'total', 'headline_key', 'dismissed', 'steps']);
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertProgressShape($response->json());
+    }
+
+    public function test_post_legacy_properties_maps_to_first_property_flag(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $this->postJson('/api/steps/complete', ['step' => 'properties'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+    }
+
+    public function test_post_contact_info_writes_contacts_social_info(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $this->postJson('/api/steps/complete', ['step' => 'contact_info'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('contacts_social_info')
+        );
+    }
+
+    public function test_post_noop_steps_do_not_write_user_steps_columns(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        foreach (['site_identity', 'integrated_link', 'connect_site'] as $step) {
+            $response = $this->postJson('/api/steps/complete', ['step' => $step]);
+            $response->assertOk();
+            $this->assertProgressShape($response->json());
+        }
+
+        $row = UserStep::where('user_id', $tenant->id)->first();
+        if ($row) {
+            $this->assertFalse((bool) $row->properties);
+            $this->assertFalse((bool) $row->contacts_social_info);
+        }
+    }
+
+    public function test_post_legacy_steps_return_422(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        foreach (['banner', 'footer', 'homepage_about_update', 'menu_builder', 'projects'] as $step) {
+            $this->postJson('/api/steps/complete', ['step' => $step])
+                ->assertStatus(422);
+        }
+    }
+
+    public function test_employee_post_writes_owner_user_steps_row(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $employee = $this->createEmployeeFor($tenant);
+        Sanctum::actingAs($employee);
+
+        $this->postJson('/api/steps/complete', ['step' => 'first_property'])
+            ->assertOk();
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertFalse(
+            UserStep::where('user_id', $employee->id)->where('properties', true)->exists()
+        );
+    }
+
+    public function test_property_create_syncs_owner_properties_flag_only(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $employee = $this->createEmployeeFor($tenant);
+
+        Property::create([
+            'user_id' => $tenant->id,
+            'created_by' => $employee->id,
+            'price' => 50000,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'obs.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+        $this->assertFalse(
+            UserStep::where('user_id', $employee->id)->where('properties', true)->exists()
+        );
+
+        // Early-return path: already true should not throw.
+        app(SiteSetupProgressService::class)->syncPropertiesFlag($tenant);
+        $this->assertTrue(
+            (bool) UserStep::where('user_id', $tenant->id)->value('properties')
+        );
+    }
+
+    public function test_owner_null_employee_fails_closed_with_403(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $employee = User::factory()->employee()->create([
+            'tenant_id' => 0,
+            'email' => 'orphan-' . uniqid('', true) . '@example.com',
+            'username' => 'orphan' . substr(md5(uniqid('', true)), 0, 8),
+        ]);
+
+        Sanctum::actingAs($employee);
+
+        $this->getJson('/api/steps/progress')->assertStatus(403);
+        $this->postJson('/api/steps/complete', ['step' => 'contact_info'])->assertStatus(403);
+    }
+
+    public function test_tenant_scoping_does_not_leak_other_owner_progress(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $ownerA = $this->createTenant(['onboarding_completed' => true]);
+        $this->seedRealContact($ownerA);
+        Property::create([
+            'user_id' => $ownerA->id,
+            'price' => 1,
+            'purpose' => 'sale',
+            'listing_purpose' => 'sale',
+            'unit_status' => 'available',
+            'publish_status' => 'draft',
+            'status' => 0,
+            'featured_image' => 'a.jpg',
+            'property_type' => 'apartment',
+        ]);
+
+        $ownerB = $this->createTenant(['onboarding_completed' => false]);
+        Sanctum::actingAs($ownerB);
+
+        $json = $this->getJson('/api/steps/progress')->assertOk()->json();
+
+        $this->assertFalse($this->stepStatus($json, 'site_identity'));
+        $this->assertFalse($this->stepStatus($json, 'contact_info'));
+        $this->assertFalse($this->stepStatus($json, 'first_property'));
+        $this->assertSame(0, $json['done']);
+    }
+
+    public function test_complete_onboarding_step_request_enums_match_openapi(): void
+    {
+        $request = new \App\Http\Requests\Api\Onboarding\CompleteOnboardingStepRequest();
+        $rule = $request->rules()['step'];
+        $this->assertIsString($rule);
+        $this->assertStringContainsString('site_identity', $rule);
+        $this->assertStringContainsString('contact_info', $rule);
+        $this->assertStringContainsString('first_property', $rule);
+        $this->assertStringContainsString('integrated_link', $rule);
+        $this->assertStringContainsString('connect_site', $rule);
+        $this->assertStringContainsString('properties', $rule);
+        $this->assertStringNotContainsString('banner', $rule);
+    }
+}

--- a/tests/Feature/Api/StoreCustomerTypeIdTest.php
+++ b/tests/Feature/Api/StoreCustomerTypeIdTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Api\UserApiCustomerType;
+use App\Models\ApiCustomer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class StoreCustomerTypeIdTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function skipIfMissingSchema(): void
+    {
+        foreach (['users', 'api_customers', 'users_api_customers_types'] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+
+        $this->ensureNewLeadHubStage();
+    }
+
+    private function ensureNewLeadHubStage(): void
+    {
+        if (! Schema::hasTable('customers_hub_stages')) {
+            return;
+        }
+
+        if (DB::table('customers_hub_stages')->where('stage_id', 'new_lead')->exists()) {
+            return;
+        }
+
+        $row = [
+            'stage_id' => 'new_lead',
+            'stage_name_ar' => 'عميل جديد',
+            'stage_name_en' => 'New Lead',
+            'color' => '#3b82f6',
+            'order' => 1,
+            'description' => 'Initial inquiry from any source',
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (Schema::hasColumn('customers_hub_stages', 'user_id')) {
+            $row['user_id'] = null;
+        }
+        if (Schema::hasColumn('customers_hub_stages', 'is_system')) {
+            $row['is_system'] = true;
+        }
+
+        DB::table('customers_hub_stages')->insert($row);
+    }
+
+    private function createTenant(): User
+    {
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'tenant_id' => null,
+        ]);
+
+        // Tenants are seeded with the default CRM types on creation; these tests
+        // drive the type set explicitly, so start from a clean slate.
+        UserApiCustomerType::where('user_id', $tenant->id)->delete();
+        Cache::forget("customer_defaults:{$tenant->id}");
+
+        return $tenant;
+    }
+
+    private function createType(User $owner, array $overrides = []): UserApiCustomerType
+    {
+        return UserApiCustomerType::create(array_merge([
+            'user_id' => $owner->id,
+            'name' => 'Lead',
+            'value' => 'lead_' . uniqid(),
+            'color' => '#ccc',
+            'icon' => '',
+            'order' => 1,
+            'is_active' => true,
+        ], $overrides));
+    }
+
+    /** @test */
+    public function store_omitting_type_id_uses_first_active_type_by_order(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Cache::forget("customer_defaults:{$tenant->id}");
+
+        $second = $this->createType($tenant, [
+            'name' => 'Second',
+            'value' => 'second_' . uniqid(),
+            'order' => 20,
+        ]);
+        $first = $this->createType($tenant, [
+            'name' => 'First',
+            'value' => 'first_' . uniqid(),
+            'order' => 1,
+        ]);
+        $this->createType($tenant, [
+            'name' => 'Inactive',
+            'value' => 'inactive_' . uniqid(),
+            'order' => 0,
+            'is_active' => false,
+        ]);
+
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/customers', [
+            'name' => 'Default Type Customer',
+            'phone_number' => '+9665' . random_int(10000000, 99999999),
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('status', 'success')
+            ->assertJsonPath('data.type_id', $first->id);
+
+        $this->assertNotEquals($second->id, $response->json('data.type_id'));
+
+        $this->assertDatabaseHas('api_customers', [
+            'id' => $response->json('data.id'),
+            'type_id' => $first->id,
+            'user_id' => $tenant->id,
+        ]);
+    }
+
+    /** @test */
+    public function store_falls_back_to_direct_lookup_when_cached_default_is_null(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+
+        // Simulate defaults warmed before the tenant's CRM types were seeded.
+        Cache::put("customer_defaults:{$tenant->id}", [
+            'type_id' => null,
+            'priority_id' => null,
+            'procedure_id' => null,
+        ], now()->addMinutes(5));
+
+        $type = $this->createType($tenant, [
+            'name' => 'Seeded Later',
+            'value' => 'seeded_later_' . uniqid(),
+            'order' => 1,
+        ]);
+
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/customers', [
+            'name' => 'Stale Cache Customer',
+            'phone_number' => '+9665' . random_int(10000000, 99999999),
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.type_id', $type->id);
+    }
+
+    /** @test */
+    public function store_with_invalid_type_id_returns_422(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        $other = $this->createTenant();
+        $foreignType = $this->createType($other);
+
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/customers', [
+            'name' => 'Bad Type Customer',
+            'phone_number' => '+9665' . random_int(10000000, 99999999),
+            'type_id' => $foreignType->id,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 'error')
+            ->assertJsonValidationErrors(['type_id'], 'errors');
+
+        $this->assertSame(0, ApiCustomer::where('user_id', $tenant->id)->where('name', 'Bad Type Customer')->count());
+    }
+
+    /** @test */
+    public function store_with_valid_type_id_uses_provided_value(): void
+    {
+        $this->skipIfMissingSchema();
+
+        $tenant = $this->createTenant();
+        Cache::forget("customer_defaults:{$tenant->id}");
+
+        $defaultType = $this->createType($tenant, [
+            'name' => 'Default',
+            'value' => 'default_' . uniqid(),
+            'order' => 1,
+        ]);
+        $chosenType = $this->createType($tenant, [
+            'name' => 'Chosen',
+            'value' => 'chosen_' . uniqid(),
+            'order' => 5,
+        ]);
+
+        Sanctum::actingAs($tenant);
+
+        $response = $this->postJson('/api/customers', [
+            'name' => 'Explicit Type Customer',
+            'phone_number' => '+9665' . random_int(10000000, 99999999),
+            'type_id' => $chosenType->id,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('status', 'success')
+            ->assertJsonPath('data.type_id', $chosenType->id);
+
+        $this->assertNotEquals($defaultType->id, $response->json('data.type_id'));
+    }
+}

--- a/tests/Feature/E2E/PropertyRequestWithPropertyIdsTest.php
+++ b/tests/Feature/E2E/PropertyRequestWithPropertyIdsTest.php
@@ -6,10 +6,52 @@ namespace Tests\Feature\E2E;
 
 use App\Models\User;
 use App\Models\User\UserCity;
+use App\Models\User\RealestateManagement\Project;
 use App\Models\User\RealestateManagement\Property;
+use Illuminate\Support\Facades\Schema;
 
 class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
 {
+    private function skipIfMissingProjectIdColumn(): void
+    {
+        if (! Schema::hasColumn('users_property_requests', 'project_id')) {
+            $this->markTestSkipped('project_id column required on users_property_requests. Run migration.');
+        }
+        if (! Schema::hasTable('user_projects')) {
+            $this->markTestSkipped('user_projects table required.');
+        }
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
+    }
+
+    private function loginAs(User $tenant): string
+    {
+        $this->fakeRecaptcha();
+
+        $login = $this->postJson('/api/login', [
+            'recaptcha_token' => 'fake',
+            'email' => $tenant->email,
+            'password' => 'password',
+        ]);
+        $login->assertOk();
+
+        return (string) $login->json('token');
+    }
+
     /** @test */
     public function create_property_request_without_property_ids_still_works(): void
     {
@@ -23,13 +65,7 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
         $city = UserCity::first();
         $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
 
-        $login = $this->postJson('/api/login', [
-            'recaptcha_token' => 'fake',
-            'email' => $tenant->email,
-            'password' => 'password',
-        ]);
-        $login->assertOk();
-        $token = $login->json('token');
+        $token = $this->loginAs($tenant);
 
         $response = $this->withHeader('Authorization', 'Bearer ' . $token)
             ->postJson('/api/v1/property-requests', [
@@ -62,13 +98,7 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
             'user_id' => $tenant->id,
         ]);
 
-        $login = $this->postJson('/api/login', [
-            'recaptcha_token' => 'fake',
-            'email' => $tenant->email,
-            'password' => 'password',
-        ]);
-        $login->assertOk();
-        $token = $login->json('token');
+        $token = $this->loginAs($tenant);
 
         $response = $this->withHeader('Authorization', 'Bearer ' . $token)
             ->postJson('/api/v1/property-requests', [
@@ -105,13 +135,7 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
             'user_id' => $otherTenant->id,
         ]);
 
-        $login = $this->postJson('/api/login', [
-            'recaptcha_token' => 'fake',
-            'email' => $tenant->email,
-            'password' => 'password',
-        ]);
-        $login->assertOk();
-        $token = $login->json('token');
+        $token = $this->loginAs($tenant);
 
         $response = $this->withHeader('Authorization', 'Bearer ' . $token)
             ->postJson('/api/v1/property-requests', [
@@ -123,6 +147,171 @@ class PropertyRequestWithPropertyIdsTest extends ApiE2ETestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['property_ids']);
+    }
+
+    /** @test */
+    public function create_property_request_with_valid_project_id_persists(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-valid-project',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $project = $this->createProject($tenant);
+        $token = $this->loginAs($tenant);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'With Project ID',
+                'phone' => '+966500000011',
+                'region' => $city->id,
+                'project_id' => $project->id,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.project_id', $project->id);
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $response->json('data.id'),
+            'user_id' => $tenant->id,
+            'project_id' => $project->id,
+        ]);
+    }
+
+    /** @test */
+    public function create_property_request_with_foreign_project_id_fails(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-foreign-project',
+        ]);
+
+        $otherTenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-foreign-project-other',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $foreignProject = $this->createProject($otherTenant);
+        $token = $this->loginAs($tenant);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'Foreign Project ID',
+                'phone' => '+966500000012',
+                'region' => $city->id,
+                'project_id' => $foreignProject->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['project_id']);
+    }
+
+    /** @test */
+    public function create_property_request_normalizes_empty_string_project_id_to_null(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-empty-project',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $token = $this->loginAs($tenant);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'Empty Project ID',
+                'phone' => '+966500000013',
+                'region' => $city->id,
+                'project_id' => '',
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $response->json('data.id'),
+            'user_id' => $tenant->id,
+            'project_id' => null,
+        ]);
+    }
+
+    /** @test */
+    public function update_property_request_can_set_and_clear_project_id(): void
+    {
+        $this->skipIfMissingProjectIdColumn();
+
+        $tenant = User::factory()->create([
+            'account_type' => 'tenant',
+            'username' => 'e2e-tenant-pr-update-project',
+        ]);
+
+        $city = UserCity::first();
+        $this->assertNotNull($city, 'Test DB should have at least one user_cities row');
+
+        $project = $this->createProject($tenant);
+        $token = $this->loginAs($tenant);
+
+        $create = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/property-requests', [
+                'full_name' => 'Update Project ID',
+                'phone' => '+966500000014',
+                'region' => $city->id,
+            ]);
+        $create->assertStatus(201);
+        $requestId = (int) $create->json('data.id');
+
+        $set = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => $project->id,
+            ]);
+        $set->assertOk()
+            ->assertJsonPath('data.project_id', $project->id);
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => $project->id,
+        ]);
+
+        $clear = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => null,
+            ]);
+        $clear->assertOk();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => null,
+        ]);
+
+        $emptyString = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => $project->id,
+            ]);
+        $emptyString->assertOk();
+
+        $normalize = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/property-requests/' . $requestId, [
+                'project_id' => '',
+            ]);
+        $normalize->assertOk();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => null,
+        ]);
     }
 }
 

--- a/tests/Feature/PropertyDraftCompletionRequirementsTest.php
+++ b/tests/Feature/PropertyDraftCompletionRequirementsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User\RealestateManagement\Property;
+use App\Services\PropertyConflictDetectionService;
+use App\Support\PropertyCompletionRequirements;
+use Tests\TestCase;
+
+/**
+ * Draft completion is gated on five fields only:
+ * title, address, description, featured_image, property_type.
+ *
+ * price / purpose / area are optional — supplying them is validated for format,
+ * omitting them must not block completion. Read-only: no rows are created.
+ */
+class PropertyDraftCompletionRequirementsTest extends TestCase
+{
+    /** A user id no fixture uses, so the duplicate lookup can never match. */
+    private const ORPHAN_USER_ID = 999999999;
+
+    private function draft(): Property
+    {
+        $property = new Property();
+        $property->user_id = self::ORPHAN_USER_ID;
+
+        return $property;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function completeData(array $overrides = []): array
+    {
+        return array_merge([
+            'title' => 'شقة فاخرة في القلب التجاري',
+            'address' => 'شارع الملك فهد، حي العليا',
+            'description' => 'شقة ثلاث غرف نوم بإطلالة مدينة ومصعد وأمن',
+            'featured_image' => 'https://example.com/img1.jpg',
+            'property_type' => 'residential',
+        ], $overrides);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function errors(array $data): array
+    {
+        $conflicts = (new PropertyConflictDetectionService())->detectConflicts($this->draft(), $data);
+
+        return array_values(array_filter($conflicts, fn ($c) => $c['severity'] === 'error'));
+    }
+
+    /** @test */
+    public function the_five_required_fields_are_enough_to_complete(): void
+    {
+        $this->assertSame([], $this->errors($this->completeData()));
+    }
+
+    /** @test */
+    public function price_purpose_and_area_are_not_required(): void
+    {
+        // The regression this guards: these three used to be required, so a
+        // draft carrying only the five could never be completed.
+        $errors = $this->errors($this->completeData([
+            'price' => null,
+            'purpose' => null,
+            'area' => null,
+        ]));
+
+        $this->assertSame([], $errors);
+    }
+
+    /** @test */
+    public function blank_optional_values_are_treated_as_absent_not_invalid(): void
+    {
+        // Empty strings survive isset(), so they used to trip the format checks.
+        $errors = $this->errors($this->completeData([
+            'price' => '',
+            'area' => '',
+            'purpose' => '',
+        ]));
+
+        $this->assertSame([], $errors);
+    }
+
+    /** @test */
+    public function a_missing_featured_image_blocks_completion(): void
+    {
+        $errors = $this->errors($this->completeData(['featured_image' => null]));
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('missing_fields', $errors[0]['type']);
+        $this->assertSame(['featured_image'], $errors[0]['fields']);
+    }
+
+    /** @test */
+    public function a_missing_property_type_blocks_completion(): void
+    {
+        $errors = $this->errors($this->completeData(['property_type' => null]));
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(['property_type'], $errors[0]['fields']);
+    }
+
+    /** @test */
+    public function the_legacy_type_key_still_satisfies_property_type(): void
+    {
+        $data = $this->completeData();
+        unset($data['property_type']);
+        $data['type'] = 'residential';
+
+        $this->assertSame([], $this->errors($data));
+    }
+
+    /** @test */
+    public function all_four_canonical_property_types_are_accepted(): void
+    {
+        foreach (['residential', 'commercial', 'agricultural', 'industrial'] as $type) {
+            $errors = $this->errors($this->completeData(['property_type' => $type]));
+            $this->assertSame([], $errors, "Type '{$type}' should be accepted");
+        }
+    }
+
+    /** @test */
+    public function an_unknown_property_type_is_rejected(): void
+    {
+        $errors = $this->errors($this->completeData(['property_type' => 'spaceship']));
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('property_type', $errors[0]['field']);
+    }
+
+    /** @test */
+    public function a_supplied_but_malformed_optional_value_is_still_rejected(): void
+    {
+        $errors = $this->errors($this->completeData(['price' => 'not-a-number']));
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('price', $errors[0]['field']);
+    }
+
+    /** @test */
+    public function a_blank_required_field_is_reported_once_not_twice(): void
+    {
+        // '' would fail both the missing check and the length check; only the
+        // missing check should fire.
+        $errors = $this->errors($this->completeData(['title' => '   ']));
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('missing_fields', $errors[0]['type']);
+        $this->assertSame(['title'], $errors[0]['fields']);
+    }
+
+    /** @test */
+    public function arabic_titles_are_measured_in_characters_not_bytes(): void
+    {
+        // 200 Arabic chars = 400 bytes; strlen() would have rejected this as >255.
+        $errors = $this->errors($this->completeData(['title' => str_repeat('ش', 200)]));
+
+        $this->assertSame([], $errors);
+    }
+
+    /** @test */
+    public function missing_fields_are_reported_as_canonical_english_keys(): void
+    {
+        $this->assertSame(
+            ['title', 'address', 'description', 'featured_image', 'property_type'],
+            PropertyCompletionRequirements::missingFrom([])
+        );
+    }
+}

--- a/tests/Feature/PropertyExcelHeaderAsteriskTest.php
+++ b/tests/Feature/PropertyExcelHeaderAsteriskTest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\PropertyExcelHeaderMapping;
+use Tests\TestCase;
+
+class PropertyExcelHeaderAsteriskTest extends TestCase
+{
+    /**
+     * Test that Arabic headers with trailing asterisk map correctly.
+     */
+    public function test_arabic_header_with_asterisk_space()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('عنوان الإعلان *');
+        $this->assertEquals('title', $result);
+    }
+
+    /**
+     * Test that Arabic headers without asterisk still work (no regression).
+     */
+    public function test_arabic_header_without_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('عنوان الإعلان');
+        $this->assertEquals('title', $result);
+    }
+
+    /**
+     * Test Arabic address header with asterisk.
+     */
+    public function test_arabic_address_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('العنوان *');
+        $this->assertEquals('address', $result);
+    }
+
+    /**
+     * Test Arabic address header without asterisk.
+     */
+    public function test_arabic_address_header_without_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('العنوان');
+        $this->assertEquals('address', $result);
+    }
+
+    /**
+     * Test Arabic description header with asterisk.
+     */
+    public function test_arabic_description_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('الوصف *');
+        $this->assertEquals('description', $result);
+    }
+
+    /**
+     * Test Arabic description header without asterisk.
+     */
+    public function test_arabic_description_header_without_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('الوصف');
+        $this->assertEquals('description', $result);
+    }
+
+    /**
+     * Test Arabic type header with asterisk.
+     */
+    public function test_arabic_type_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('النوع *');
+        $this->assertEquals('type', $result);
+    }
+
+    /**
+     * Test Arabic type header without asterisk.
+     */
+    public function test_arabic_type_header_without_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('النوع');
+        $this->assertEquals('type', $result);
+    }
+
+    /**
+     * Test Arabic price header with asterisk.
+     */
+    public function test_arabic_price_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('السعر *');
+        $this->assertEquals('price', $result);
+    }
+
+    /**
+     * Test Arabic purpose header with asterisk.
+     */
+    public function test_arabic_purpose_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('الغرض *');
+        $this->assertEquals('purpose', $result);
+    }
+
+    /**
+     * Test Arabic area header with asterisk.
+     */
+    public function test_arabic_area_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('المساحة *');
+        $this->assertEquals('area', $result);
+    }
+
+    /**
+     * Test Arabic beds header with asterisk.
+     */
+    public function test_arabic_beds_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('غرف النوم *');
+        $this->assertEquals('beds', $result);
+    }
+
+    /**
+     * Test Arabic bath header with asterisk.
+     */
+    public function test_arabic_bath_header_with_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('دورات المياه *');
+        $this->assertEquals('bath', $result);
+    }
+
+    /**
+     * Test Arabic header with asterisk but no space.
+     */
+    public function test_arabic_header_with_asterisk_no_space()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('عنوان الإعلان*');
+        $this->assertEquals('title', $result);
+    }
+
+    /**
+     * Test Arabic header with asterisk and extra whitespace.
+     */
+    public function test_arabic_header_with_asterisk_extra_whitespace()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('عنوان الإعلان  *  ');
+        $this->assertEquals('title', $result);
+    }
+
+    /**
+     * Test Arabic header with multiple spaces before asterisk.
+     */
+    public function test_arabic_header_with_asterisk_multiple_spaces_before()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('العنوان   *');
+        $this->assertEquals('address', $result);
+    }
+
+    /**
+     * Test Arabic header with spaces on both sides of asterisk.
+     */
+    public function test_arabic_header_with_asterisk_spaces_both_sides()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('الوصف  *  ');
+        $this->assertEquals('description', $result);
+    }
+
+    /**
+     * Test English header with asterisk space.
+     */
+    public function test_english_header_with_asterisk_space()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('Title *');
+        // English headers fall through to Str::snake()
+        $this->assertEquals('title', $result);
+    }
+
+    /**
+     * Test English header without asterisk.
+     */
+    public function test_english_header_without_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('Title');
+        $this->assertEquals('title', $result);
+    }
+
+    /**
+     * Test header that is only an asterisk.
+     */
+    public function test_header_only_asterisk()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('*');
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * Test header that is only asterisk with spaces.
+     */
+    public function test_header_only_asterisk_with_spaces()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('  *  ');
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * Test empty header (no regression).
+     */
+    public function test_empty_header()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('');
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * Test header with only spaces (no regression).
+     */
+    public function test_header_only_spaces()
+    {
+        $result = PropertyExcelHeaderMapping::headerToKey('   ');
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * Test that asterisks in the middle of the header are NOT stripped.
+     * (Only trailing asterisks should be stripped)
+     */
+    public function test_asterisk_in_middle_not_stripped()
+    {
+        // A header with asterisk in the middle should snake_case it
+        // since it won't match the Arabic map exactly
+        $result = PropertyExcelHeaderMapping::headerToKey('Title * Description');
+        $this->assertEquals('title*_description', $result);
+    }
+
+    /**
+     * Test Arabic header with trailing asterisk but internal asterisk preserved.
+     * (Only the trailing asterisk is stripped)
+     */
+    public function test_arabic_with_internal_text_and_trailing_asterisk()
+    {
+        // This should strip only the trailing asterisk
+        // The internal structure is preserved before stripping
+        $result = PropertyExcelHeaderMapping::headerToKey('عنوان الإعلان *');
+        $this->assertEquals('title', $result);
+    }
+}

--- a/tests/Feature/TenantCrmDefaultLookupsTest.php
+++ b/tests/Feature/TenantCrmDefaultLookupsTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Api\PropertyRequestAutoCustomerSetting;
+use App\Models\Api\UserApiCustomerPriority;
+use App\Models\Api\UserApiCustomerProcedure;
+use App\Models\Api\UserApiCustomerType;
+use App\Models\User;
+use App\Services\TenantCrmBootstrapService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class TenantCrmDefaultLookupsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function requireTables(): void
+    {
+        foreach ([
+            'users_api_customers_types',
+            'users_api_customers_priorities',
+            'users_api_customers_procedures',
+        ] as $table) {
+            if (! Schema::hasTable($table)) {
+                $this->markTestSkipped("Missing DB table: {$table}.");
+            }
+        }
+    }
+
+    private function createTenant(): User
+    {
+        return User::factory()->create([
+            'account_type' => 'tenant',
+            'tenant_id' => null,
+        ]);
+    }
+
+    /** @test */
+    public function creating_a_tenant_seeds_types_priorities_and_procedures(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+
+        $this->assertEqualsCanonicalizing(
+            array_column(TenantCrmBootstrapService::defaultTypes(), 'value'),
+            UserApiCustomerType::where('user_id', $tenant->id)->pluck('value')->all()
+        );
+
+        $this->assertEqualsCanonicalizing(
+            array_map('strval', array_column(TenantCrmBootstrapService::defaultPriorities(), 'value')),
+            UserApiCustomerPriority::where('user_id', $tenant->id)->pluck('value')->map('strval')->all()
+        );
+
+        $this->assertEqualsCanonicalizing(
+            array_column(TenantCrmBootstrapService::defaultProcedures(), 'procedure_name'),
+            UserApiCustomerProcedure::where('user_id', $tenant->id)->pluck('procedure_name')->all()
+        );
+    }
+
+    /** @test */
+    public function seeded_types_are_active_and_ordered_so_a_default_resolves(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+
+        $first = UserApiCustomerType::where('user_id', $tenant->id)
+            ->where('is_active', true)
+            ->orderBy('order')
+            ->first();
+
+        $this->assertNotNull($first, 'A newly created tenant must have a resolvable default type.');
+        $this->assertSame('Rent', $first->value);
+    }
+
+    /** @test */
+    public function seeding_is_idempotent(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+        $bootstrap = app(TenantCrmBootstrapService::class);
+
+        $bootstrap->ensureDefaultTypes((int) $tenant->id);
+        $bootstrap->ensureDefaultTypes((int) $tenant->id);
+        $bootstrap->ensureDefaultPriorities((int) $tenant->id);
+        $bootstrap->ensureDefaultProcedures((int) $tenant->id);
+
+        $this->assertCount(
+            count(TenantCrmBootstrapService::defaultTypes()),
+            UserApiCustomerType::where('user_id', $tenant->id)->get()
+        );
+        $this->assertCount(
+            count(TenantCrmBootstrapService::defaultPriorities()),
+            UserApiCustomerPriority::where('user_id', $tenant->id)->get()
+        );
+        $this->assertCount(
+            count(TenantCrmBootstrapService::defaultProcedures()),
+            UserApiCustomerProcedure::where('user_id', $tenant->id)->get()
+        );
+    }
+
+    /** @test */
+    public function seeding_backfills_only_the_missing_types_and_keeps_custom_ones(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+
+        UserApiCustomerType::where('user_id', $tenant->id)->delete();
+
+        UserApiCustomerType::create([
+            'user_id' => $tenant->id,
+            'name' => 'Bespoke',
+            'value' => 'Bespoke',
+            'color' => '#000',
+            'icon' => 'star',
+            'order' => 9,
+            'is_active' => true,
+        ]);
+
+        app(TenantCrmBootstrapService::class)->ensureDefaultTypes((int) $tenant->id);
+
+        $values = UserApiCustomerType::where('user_id', $tenant->id)->pluck('value')->all();
+
+        $this->assertContains('Bespoke', $values);
+        foreach (array_column(TenantCrmBootstrapService::defaultTypes(), 'value') as $expected) {
+            $this->assertContains($expected, $values);
+        }
+    }
+
+    /** @test */
+    public function crm_index_bootstrap_does_not_re_enable_disabled_auto_create(): void
+    {
+        $this->requireTables();
+
+        if (! Schema::hasTable('property_request_auto_customer_settings')) {
+            $this->markTestSkipped('property_request_auto_customer_settings table required.');
+        }
+
+        $tenant = $this->createTenant();
+
+        PropertyRequestAutoCustomerSetting::where('user_id', $tenant->id)
+            ->update(['auto_create_customer' => false]);
+
+        // The seeders the CRM board calls must not rewrite auto-customer settings.
+        $bootstrap = app(TenantCrmBootstrapService::class);
+        $bootstrap->ensureDefaultStages((int) $tenant->id);
+        $bootstrap->ensureDefaultProcedures((int) $tenant->id);
+        $bootstrap->ensureDefaultPriorities((int) $tenant->id);
+        $bootstrap->ensureDefaultTypes((int) $tenant->id);
+
+        $this->assertFalse(
+            (bool) PropertyRequestAutoCustomerSetting::where('user_id', $tenant->id)->value('auto_create_customer')
+        );
+    }
+
+    /** @test */
+    public function backfill_command_creates_missing_rows(): void
+    {
+        $this->requireTables();
+
+        $tenant = $this->createTenant();
+
+        UserApiCustomerType::where('user_id', $tenant->id)->delete();
+        UserApiCustomerPriority::where('user_id', $tenant->id)->delete();
+        UserApiCustomerProcedure::where('user_id', $tenant->id)->delete();
+
+        $this->artisan('crm:backfill-tenant-defaults', ['--tenant' => $tenant->id, '--dry-run' => true])
+            ->assertExitCode(0);
+
+        $this->assertSame(0, UserApiCustomerType::where('user_id', $tenant->id)->count(), 'Dry run must not write.');
+
+        $this->artisan('crm:backfill-tenant-defaults', ['--tenant' => $tenant->id])
+            ->assertExitCode(0);
+
+        $this->assertCount(
+            count(TenantCrmBootstrapService::defaultTypes()),
+            UserApiCustomerType::where('user_id', $tenant->id)->get()
+        );
+        $this->assertCount(
+            count(TenantCrmBootstrapService::defaultProcedures()),
+            UserApiCustomerProcedure::where('user_id', $tenant->id)->get()
+        );
+    }
+}

--- a/tests/Feature/UserPropertiesCompletionIntegrityTest.php
+++ b/tests/Feature/UserPropertiesCompletionIntegrityTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User\Language;
 use App\Models\User\RealestateManagement\Property;
 use App\Models\User\RealestateManagement\PropertyContent;
+use App\Support\PropertyCompletionRequirements;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -12,8 +13,8 @@ use Tests\TestCase;
  * Verifies that for user_id = 1037, all properties with completion_status = 'complete'
  * have no missing required fields in user_properties and user_property_contents.
  *
- * Required fields: title, price, address, description, purpose, property_type, area
- * - From user_properties: price, purpose, property_type, area
+ * Required fields: title, address, description, featured_image, property_type
+ * - From user_properties: featured_image, property_type
  * - From user_property_contents (default language): title, address, description
  *
  * Skips when user_properties does not exist (e.g. empty taearif_testing). To check
@@ -22,7 +23,6 @@ use Tests\TestCase;
  */
 class UserPropertiesCompletionIntegrityTest extends TestCase
 {
-    protected array $requiredFields = ['title', 'price', 'address', 'description', 'purpose', 'property_type', 'area'];
 
     /**
      * For user_id 1037, complete properties must not have missing required fields.
@@ -39,7 +39,7 @@ class UserPropertiesCompletionIntegrityTest extends TestCase
 
         $properties = Property::where('user_id', $userId)
             ->where('completion_status', 'complete')
-            ->select(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'completion_status'])
+            ->select(['id', 'user_id', 'price', 'purpose', 'property_type', 'area', 'featured_image', 'completion_status'])
             ->get();
 
         if ($properties->isEmpty()) {
@@ -78,7 +78,7 @@ class UserPropertiesCompletionIntegrityTest extends TestCase
             ->first();
 
         if (!$defaultLanguage) {
-            return $this->requiredFields;
+            return PropertyCompletionRequirements::fields();
         }
 
         $content = PropertyContent::where('property_id', $property->id)
@@ -87,22 +87,12 @@ class UserPropertiesCompletionIntegrityTest extends TestCase
 
         $currentData = [
             'title' => $content?->title,
-            'price' => $property->price,
             'address' => $content?->address,
             'description' => $content?->description,
-            'purpose' => $property->purpose,
             'property_type' => $property->property_type,
-            'area' => $property->area,
+            'featured_image' => $property->featured_image,
         ];
 
-        $missing = [];
-        foreach ($this->requiredFields as $field) {
-            $value = $currentData[$field] ?? null;
-            if (is_null($value) || (is_string($value) && trim((string) $value) === '') || $value === '') {
-                $missing[] = $field;
-            }
-        }
-
-        return $missing;
+        return PropertyCompletionRequirements::missingFrom($currentData);
     }
 }

--- a/tests/Feature/V2/CustomersHub/RequestCompleteDataTest.php
+++ b/tests/Feature/V2/CustomersHub/RequestCompleteDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V2\CustomersHub;
 
 use App\Models\User;
+use App\Models\User\RealestateManagement\Project;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -25,9 +26,37 @@ class RequestCompleteDataTest extends TestCase
         }
     }
 
+    private function requireProjectIdColumn(): void
+    {
+        $this->requireTables();
+
+        if (!Schema::hasTable('user_projects')) {
+            $this->markTestSkipped('user_projects table required.');
+        }
+        if (!Schema::hasColumn('users_property_requests', 'project_id')) {
+            $this->markTestSkipped('project_id column required on users_property_requests. Run migration.');
+        }
+    }
+
     private function createTenant(): User
     {
         return User::factory()->create(['account_type' => 'tenant', 'tenant_id' => null]);
+    }
+
+    private function createProject(User $tenant): Project
+    {
+        return Project::query()->create([
+            'user_id' => $tenant->id,
+            'featured_image' => 'projects/test.jpg',
+            'min_price' => 100000,
+            'max_price' => 200000,
+            'featured' => 0,
+            'published' => 1,
+            'developer' => 'Test Developer',
+            'units' => 10,
+            'completion_date' => now()->addYear()->toDateString(),
+            'complete_status' => 0,
+        ]);
     }
 
     private function createPropertyRequest(int $userId, array $overrides = []): int
@@ -191,6 +220,28 @@ class RequestCompleteDataTest extends TestCase
         $row = DB::table('users_property_requests')->where('id', $requestId)->first();
         $this->assertEquals('الرياض', $row->city);
         $this->assertEquals('حي النزهة', $row->district);
+    }
+
+    /** @test */
+    public function complete_data_can_set_project_id(): void
+    {
+        $this->requireProjectIdColumn();
+
+        $tenant = $this->createTenant();
+        Sanctum::actingAs($tenant);
+
+        $project = $this->createProject($tenant);
+        $requestId = $this->createPropertyRequest($tenant->id);
+
+        $this->postJson("/api/v2/customers-hub/requests/property_request_{$requestId}/complete-data", [
+            'project_id' => $project->id,
+            'city' => 'الرياض',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('users_property_requests', [
+            'id' => $requestId,
+            'project_id' => $project->id,
+        ]);
     }
 
     /** @test */

--- a/tests/PropertyImportTester.php
+++ b/tests/PropertyImportTester.php
@@ -2,15 +2,20 @@
 
 /**
  * Property Import Tester Script
- * 
+ *
  * This script tests the incomplete properties import feature by:
  * 1. Reading CSV test files
  * 2. Converting them to Excel format
  * 3. Calling the import API
  * 4. Validating responses
  * 5. Reporting errors
- * 
- * Usage: php PropertyImportTester.php
+ *
+ * Usage:
+ *   PROPERTY_IMPORT_TEST_TOKEN=your-token php PropertyImportTester.php [base_url]
+ *   php PropertyImportTester.php [base_url] [token]
+ *   php PropertyImportTester.php [base_url] [token] --debug
+ *
+ * Token is required via the second CLI argument or PROPERTY_IMPORT_TEST_TOKEN env var.
  */
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -26,10 +31,21 @@ class PropertyImportTester
     private $testFilesDir;
     private $results = [];
     
-    public function __construct($baseUrl = 'http://localhost', $token = '3047|uahD3zAkkIoIgCayvGoFcrqT6tPGGa1Yz3CGvK1f14a54d22')
+    public function __construct($baseUrl = 'http://localhost', $token = null)
     {
+        $resolvedToken = $token !== null && $token !== ''
+            ? (string) $token
+            : (string) (getenv('PROPERTY_IMPORT_TEST_TOKEN') ?: '');
+
+        if ($resolvedToken === '') {
+            throw new \InvalidArgumentException(
+                'Sanctum token required. Pass it as the second constructor/CLI argument '
+                . 'or set PROPERTY_IMPORT_TEST_TOKEN in the environment.'
+            );
+        }
+
         $this->baseUrl = rtrim($baseUrl, '/');
-        $this->token = $token;
+        $this->token = $resolvedToken;
         $this->testFilesDir = __DIR__ . '/../docs/test-files/';
     }
     
@@ -430,10 +446,15 @@ class PropertyImportTester
 
 // Run tests
 if (php_sapi_name() === 'cli') {
-    // Get base URL from command line or use default
     $baseUrl = $argv[1] ?? 'http://localhost';
-    $token = $argv[2] ?? '3047|uahD3zAkkIoIgCayvGoFcrqT6tPGGa1Yz3CGvK1f14a54d22';
-    
+    $tokenArg = $argv[2] ?? null;
+    if ($tokenArg === '--debug') {
+        $tokenArg = null;
+    }
+    $token = ($tokenArg !== null && $tokenArg !== '')
+        ? $tokenArg
+        : (getenv('PROPERTY_IMPORT_TEST_TOKEN') ?: null);
+
     // Check if vendor/autoload.php exists
     $autoloadPath = __DIR__ . '/../vendor/autoload.php';
     if (!file_exists($autoloadPath)) {
@@ -441,25 +462,35 @@ if (php_sapi_name() === 'cli') {
         echo "Please run 'composer install' first.\n";
         exit(1);
     }
-    
+
     // Check if test files directory exists
     $testFilesDir = __DIR__ . '/../docs/test-files/';
     if (!is_dir($testFilesDir)) {
         echo "ERROR: Test files directory not found: {$testFilesDir}\n";
         exit(1);
     }
-    
+
+    if ($token === null || $token === '') {
+        echo "ERROR: Sanctum token required.\n";
+        echo "Pass it as the second argument or set PROPERTY_IMPORT_TEST_TOKEN.\n";
+        echo "Usage: php PropertyImportTester.php [base_url] [token] [--debug]\n";
+        echo "Example: PROPERTY_IMPORT_TEST_TOKEN=your-token php PropertyImportTester.php http://localhost:8000\n";
+        echo "Example: php PropertyImportTester.php http://localhost:8000 \"your-token\" --debug\n";
+        exit(1);
+    }
+
     echo "Base URL: {$baseUrl}\n";
     echo "Test Files Directory: {$testFilesDir}\n";
     echo "\n";
-    
+
     try {
         $tester = new PropertyImportTester($baseUrl, $token);
         $tester->runAllTests();
     } catch (\Exception $e) {
         echo "\n❌ FATAL ERROR: " . $e->getMessage() . "\n";
         echo "File: " . $e->getFile() . ":" . $e->getLine() . "\n";
-        if (isset($argv[3]) && $argv[3] === '--debug') {
+        $debug = in_array('--debug', $argv, true);
+        if ($debug) {
             echo "\nStack Trace:\n" . $e->getTraceAsString() . "\n";
         }
         exit(1);
@@ -467,6 +498,6 @@ if (php_sapi_name() === 'cli') {
 } else {
     echo "This script must be run from command line.\n";
     echo "Usage: php PropertyImportTester.php [base_url] [token] [--debug]\n";
-    echo "Example: php PropertyImportTester.php http://localhost:8000\n";
+    echo "Example: PROPERTY_IMPORT_TEST_TOKEN=your-token php PropertyImportTester.php http://localhost:8000\n";
     echo "Example: php PropertyImportTester.php http://localhost:8000 \"your-token\" --debug\n";
 }

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -72,6 +72,18 @@ class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
         $this->assertArrayNotHasKey(Str::slug('عنوان الإعلان', '_'), $normalized);
     }
 
+    public function test_prepare_for_validation_casts_numeric_unit_number_to_string(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+
+        $data = $import->prepareForValidation([
+            Str::slug('رقم الوحدة', '_') => 301,
+        ], 3);
+
+        $this->assertSame('301', $data['unit_number']);
+        $this->assertIsString($data['unit_number']);
+    }
+
     public function test_prepare_for_validation_remaps_headers_and_purpose_type(): void
     {
         $import = $this->newImportWithoutConstructor();

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -84,6 +84,41 @@ class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
         $this->assertIsString($data['unit_number']);
     }
 
+    public function test_prepare_for_validation_casts_numeric_boolean_like_fields_from_raw_export(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+
+        $data = $import->prepareForValidation([
+            Str::slug('مصعد', '_') => 0,
+            'featured' => 0,
+            'balcony' => 0,
+            'maid_room' => 0,
+            'storage_room' => 0,
+            'swimming_pool' => 0,
+        ], 2);
+
+        $this->assertSame('0', $data['amenity_مصعد']);
+        $this->assertSame('0', $data['featured']);
+        $this->assertSame('0', $data['balcony']);
+        $this->assertSame('0', $data['maid_room']);
+        $this->assertSame('0', $data['storage_room']);
+        $this->assertSame('0', $data['swimming_pool']);
+    }
+
+    public function test_normalize_row_keys_keeps_first_non_empty_when_duplicate_headers_map_to_same_key(): void
+    {
+        $normalize = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('normalizeRowKeys');
+        $normalize->setAccessible(true);
+        $import = $this->newImportWithoutConstructor();
+
+        $normalized = $normalize->invoke($import, [
+            Str::slug('دورات المياه', '_') => 3,
+            'bath' => null,
+        ]);
+
+        $this->assertSame(3, $normalized['bath']);
+    }
+
     public function test_prepare_for_validation_remaps_headers_and_purpose_type(): void
     {
         $import = $this->newImportWithoutConstructor();

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Imports;
+
+use App\Imports\PropertiesSingleSheetImport;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use Tests\TestCase;
+
+class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
+{
+    /**
+     * @return array<string, string>
+     */
+    private function headerKeyMap(): array
+    {
+        $method = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('headerKeyMap');
+        $method->setAccessible(true);
+
+        return $method->invoke(null);
+    }
+
+    public function test_header_key_map_includes_exact_arabic_and_maatwebsite_slugs(): void
+    {
+        $map = $this->headerKeyMap();
+
+        $this->assertSame('title', $map['عنوان الإعلان']);
+        $this->assertSame('title', $map[Str::slug('عنوان الإعلان', '_')]);
+        $this->assertSame('aanoan_alaaalan', Str::slug('عنوان الإعلان', '_'));
+
+        $this->assertSame('purpose', $map['الغرض']);
+        $this->assertSame('purpose', $map[Str::slug('الغرض', '_')]);
+
+        $this->assertSame('type', $map['النوع']);
+        $this->assertSame('type', $map[Str::slug('النوع', '_')]);
+
+        $this->assertSame('price', $map['السعر']);
+        $this->assertSame('price', $map[Str::slug('السعر', '_')]);
+
+        $this->assertSame('amenity_مصعد', $map['مصعد']);
+        $this->assertSame('amenity_مصعد', $map[Str::slug('مصعد', '_')]);
+        $this->assertSame('amenity_مصعد', $map[Str::slug('amenity_مصعد', '_')]);
+    }
+
+    public function test_normalize_row_keys_maps_slugified_arabic_headers(): void
+    {
+        $normalize = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('normalizeRowKeys');
+        $normalize->setAccessible(true);
+
+        // Bypass constructor language requirement by allocating without __construct
+        $import = $this->newImportWithoutConstructor();
+
+        $row = [
+            Str::slug('عنوان الإعلان', '_') => 'شقة الرياض',
+            Str::slug('السعر', '_') => 500000,
+            Str::slug('الغرض', '_') => 'بيع',
+            Str::slug('النوع', '_') => 'سكني',
+            Str::slug('مصعد', '_') => 'نعم',
+            'title' => 'should-not-overwrite-if-absent',
+        ];
+        unset($row['title']);
+
+        $normalized = $normalize->invoke($import, $row);
+
+        $this->assertSame('شقة الرياض', $normalized['title']);
+        $this->assertSame(500000, $normalized['price']);
+        $this->assertSame('بيع', $normalized['purpose']);
+        $this->assertSame('سكني', $normalized['type']);
+        $this->assertSame('نعم', $normalized['amenity_مصعد']);
+        $this->assertArrayNotHasKey(Str::slug('عنوان الإعلان', '_'), $normalized);
+    }
+
+    public function test_prepare_for_validation_remaps_headers_and_purpose_type(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+
+        $data = $import->prepareForValidation([
+            Str::slug('عنوان الإعلان', '_') => 'وحدة تجريبية',
+            Str::slug('الغرض', '_') => 'إيجار',
+            Str::slug('النوع', '_') => 'تجاري',
+            Str::slug('مصعد', '_') => 'نعم',
+            Str::slug('أمن', '_') => 'لا',
+        ], 2);
+
+        $this->assertSame('وحدة تجريبية', $data['title']);
+        $this->assertSame('rent', $data['purpose']);
+        $this->assertSame('commercial', $data['type']);
+        $this->assertSame('نعم', $data['amenity_مصعد']);
+        $this->assertSame('لا', $data['amenity_أمن']);
+    }
+
+    public function test_amenity_validation_rules_accept_arabic_yes_no(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+        $rules = $import->rules();
+
+        foreach ([
+            'amenity_مصعد',
+            'amenity_أمن',
+            'amenity_كاميرات_مراقبة',
+            'amenity_تكييف_مركزي',
+            'amenity_تدفئة_مركزية',
+            'amenity_صيانة',
+            'amenity_بواب',
+            'amenity_إنترنت',
+        ] as $field) {
+            $this->assertArrayHasKey($field, $rules);
+            $this->assertStringContainsString('نعم', $rules[$field]);
+            $this->assertStringContainsString('لا', $rules[$field]);
+        }
+    }
+
+    private function newImportWithoutConstructor(): PropertiesSingleSheetImport
+    {
+        return (new ReflectionClass(PropertiesSingleSheetImport::class))
+            ->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
+++ b/tests/Unit/Imports/PropertiesSingleSheetImportHeaderMappingTest.php
@@ -138,6 +138,64 @@ class PropertiesSingleSheetImportHeaderMappingTest extends TestCase
         $this->assertSame('لا', $data['amenity_أمن']);
     }
 
+    public function test_normalize_row_keys_strips_trailing_required_asterisk(): void
+    {
+        $normalize = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('normalizeRowKeys');
+        $normalize->setAccessible(true);
+        $import = $this->newImportWithoutConstructor();
+
+        $normalized = $normalize->invoke($import, [
+            'عنوان الإعلان *' => 'شقة الرياض',
+            'العنوان *' => 'حي العليا',
+            'الوصف *' => 'وصف كافٍ للعقار المستورد',
+            'النوع *' => 'سكني',
+            'الصورة الرئيسية *' => 'https://example.com/img1.jpg',
+        ]);
+
+        $this->assertSame('شقة الرياض', $normalized['title']);
+        $this->assertSame('حي العليا', $normalized['address']);
+        $this->assertSame('وصف كافٍ للعقار المستورد', $normalized['description']);
+        $this->assertSame('سكني', $normalized['type']);
+        $this->assertSame('https://example.com/img1.jpg', $normalized['featured_image']);
+    }
+
+    public function test_template_shaped_row_is_not_marked_raw_export(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+        $method = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('isRawExportRow');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($import, [
+            'title' => 'شقة',
+            'address' => 'عنوان كافٍ',
+            'description' => 'وصف كافٍ للاستيراد',
+            'type' => 'residential',
+            'featured_image' => 'https://example.com/a.jpg',
+            // id alone is create-only ignore, not raw-export
+            'id' => 42,
+        ]));
+
+        $this->assertFalse($method->invoke($import, [
+            'title' => 'شقة',
+            // Empty metadata headers must not reject (Option A)
+            'user_id' => '',
+            'created_at' => null,
+        ]));
+    }
+
+    public function test_raw_export_row_with_metadata_values_is_detected(): void
+    {
+        $import = $this->newImportWithoutConstructor();
+        $method = (new ReflectionClass(PropertiesSingleSheetImport::class))->getMethod('isRawExportRow');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($import, [
+            'title' => 'شقة',
+            'user_id' => 7,
+            'created_at' => '2026-01-01 00:00:00',
+        ]));
+    }
+
     public function test_amenity_validation_rules_accept_arabic_yes_no(): void
     {
         $import = $this->newImportWithoutConstructor();


### PR DESCRIPTION
## Summary
- Make `type_id` optional on customer create.
- Seed CRM defaults at tenant creation.

## Merge order
Merge **last**, after `feat/saudi-locations-nzl-sync` into `feat-mahmoud` (tip of the stack).

## Test plan
- [ ] Create customer without `type_id`
- [ ] Create customer with `type_id`
- [ ] New tenant gets expected CRM defaults